### PR TITLE
Renaming SSEEvent to ServerSentEvent

### DIFF
--- a/src/examples/groovy/io/reactivex/netty/examples/HttpSseClient.groovy
+++ b/src/examples/groovy/io/reactivex/netty/examples/HttpSseClient.groovy
@@ -22,7 +22,7 @@ class HttpSseClient {
 
         RxNetty.createSseClient("localhost", 8080)
                 .submit(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello"))
-                .flatMap({ ObservableHttpResponse<SSEEvent> response ->
+                .flatMap({ ObservableHttpResponse<ServerSentEvent> response ->
                     response.header().subscribe({HttpResponse header ->
                         println("New response recieved.");
                         println("========================");

--- a/src/examples/groovy/io/reactivex/netty/examples/HttpSseServer.groovy
+++ b/src/examples/groovy/io/reactivex/netty/examples/HttpSseServer.groovy
@@ -22,7 +22,7 @@ import io.netty.handler.codec.http.HttpVersion
 import io.reactivex.netty.RxNetty
 import io.reactivex.netty.channel.ObservableConnection
 import io.reactivex.netty.protocol.http.server.HttpServer
-import io.reactivex.netty.protocol.text.sse.SSEEvent
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent
 import rx.Notification
 import rx.util.functions.Action1
 
@@ -52,7 +52,7 @@ class HttpSseServer {
                 .flatMap({ Long interval ->
                     println("Writing SSE event for interval: " + interval);
                     // emit the interval to the output and return the notification received from it
-                    return connection.write(new SSEEvent("1", "data: ", String.valueOf(interval))).materialize();
+                    return connection.write(new ServerSentEvent("1", "data: ", String.valueOf(interval))).materialize();
                 }).takeWhile({ Notification<Void> n ->
                     // unsubscribe from interval if we receive an error
                     return !n.isOnError();

--- a/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
@@ -23,7 +23,6 @@ import io.reactivex.netty.protocol.http.client.HttpRequest;
 import io.reactivex.netty.protocol.http.client.HttpResponse;
 import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import rx.Observable;
-import rx.util.functions.Action0;
 import rx.util.functions.Action1;
 
 import java.util.Map;
@@ -49,15 +48,10 @@ public final class HttpSseClient {
                     System.out.println(header.getKey() + ": " + header.getValue());
                 }
 
-                response.getContent().take(1).finallyDo(new Action0() {
-                    @Override
-                    public void call() {
-                        System.out.println("HttpSseClient.call");
-                    }
-                }).subscribe(new Action1<ServerSentEvent>() {
+                response.getContent().subscribe(new Action1<ServerSentEvent>() {
                     @Override
                     public void call(ServerSentEvent event) {
-                        System.out.print(event.getEventData());
+                        System.out.println(event.getEventName() + ':' + event.getEventData());
                     }
                 });
             }

--- a/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
@@ -26,7 +26,7 @@ import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClient;
 import io.reactivex.netty.protocol.http.client.HttpRequest;
 import io.reactivex.netty.protocol.http.client.HttpResponse;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import rx.Observable;
 import rx.util.functions.Action1;
 
@@ -38,9 +38,9 @@ import java.util.Map;
 public final class HttpSseClient {
 
     public static void main(String[] args) {
-        HttpClient<ByteBuf, SSEEvent> client =
+        HttpClient<ByteBuf, ServerSentEvent> client =
                 RxNetty.createHttpClient("localhost", 8080,
-                                         new PipelineConfiguratorComposite<HttpResponse<SSEEvent>, HttpRequest<ByteBuf>>(new PipelineConfigurator() {
+                                         new PipelineConfiguratorComposite<HttpResponse<ServerSentEvent>, HttpRequest<ByteBuf>>(new PipelineConfigurator() {
 
                                              @Override
                                              public void configureNewPipeline(ChannelPipeline pipeline) {
@@ -48,10 +48,10 @@ public final class HttpSseClient {
                                              }
                                          }, PipelineConfigurators.<ByteBuf>sseClientConfigurator()));
 
-        Observable<HttpResponse<SSEEvent>> response = client.submit(HttpRequest.createGet("/hello"));
-        response.toBlockingObservable().forEach(new Action1<HttpResponse<SSEEvent>>() {
+        Observable<HttpResponse<ServerSentEvent>> response = client.submit(HttpRequest.createGet("/hello"));
+        response.toBlockingObservable().forEach(new Action1<HttpResponse<ServerSentEvent>>() {
             @Override
-            public void call(HttpResponse<SSEEvent> response) {
+            public void call(HttpResponse<ServerSentEvent> response) {
                 System.out.println("New response recieved.");
                 System.out.println("========================");
                 System.out.println(response.getHttpVersion().text() + ' ' + response.getStatus().code()
@@ -60,9 +60,9 @@ public final class HttpSseClient {
                     System.out.println(header.getKey() + ": " + header.getValue());
                 }
 
-                response.getContent().subscribe(new Action1<SSEEvent>() {
+                response.getContent().subscribe(new Action1<ServerSentEvent>() {
                     @Override
-                    public void call(SSEEvent event) {
+                    public void call(ServerSentEvent event) {
                         System.out.print(event.getEventData());
                     }
                 });

--- a/src/examples/java/io/reactivex/netty/examples/java/HttpSseServer.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HttpSseServer.java
@@ -26,7 +26,7 @@ import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.server.HttpRequest;
 import io.reactivex.netty.protocol.http.server.HttpResponse;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import rx.Notification;
 import rx.Observable;
 import rx.util.functions.Func1;
@@ -42,13 +42,13 @@ public final class HttpSseServer {
         final int port = 8080;
 
         RxNetty.createHttpServer(port,
-                                 new RequestHandler<ByteBuf, SSEEvent>() {
+                                 new RequestHandler<ByteBuf, ServerSentEvent>() {
                                      @Override
                                      public Observable<Void> handle(HttpRequest<ByteBuf> request,
-                                                                    HttpResponse<SSEEvent> response) {
+                                                                    HttpResponse<ServerSentEvent> response) {
                                          return getIntervalObservable(response);
                                      }
-                                 }, new PipelineConfiguratorComposite<HttpRequest<ByteBuf>, HttpResponse<SSEEvent>>(
+                                 }, new PipelineConfiguratorComposite<HttpRequest<ByteBuf>, HttpResponse<ServerSentEvent>>(
                                          new PipelineConfigurator() {
 
                                              @Override
@@ -59,13 +59,13 @@ public final class HttpSseServer {
                                          PipelineConfigurators.<ByteBuf>sseServerConfigurator())).startAndWait();
     }
 
-    private static Observable<Void> getIntervalObservable(final HttpResponse<SSEEvent> response) {
+    private static Observable<Void> getIntervalObservable(final HttpResponse<ServerSentEvent> response) {
         return Observable.interval(1, TimeUnit.SECONDS)
                          .flatMap(new Func1<Long, Observable<Notification<Void>>>() {
                              @Override
                              public Observable<Notification<Void>> call(Long interval) {
                                  System.out.println("Writing SSE event for interval: " + interval);
-                                 return response.writeAndFlush(new SSEEvent("1", "data: ", String.valueOf(
+                                 return response.writeAndFlush(new ServerSentEvent("1", "data: ", String.valueOf(
                                          interval))).materialize();
                              }
                          })

--- a/src/examples/java/io/reactivex/netty/examples/java/HttpSseServer.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HttpSseServer.java
@@ -16,12 +16,7 @@
 package io.reactivex.netty.examples.java;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
 import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurator;
-import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.server.HttpRequest;
 import io.reactivex.netty.protocol.http.server.HttpResponse;
@@ -48,15 +43,7 @@ public final class HttpSseServer {
                                                                     HttpResponse<ServerSentEvent> response) {
                                          return getIntervalObservable(response);
                                      }
-                                 }, new PipelineConfiguratorComposite<HttpRequest<ByteBuf>, HttpResponse<ServerSentEvent>>(
-                                         new PipelineConfigurator() {
-
-                                             @Override
-                                             public void configureNewPipeline(ChannelPipeline pipeline) {
-                                                 pipeline.addFirst(new LoggingHandler(LogLevel.DEBUG));
-                                              }
-                                  },
-                                         PipelineConfigurators.<ByteBuf>sseServerConfigurator())).startAndWait();
+                                 }, PipelineConfigurators.<ByteBuf>sseServerConfigurator()).startAndWait();
     }
 
     private static Observable<Void> getIntervalObservable(final HttpResponse<ServerSentEvent> response) {

--- a/src/main/java/io/reactivex/netty/pipeline/PipelineConfigurators.java
+++ b/src/main/java/io/reactivex/netty/pipeline/PipelineConfigurators.java
@@ -25,7 +25,7 @@ import io.reactivex.netty.protocol.http.server.HttpServerPipelineConfigurator;
 import io.reactivex.netty.protocol.http.sse.SseOverHttpClientPipelineConfigurator;
 import io.reactivex.netty.protocol.http.sse.SseOverHttpServerPipelineConfigurator;
 import io.reactivex.netty.protocol.text.SimpleTextProtocolConfigurator;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 
 import java.nio.charset.Charset;
 
@@ -73,12 +73,12 @@ public final class PipelineConfigurators {
                                                                                   new HttpObjectAggregationConfigurator());
     }
 
-    public static <I> PipelineConfigurator<HttpResponse<SSEEvent>, HttpRequest<I>> sseClientConfigurator() {
+    public static <I> PipelineConfigurator<HttpResponse<ServerSentEvent>, HttpRequest<I>> sseClientConfigurator() {
         return new SseOverHttpClientPipelineConfigurator<I>();
     }
 
     public static <I> PipelineConfigurator<io.reactivex.netty.protocol.http.server.HttpRequest<I>,
-                                           io.reactivex.netty.protocol.http.server.HttpResponse<SSEEvent>> sseServerConfigurator() {
+                                           io.reactivex.netty.protocol.http.server.HttpResponse<ServerSentEvent>> sseServerConfigurator() {
         return new SseOverHttpServerPipelineConfigurator<I>();
     }
 

--- a/src/main/java/io/reactivex/netty/protocol/http/sse/SSEInboundHandler.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/sse/SSEInboundHandler.java
@@ -24,7 +24,6 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
 import io.reactivex.netty.protocol.text.sse.ServerSentEventDecoder;
 
 /**
@@ -36,7 +35,7 @@ import io.reactivex.netty.protocol.text.sse.ServerSentEventDecoder;
  *
  * <h1>Http response with no chunking</h1>
  * In this case, the {@link ServerSentEventDecoder} is inserted as the first handler in the pipeline. This makes the
- * {@link ByteBuf} at the origin to be converted to {@link SSEEvent} and hence any other handler will not look at this
+ * {@link ByteBuf} at the origin to be converted to {@link io.reactivex.netty.protocol.text.sse.ServerSentEvent} and hence any other handler will not look at this
  * message unless it is really interested.
  * <h3>Caveat</h3>
  * In some cases where any message is buffered before this pipeline change is made by this handler (i.e. adding

--- a/src/main/java/io/reactivex/netty/protocol/http/sse/SseOverHttpClientPipelineConfigurator.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/sse/SseOverHttpClientPipelineConfigurator.java
@@ -21,7 +21,7 @@ import io.reactivex.netty.protocol.http.client.HttpClientPipelineConfigurator;
 import io.reactivex.netty.protocol.http.client.HttpRequest;
 import io.reactivex.netty.protocol.http.client.HttpResponse;
 import io.reactivex.netty.protocol.text.sse.SSEClientPipelineConfigurator;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import io.reactivex.netty.protocol.text.sse.ServerSentEventDecoder;
 
 /**
@@ -32,7 +32,7 @@ import io.reactivex.netty.protocol.text.sse.ServerSentEventDecoder;
  *
  * @author Nitesh Kant
  */
-public class SseOverHttpClientPipelineConfigurator<I> implements PipelineConfigurator<HttpResponse<SSEEvent>, HttpRequest<I>> {
+public class SseOverHttpClientPipelineConfigurator<I> implements PipelineConfigurator<HttpResponse<ServerSentEvent>, HttpRequest<I>> {
 
     private final HttpClientPipelineConfigurator<I, ?> httpClientPipelineConfigurator;
 

--- a/src/main/java/io/reactivex/netty/protocol/http/sse/SseOverHttpServerPipelineConfigurator.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/sse/SseOverHttpServerPipelineConfigurator.java
@@ -23,8 +23,8 @@ import io.reactivex.netty.pipeline.PipelineConfigurator;
 import io.reactivex.netty.protocol.http.server.HttpRequest;
 import io.reactivex.netty.protocol.http.server.HttpResponse;
 import io.reactivex.netty.protocol.http.server.HttpServerPipelineConfigurator;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
 import io.reactivex.netty.protocol.text.sse.SSEServerPipelineConfigurator;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import io.reactivex.netty.protocol.text.sse.ServerSentEventEncoder;
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
@@ -39,7 +39,7 @@ import static io.reactivex.netty.protocol.text.sse.SSEServerPipelineConfigurator
  * @author Nitesh Kant
  */
 public class SseOverHttpServerPipelineConfigurator<I>
-        implements PipelineConfigurator<HttpRequest<I>, HttpResponse<SSEEvent>> {
+        implements PipelineConfigurator<HttpRequest<I>, HttpResponse<ServerSentEvent>> {
 
     public static final String SSE_RESPONSE_HEADERS_COMPLETER = "sse-response-headers-completer";
 

--- a/src/main/java/io/reactivex/netty/protocol/text/sse/SSEClientPipelineConfigurator.java
+++ b/src/main/java/io/reactivex/netty/protocol/text/sse/SSEClientPipelineConfigurator.java
@@ -24,7 +24,7 @@ import io.reactivex.netty.protocol.http.sse.SseOverHttpClientPipelineConfigurato
 /**
  * An implementation of {@link PipelineConfigurator} that will setup Netty's pipeline for a client recieving
  * Server Sent Events. <br/>
- * This will convert {@link ByteBuf} objects to {@link SSEEvent}. So, if the client is an HTTP client, then you would
+ * This will convert {@link ByteBuf} objects to {@link ServerSentEvent}. So, if the client is an HTTP client, then you would
  * have to use {@link SseOverHttpClientPipelineConfigurator} instead.
  *
  * @param <W> The request type for the client pipeline.
@@ -33,7 +33,7 @@ import io.reactivex.netty.protocol.http.sse.SseOverHttpClientPipelineConfigurato
  *
  * @author Nitesh Kant
  */
-public class SSEClientPipelineConfigurator<W> implements PipelineConfigurator<SSEEvent, W> {
+public class SSEClientPipelineConfigurator<W> implements PipelineConfigurator<ServerSentEvent, W> {
 
     public static final SSEInboundHandler SSE_INBOUND_HANDLER = new SSEInboundHandler();
 

--- a/src/main/java/io/reactivex/netty/protocol/text/sse/SSEServerPipelineConfigurator.java
+++ b/src/main/java/io/reactivex/netty/protocol/text/sse/SSEServerPipelineConfigurator.java
@@ -23,7 +23,7 @@ import io.reactivex.netty.protocol.http.sse.SseOverHttpServerPipelineConfigurato
 /**
  * An implementation of {@link PipelineConfigurator} that will setup Netty's pipeline for a server sending
  * Server Sent Events. <br/>
- * This will convert {@link SSEEvent} objects to {@link ByteBuf}. So, if the server is an HTTP server, then you would
+ * This will convert {@link ServerSentEvent} objects to {@link ByteBuf}. So, if the server is an HTTP server, then you would
  * have to use {@link SseOverHttpServerPipelineConfigurator} instead.
  *
  * @see {@link ServerSentEventEncoder}

--- a/src/main/java/io/reactivex/netty/protocol/text/sse/ServerSentEvent.java
+++ b/src/main/java/io/reactivex/netty/protocol/text/sse/ServerSentEvent.java
@@ -18,13 +18,13 @@ package io.reactivex.netty.protocol.text.sse;
 /**
  * This class represents a single server-sent event.
  */
-public class SSEEvent {
+public class ServerSentEvent {
 
     private final String eventId;
     private final String eventName;
     private final String eventData;
 
-    public SSEEvent(String eventId, String eventName, String eventData) {
+    public ServerSentEvent(String eventId, String eventName, String eventData) {
         this.eventId = eventId;
         this.eventName = eventName;
         this.eventData = eventData;

--- a/src/main/java/io/reactivex/netty/protocol/text/sse/ServerSentEventDecoder.java
+++ b/src/main/java/io/reactivex/netty/protocol/text/sse/ServerSentEventDecoder.java
@@ -76,8 +76,8 @@ public class ServerSentEventDecoder extends ReplayingDecoder<ServerSentEventDeco
             return this;
         }
 
-        public SSEEvent toMessage() {
-            SSEEvent message = new SSEEvent(
+        public ServerSentEvent toMessage() {
+            ServerSentEvent message = new ServerSentEvent(
                     eventId.toString(),
                     eventName.toString(),
                     eventData.toString()

--- a/src/main/java/io/reactivex/netty/protocol/text/sse/ServerSentEventEncoder.java
+++ b/src/main/java/io/reactivex/netty/protocol/text/sse/ServerSentEventEncoder.java
@@ -23,19 +23,19 @@ import io.netty.handler.codec.MessageToMessageEncoder;
 import java.util.List;
 
 /**
- * An encoder to convert {@link SSEEvent} to a {@link ByteBuf}
+ * An encoder to convert {@link ServerSentEvent} to a {@link ByteBuf}
  *
  * @author Nitesh Kant
  */
 @ChannelHandler.Sharable
-public class ServerSentEventEncoder extends MessageToMessageEncoder<SSEEvent> {
+public class ServerSentEventEncoder extends MessageToMessageEncoder<ServerSentEvent> {
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, SSEEvent sseEvent, List<Object> out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, ServerSentEvent serverSentEvent, List<Object> out) throws Exception {
         StringBuilder eventBuilder = new StringBuilder();
-        eventBuilder.append(sseEvent.getEventName());
+        eventBuilder.append(serverSentEvent.getEventName());
         eventBuilder.append(": ");
-        eventBuilder.append(sseEvent.getEventData());
+        eventBuilder.append(serverSentEvent.getEventData());
         eventBuilder.append("\n\n");
         String data = eventBuilder.toString();
         out.add(ctx.alloc().buffer(data.length()).writeBytes(data.getBytes()));

--- a/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
+++ b/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
@@ -24,7 +24,7 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.client.RxClient;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.server.HttpServer;
-import io.reactivex.netty.protocol.text.sse.SSEEvent;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -69,9 +69,9 @@ public class HttpClientTest {
     
     @Test
     public void testChunkedStreaming() throws Exception {
-        HttpClient<ByteBuf, SSEEvent> client = RxNetty.createHttpClient("localhost", port,
+        HttpClient<ByteBuf, ServerSentEvent> client = RxNetty.createHttpClient("localhost", port,
                                                                         PipelineConfigurators.<ByteBuf>sseClientConfigurator());
-        Observable<HttpResponse<SSEEvent>> response =
+        Observable<HttpResponse<ServerSentEvent>> response =
                 client.submit(HttpRequest.createGet("test/stream"));
 
         final List<String> result = new ArrayList<String>();
@@ -81,10 +81,10 @@ public class HttpClientTest {
 
     @Test
     public void testMultipleChunks() throws Exception {
-        HttpClient<ByteBuf, SSEEvent> client = RxNetty.createHttpClient("localhost", port,
+        HttpClient<ByteBuf, ServerSentEvent> client = RxNetty.createHttpClient("localhost", port,
                                                                         PipelineConfigurators
                                                                                 .<ByteBuf>sseClientConfigurator());
-        Observable<HttpResponse<SSEEvent>> response =
+        Observable<HttpResponse<ServerSentEvent>> response =
                 client.submit(HttpRequest.createDelete("test/largeStream"));
 
         final List<String> result = new ArrayList<String>();
@@ -94,18 +94,18 @@ public class HttpClientTest {
 
     @Test
     public void testMultipleChunksWithTransformation() throws Exception {
-        HttpClient<ByteBuf, SSEEvent> client = RxNetty.createHttpClient("localhost", port,
+        HttpClient<ByteBuf, ServerSentEvent> client = RxNetty.createHttpClient("localhost", port,
                                                                         PipelineConfigurators
                                                                                 .<ByteBuf>sseClientConfigurator());
-        Observable<HttpResponse<SSEEvent>> response =
+        Observable<HttpResponse<ServerSentEvent>> response =
                 client.submit(HttpRequest.createGet("test/largeStream"));
-        Observable<String> transformed = response.flatMap(new Func1<HttpResponse<SSEEvent>, Observable<String>>() {
+        Observable<String> transformed = response.flatMap(new Func1<HttpResponse<ServerSentEvent>, Observable<String>>() {
             @Override
-            public Observable<String> call(HttpResponse<SSEEvent> httpResponse) {
+            public Observable<String> call(HttpResponse<ServerSentEvent> httpResponse) {
                 if (httpResponse.getStatus().equals(HttpResponseStatus.OK)) {
-                    return httpResponse.getContent().map(new Func1<SSEEvent, String>() {
+                    return httpResponse.getContent().map(new Func1<ServerSentEvent, String>() {
                         @Override
-                        public String call(SSEEvent sseEvent) {
+                        public String call(ServerSentEvent sseEvent) {
                             return sseEvent.getEventData();
                         }
                     });
@@ -153,19 +153,19 @@ public class HttpClientTest {
 
     @Test
     public void testNonChunkingStream() throws Exception {
-        HttpClient<ByteBuf, SSEEvent> client = RxNetty.createHttpClient("localhost", port,
+        HttpClient<ByteBuf, ServerSentEvent> client = RxNetty.createHttpClient("localhost", port,
                                                                         PipelineConfigurators.<ByteBuf>sseClientConfigurator());
-        Observable<HttpResponse<SSEEvent>> response =
+        Observable<HttpResponse<ServerSentEvent>> response =
                 client.submit(HttpRequest.createGet("test/nochunk_stream"));
         final List<String> result = new ArrayList<String>();
-        response.flatMap(new Func1<HttpResponse<SSEEvent>, Observable<SSEEvent>>() {
+        response.flatMap(new Func1<HttpResponse<ServerSentEvent>, Observable<ServerSentEvent>>() {
             @Override
-            public Observable<SSEEvent> call(HttpResponse<SSEEvent> httpResponse) {
+            public Observable<ServerSentEvent> call(HttpResponse<ServerSentEvent> httpResponse) {
                 return httpResponse.getContent();
             }
-        }).toBlockingObservable().forEach(new Action1<SSEEvent>() {
+        }).toBlockingObservable().forEach(new Action1<ServerSentEvent>() {
             @Override
-            public void call(SSEEvent event) {
+            public void call(ServerSentEvent event) {
                 result.add(event.getEventData());
             }
         });
@@ -294,19 +294,19 @@ public class HttpClientTest {
         assertEquals(200, status[0]);
     }
 
-    private static void readResponseContent(Observable<HttpResponse<SSEEvent>> response,
+    private static void readResponseContent(Observable<HttpResponse<ServerSentEvent>> response,
                                             final List<String> result) {
         response.flatMap(
-                new Func1<HttpResponse<SSEEvent>, Observable<SSEEvent>>() {
+                new Func1<HttpResponse<ServerSentEvent>, Observable<ServerSentEvent>>() {
                     @Override
-                    public Observable<SSEEvent> call(HttpResponse<SSEEvent> sseEventHttpResponse) {
+                    public Observable<ServerSentEvent> call(HttpResponse<ServerSentEvent> sseEventHttpResponse) {
                         return sseEventHttpResponse.getContent();
                     }
                 })
-                .toBlockingObservable().forEach(new Action1<SSEEvent>() {
+                .toBlockingObservable().forEach(new Action1<ServerSentEvent>() {
             @Override
-            public void call(SSEEvent sseEvent) {
-                result.add(sseEvent.getEventData());
+            public void call(ServerSentEvent serverSentEvent) {
+                result.add(serverSentEvent.getEventData());
             }
         });
     }


### PR DESCRIPTION
Also improving the SSE client & server example to remove unnecessary netty pipeline configurations.
