### PR TITLE
Update to allow better extension

### DIFF
--- a/src/main/java/rx/netty/protocol/http/ConnectionPromise.java
+++ b/src/main/java/rx/netty/protocol/http/ConnectionPromise.java
@@ -32,9 +32,11 @@ import io.netty.util.concurrent.Promise;
 public class ConnectionPromise<T, R extends HttpRequest> extends DefaultPromise<RequestWriter<T, R>> {
     private EventExecutor executor;
     private Channel channel;
+    private HttpProtocolHandler<T> handler;
 
-    ConnectionPromise(EventExecutor executor) {
+    ConnectionPromise(EventExecutor executor, HttpProtocolHandler<T> handler) {
         this.executor = executor;
+        this.handler = handler;
     }
 
     @Override
@@ -49,7 +51,7 @@ public class ConnectionPromise<T, R extends HttpRequest> extends DefaultPromise<
     void onConnect(Channel channel) {
         this.executor = channel.eventLoop();
         this.channel = channel;
-
+        handler.configure(channel.pipeline());
         trySuccess(new RequestWriter<T, R>(channel));
     }
 }

--- a/src/main/java/rx/netty/protocol/http/HttpProtocolHandler.java
+++ b/src/main/java/rx/netty/protocol/http/HttpProtocolHandler.java
@@ -15,16 +15,19 @@
  */
 package rx.netty.protocol.http;
 
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.FullHttpResponse;
-import rx.netty.protocol.tcp.ProtocolHandler;
+import rx.Observer;
+
 
 /**
  *
  */
-public interface HttpProtocolHandler<T> extends ProtocolHandler<Void, T> {
+public interface HttpProtocolHandler<T> {
 
     public static final HttpProtocolHandler<Message> SSE_HANDLER = new HttpProtocolHandlerAdapter<Message>();
 
     public static final HttpProtocolHandler<FullHttpResponse> FULL_HTTP_RESPONSE_HANDLER = new HttpProtocolHandlerAdapter<FullHttpResponse>();
-
+    
+    public void configure(ChannelPipeline pipeline, Observer<? super ObservableHttpResponse<T>> observer, Observer<T> entityObserver);
 }

--- a/src/main/java/rx/netty/protocol/http/HttpProtocolHandlerAdapter.java
+++ b/src/main/java/rx/netty/protocol/http/HttpProtocolHandlerAdapter.java
@@ -15,14 +15,11 @@
  */
 package rx.netty.protocol.http;
 
-import rx.Observer;
 import io.netty.channel.ChannelPipeline;
 
 public class HttpProtocolHandlerAdapter<T> implements HttpProtocolHandler<T> {
 
     @Override
-    public void configure(ChannelPipeline pipeline,
-            Observer<? super ObservableHttpResponse<T>> observer,
-            Observer<T> entityObserver) {
+    public void configure(ChannelPipeline pipeline) {
     }
 }

--- a/src/main/java/rx/netty/protocol/http/HttpProtocolHandlerAdapter.java
+++ b/src/main/java/rx/netty/protocol/http/HttpProtocolHandlerAdapter.java
@@ -15,13 +15,14 @@
  */
 package rx.netty.protocol.http;
 
+import rx.Observer;
 import io.netty.channel.ChannelPipeline;
 
 public class HttpProtocolHandlerAdapter<T> implements HttpProtocolHandler<T> {
 
     @Override
-    public void configure(ChannelPipeline pipeline) {
-
+    public void configure(ChannelPipeline pipeline,
+            Observer<? super ObservableHttpResponse<T>> observer,
+            Observer<T> entityObserver) {
     }
-
 }

--- a/src/main/java/rx/netty/protocol/http/ObservableHttpClient.java
+++ b/src/main/java/rx/netty/protocol/http/ObservableHttpClient.java
@@ -24,17 +24,20 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
@@ -44,6 +47,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.xml.internal.ws.api.pipe.PipelineAssembler;
 
 import rx.Observable;
 import rx.Observer;
@@ -105,8 +110,8 @@ public class ObservableHttpClient {
         }
     }
 
-    private <T> ConnectionPromise<T, HttpRequest> makeConnection(Bootstrap bootstrap, UriInfo uriInfo) {
-        final ConnectionPromise<T, HttpRequest> connectionPromise = new ConnectionPromise<T, HttpRequest>(eventExecutor);
+    private <T> ConnectionPromise<T, HttpRequest> makeConnection(Bootstrap bootstrap, UriInfo uriInfo, HttpProtocolHandler<T> handler) {
+        final ConnectionPromise<T, HttpRequest> connectionPromise = new ConnectionPromise<T, HttpRequest>(eventExecutor, handler);
         bootstrap.connect(uriInfo.getHost(), uriInfo.getPort())
                 .addListener(new ChannelFutureListener() {
                     @Override
@@ -139,7 +144,7 @@ public class ObservableHttpClient {
             public Subscription onSubscribe(Observer<? super ObservableHttpResponse<T>> observer) {
                 UriInfo uriInfo = request.getUriInfo();
                 Bootstrap bootstrap = createBootstrap(handler, observer);
-                final ConnectionPromise<T, HttpRequest> connectionPromise = makeConnection(bootstrap, uriInfo);
+                final ConnectionPromise<T, HttpRequest> connectionPromise = makeConnection(bootstrap, uriInfo, handler);
 
                 RequestCompletionPromise<T, HttpRequest> requestCompletionPromise = new RequestCompletionPromise<T, HttpRequest>(self.eventExecutor, connectionPromise);
 
@@ -169,42 +174,43 @@ public class ObservableHttpClient {
         }
     }
 
-    private static class HttpResponseDecoder<T> extends MessageToMessageDecoder<HttpObject> {
-        private final HttpProtocolHandler<T> handler;
+    private static class HttpObservableTracker<T> extends SimpleChannelInboundHandler<HttpObject> {
+        protected Observer<? super ObservableHttpResponse<T>> observer;
+        
+        protected PublishSubject<T> subject;
 
-        private Observer<? super ObservableHttpResponse<T>> observer;
-
-        public HttpResponseDecoder(HttpProtocolHandler<T> handler, Observer<? super ObservableHttpResponse<T>> observer) {
-            this.handler = handler;
+        public HttpObservableTracker(HttpProtocolHandler<T> handler, Observer<? super ObservableHttpResponse<T>> observer) {
             this.observer = observer;
         }
 
         @Override
-        protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
+        protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg)
+                throws Exception {
             if (msg instanceof HttpResponse) {
                 HttpResponse response = (HttpResponse) msg;
-
-                String header = response.headers().get("Content-Type");
-                ContentType contentType = ContentType.fromHeader(header);
-                if (contentType.isSSE()) {
-                    ChannelPipeline p = ctx.channel().pipeline();
-                    p.remove("http-codec");
-                    p.replace("http-response-decoder", "http-sse-handler", new ServerSentEventDecoder());
-                } else {
-                    ctx.channel()
-                            .pipeline()
-                            .replace("http-response-decoder", "http-aggregator", new HttpObjectAggregator(Integer.MAX_VALUE));
-
-                    out.add(msg);
-                }
-                
-                PublishSubject<T> subject = PublishSubject.<T> create();
+                subject = PublishSubject.<T> create();
                 final ObservableHttpResponse<T> httpResponse = new ObservableHttpResponse<T>(response, subject);
+                ChannelPipeline pipeLine = ctx.channel().pipeline();
+                if (pipeLine.get("content-handler") == null) {
+                    pipeLine.addLast("content-handler", new HttpMessageObserver<T>(observer, httpResponse));
+                }
                 observer.onNext(httpResponse);
-                ctx.channel().pipeline().addLast("content-handler", new HttpMessageObserver<T>(observer, httpResponse));
-
-                handler.configure(ctx.channel().pipeline(), observer, subject);
             }
+            if (msg instanceof HttpContent) {
+                ((HttpContent) msg).content().retain();
+            }
+            ctx.fireChannelRead(msg);
+            if (msg instanceof LastHttpContent) {
+                subject.onCompleted();
+                observer.onCompleted();    
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+                throws Exception {
+            subject.onError(cause);
+            observer.onError(cause);
         }
     }
 
@@ -218,7 +224,7 @@ public class ObservableHttpClient {
                     protected void initChannel(SocketChannel ch) throws Exception {
                         ch.pipeline()
                                 .addLast("http-codec", new HttpClientCodec(maxInitialLineLength, maxHeaderSize, maxChunkSize))
-                                .addLast("http-response-decoder", new HttpResponseDecoder<T>(handler, observer));
+                                .addLast("http-response-decoder", new HttpObservableTracker<T>(handler, observer));
                     }
                 })
                 .option(ChannelOption.TCP_NODELAY, true)
@@ -239,17 +245,7 @@ public class ObservableHttpClient {
         ValidatedFullHttpRequest request = ValidatedFullHttpRequest.get("http://ec2-107-22-122-75.compute-1.amazonaws.com:7001/turbine.stream?cluster=api-prod-c0us.ca");
 
         request.getUriInfo().getUri().getRawPath();
-        Observable<ObservableHttpResponse<Message>> response = client.execute(request, new HttpProtocolHandler<Message>() {
-
-            @Override
-            public void configure(ChannelPipeline pipeline,
-                    Observer<? super ObservableHttpResponse<Message>> observer,
-                    Observer<Message> entityObserver) {
-                // TODO Auto-generated method stub
-                
-            }
-
-        });
+        Observable<ObservableHttpResponse<Message>> response = client.execute(request, HttpProtocolHandlerAdapter.SSE_HANDLER);
 
         response.flatMap(new Func1<ObservableHttpResponse<Message>, Observable<Message>>() {
             @Override

--- a/src/main/java/rx/netty/protocol/http/SSEHandler.java
+++ b/src/main/java/rx/netty/protocol/http/SSEHandler.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.netty.protocol.http;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpResponse;
+
+public class SSEHandler extends SimpleChannelInboundHandler<HttpObject> {
+
+    public static final String NAME = "sse-handler";
+    
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg)
+            throws Exception {
+        if (msg instanceof HttpResponse) {
+            ChannelPipeline pipeline = ctx.channel().pipeline();
+            pipeline.remove("http-codec");
+            pipeline.remove(NAME);
+            pipeline.replace("http-response-decoder", "http-sse-handler", new ServerSentEventDecoder());
+        }
+    }
+}


### PR DESCRIPTION
- Changed the pipeline configuration to keep track of HTTP state so that Observer.onCompleted() will be called appropriately.
- HttpProtocolHandler.configure() will be called after channel is established, instead of in the middle of channel read.
- Remove the code from ObservableHttpClient to dynamically install SSE decoder. Instead, SSE handling is done by specifying SSEHandler at execute() call.
