### PR TITLE
Fixes issue #51 #39

### DIFF
--- a/src/examples/java/io/reactivex/netty/examples/java/HelloHttpClient.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HelloHttpClient.java
@@ -20,7 +20,7 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.protocol.http.client.HttpRequest;
 import io.reactivex.netty.protocol.http.client.HttpResponse;
 import rx.Observable;
-import rx.util.functions.Action1;
+import rx.functions.Action1;
 
 import java.nio.charset.Charset;
 import java.util.Map;

--- a/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
@@ -23,7 +23,7 @@ import io.reactivex.netty.protocol.http.client.HttpRequest;
 import io.reactivex.netty.protocol.http.client.HttpResponse;
 import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import rx.Observable;
-import rx.util.functions.Action1;
+import rx.functions.Action1;
 
 import java.util.Map;
 

--- a/src/examples/java/io/reactivex/netty/examples/java/HttpSseServer.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/HttpSseServer.java
@@ -24,7 +24,7 @@ import io.reactivex.netty.protocol.http.server.RequestHandler;
 import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import rx.Notification;
 import rx.Observable;
-import rx.util.functions.Func1;
+import rx.functions.Func1;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpEchoClient.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpEchoClient.java
@@ -19,9 +19,9 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import rx.Observable;
-import rx.util.functions.Action0;
-import rx.util.functions.Action1;
-import rx.util.functions.Func1;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.functions.Func1;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpEchoServer.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpEchoServer.java
@@ -21,7 +21,7 @@ import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import rx.Observable;
 import rx.Subscriber;
-import rx.util.functions.Func1;
+import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientFast.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientFast.java
@@ -19,8 +19,8 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import rx.Observable;
-import rx.util.functions.Action1;
-import rx.util.functions.Func1;
+import rx.functions.Action1;
+import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientSlow.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientSlow.java
@@ -19,8 +19,8 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import rx.Observable;
-import rx.util.functions.Action1;
-import rx.util.functions.Func1;
+import rx.functions.Action1;
+import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamServer.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamServer.java
@@ -21,8 +21,8 @@ import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import rx.Notification;
 import rx.Observable;
-import rx.util.functions.Action0;
-import rx.util.functions.Func1;
+import rx.functions.Action0;
+import rx.functions.Func1;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpIntervalClientTakeN.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpIntervalClientTakeN.java
@@ -23,8 +23,8 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 import rx.Observable;
-import rx.util.functions.Action1;
-import rx.util.functions.Func1;
+import rx.functions.Action1;
+import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant

--- a/src/examples/java/io/reactivex/netty/examples/java/TcpIntervalServer.java
+++ b/src/examples/java/io/reactivex/netty/examples/java/TcpIntervalServer.java
@@ -21,8 +21,8 @@ import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import rx.Notification;
 import rx.Observable;
-import rx.util.functions.Action0;
-import rx.util.functions.Func1;
+import rx.functions.Action0;
+import rx.functions.Func1;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/io/reactivex/netty/channel/DefaultChannelWriter.java
+++ b/src/main/java/io/reactivex/netty/channel/DefaultChannelWriter.java
@@ -9,7 +9,7 @@ import io.reactivex.netty.serialization.ByteTransformer;
 import io.reactivex.netty.serialization.ContentTransformer;
 import io.reactivex.netty.serialization.StringTransformer;
 import rx.Observable;
-import rx.util.functions.Func1;
+import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant

--- a/src/main/java/io/reactivex/netty/client/RxClientImpl.java
+++ b/src/main/java/io/reactivex/netty/client/RxClientImpl.java
@@ -30,8 +30,8 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observer;
 import rx.Subscriber;
+import rx.functions.Action0;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
 
 import java.util.concurrent.TimeUnit;
 
@@ -116,7 +116,6 @@ public class RxClientImpl<I, O> implements RxClient<I, O> {
                         @Override
                         public void call() {
                             connectFuture.channel().close(); // Async close, no need to wait for close or give any callback for failures.
-                            // TODO can this throw an error? if so what should be done? unsubscribe should not throw.
                         }
 
                     }));

--- a/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -25,9 +25,9 @@ import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
 import rx.Subscription;
+import rx.functions.Action0;
+import rx.functions.Action1;
 import rx.subscriptions.Subscriptions;
-import rx.util.functions.Action0;
-import rx.util.functions.Action1;
 
 public class HttpClientImpl<I, O> extends RxClientImpl<HttpRequest<I>, HttpResponse<O>> implements HttpClient<I, O> {
 

--- a/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -59,6 +59,8 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpRequest<I>, HttpRespo
                                                  final ClientConfig config) {
         enrichRequest(request, config);
 
+        // Here we do not map the connection Observable and return because the onComplete() of connectionObservable,
+        // does not indicate onComplete of the request processing.
         return Observable.create(new Observable.OnSubscribe<HttpResponse<O>>() {
             @Override
             public void call(final Subscriber<? super HttpResponse<O>> subscriber) {
@@ -107,6 +109,11 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpRequest<I>, HttpRespo
             super(requestProcessingObserver);
             this.request = request;
             this.requestProcessingObserver = requestProcessingObserver;
+        }
+
+        @Override
+        public void onCompleted() {
+            // We do not want an onComplete() call to Request Processing Observer on onComplete of connection observable.
         }
 
         @Override

--- a/src/main/java/io/reactivex/netty/protocol/http/client/HttpRequest.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/client/HttpRequest.java
@@ -89,9 +89,6 @@ public class HttpRequest<T> {
     }
 
     public HttpRequest<T> withContent(T content) {
-        if (!headers.isContentLengthSet()) {
-            headers.set(HttpHeaders.Names.TRANSFER_ENCODING, "chunked");
-        }
         contentSource = new ContentSource.SingletonSource<T>(content);
         return this;
     }

--- a/src/main/java/io/reactivex/netty/protocol/http/client/HttpResponse.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/client/HttpResponse.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.reactivex.netty.protocol.http.CookiesHolder;
 import rx.Observable;
-import rx.functions.Func1;
 import rx.subjects.PublishSubject;
 
 import java.util.Map;
@@ -29,8 +28,7 @@ import java.util.Set;
 /**
  * A Http response object used by {@link HttpClient}
  *
- * @param <T> The type of the default response content. This can be converted to a user defined entity by using
- * {@link #getContent(Func1)}
+ * @param <T> The type of the default response content.
  *
  * @author Nitesh Kant
  */
@@ -70,10 +68,5 @@ public class HttpResponse<T> {
 
     public Observable<T> getContent() {
         return contentSubject;
-    }
-
-    public <R> Observable<R> getContent(@SuppressWarnings("unused") Func1<T, R> somestuff) {
-        // TODO: SerDe Framework
-        return Observable.error(new UnsupportedOperationException("On-demand de-serialization is not supported."));
     }
 }

--- a/src/main/java/io/reactivex/netty/protocol/http/client/HttpResponse.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/client/HttpResponse.java
@@ -20,8 +20,8 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.reactivex.netty.protocol.http.CookiesHolder;
 import rx.Observable;
+import rx.functions.Func1;
 import rx.subjects.PublishSubject;
-import rx.util.functions.Func1;
 
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/io/reactivex/netty/protocol/http/server/DefaultErrorResponseGenerator.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/DefaultErrorResponseGenerator.java
@@ -1,0 +1,13 @@
+package io.reactivex.netty.protocol.http.server;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+* @author Nitesh Kant
+*/
+class DefaultErrorResponseGenerator<O> implements ErrorResponseGenerator<O> {
+    @Override
+    public void updateResponse(HttpResponse<O> response, Throwable error) {
+        response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/io/reactivex/netty/protocol/http/server/ErrorResponseGenerator.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/ErrorResponseGenerator.java
@@ -1,0 +1,9 @@
+package io.reactivex.netty.protocol.http.server;
+
+/**
+ * @author Nitesh Kant
+ */
+public interface ErrorResponseGenerator<T> {
+
+    void updateResponse(HttpResponse<T> response, Throwable error);
+}

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -47,7 +47,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpRequest<I>, H
                             @Override
                             public Observable<Void> call(Throwable throwable) {
                                 if (!response.isHeaderWritten()) {
-                                    responseGenerator.updateResponse(response, throwable); // If there is an error here
+                                    responseGenerator.updateResponse(response, throwable);
                                 }
                                 return Observable.empty();
                             }

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -1,0 +1,64 @@
+package io.reactivex.netty.protocol.http.server;
+
+import io.reactivex.netty.channel.ConnectionHandler;
+import io.reactivex.netty.channel.ObservableConnection;
+import rx.Observable;
+import rx.functions.Action0;
+import rx.functions.Func1;
+
+/**
+* @author Nitesh Kant
+*/
+class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpRequest<I>, HttpResponse<O>> {
+
+    private ErrorResponseGenerator<O> responseGenerator = new DefaultErrorResponseGenerator<O>();
+
+    private final RequestHandler<I, O> requestHandler;
+
+    public HttpConnectionHandler(RequestHandler<I, O> requestHandler) {
+        this.requestHandler = requestHandler;
+    }
+
+    void setResponseGenerator(ErrorResponseGenerator<O> responseGenerator) {
+        this.responseGenerator = responseGenerator;
+    }
+
+    @Override
+    public Observable<Void> handle(final ObservableConnection<HttpRequest<I>, HttpResponse<O>> newConnection) {
+
+        return newConnection.getInput().flatMap(new Func1<HttpRequest<I>, Observable<Void>>() {
+            @Override
+            public Observable<Void> call(HttpRequest<I> newRequest) {
+                final HttpResponse<O> response = new HttpResponse<O>(newConnection.getChannelHandlerContext(),
+                                                               newRequest.getHttpVersion());
+                Observable<Void> toReturn;
+
+                try {
+                    toReturn = requestHandler.handle(newRequest, response);
+                    if (null == toReturn) {
+                        toReturn = Observable.empty();
+                    }
+                } catch (Throwable throwable) {
+                    toReturn = Observable.error(throwable);
+                }
+
+                return toReturn
+                        .onErrorResumeNext(new Func1<Throwable, Observable<Void>>() {
+                            @Override
+                            public Observable<Void> call(Throwable throwable) {
+                                if (!response.isHeaderWritten()) {
+                                    responseGenerator.updateResponse(response, throwable); // If there is an error here
+                                }
+                                return Observable.empty();
+                            }
+                        })
+                        .finallyDo(new Action0() {
+                            @Override
+                            public void call() {
+                                response.close();
+                            }
+                        });
+            }
+        });
+    }
+}

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpRequest.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpRequest.java
@@ -20,8 +20,8 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.reactivex.netty.protocol.http.CookiesHolder;
 import rx.Observable;
+import rx.functions.Func1;
 import rx.subjects.PublishSubject;
-import rx.util.functions.Func1;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpRequest.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpRequest.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.reactivex.netty.protocol.http.CookiesHolder;
 import rx.Observable;
-import rx.functions.Func1;
 import rx.subjects.PublishSubject;
 
 import java.util.List;
@@ -84,10 +83,5 @@ public class HttpRequest<T> {
 
     public Observable<T> getContent() {
         return contentSubject;
-    }
-
-    public <R> Observable<R> getContent(@SuppressWarnings("unused") Func1<T, R> somestuff) {
-        // TODO: SerDe Framework
-        return Observable.error(new UnsupportedOperationException("On demand de-serialization is not supported."));
     }
 }

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
@@ -16,62 +16,41 @@
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.reactivex.netty.channel.ConnectionHandler;
-import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
 import io.reactivex.netty.server.RxServer;
-import rx.Observable;
-import rx.functions.Action0;
-import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant
  */
 public class HttpServer<I, O> extends RxServer<HttpRequest<I>, HttpResponse<O>> {
 
+    private final HttpConnectionHandler<I, O> connectionHandler;
+
     public HttpServer(ServerBootstrap bootstrap, int port,
                       PipelineConfigurator<HttpRequest<I>, HttpResponse<O>> pipelineConfigurator,
                       RequestHandler<I, O> requestHandler) {
-        super(bootstrap, port, addRequiredConfigurator(pipelineConfigurator), new HttpConnectionHandler<I, O>(requestHandler));
+        this(bootstrap, port, pipelineConfigurator, new HttpConnectionHandler<I, O>(requestHandler));
     }
 
     HttpServer(ServerBootstrap bootstrap, int port,
                PipelineConfigurator<HttpRequest<I>, HttpResponse<O>> pipelineConfigurator,
                HttpConnectionHandler<I, O> connectionHandler) {
         super(bootstrap, port, addRequiredConfigurator(pipelineConfigurator), connectionHandler);
+        this.connectionHandler = connectionHandler;
+    }
+
+    HttpServer<I, O> withErrorResponseGenerator(ErrorResponseGenerator<O> responseGenerator) {
+        if (null == responseGenerator) {
+            throw new IllegalArgumentException("Response generator can not be null.");
+        }
+        connectionHandler.setResponseGenerator(responseGenerator);
+        return this;
     }
 
     private static <I, O> PipelineConfigurator<HttpRequest<I>, HttpResponse<O>> addRequiredConfigurator(
             PipelineConfigurator<HttpRequest<I>, HttpResponse<O>> pipelineConfigurator) {
         return new PipelineConfiguratorComposite<HttpRequest<I>, HttpResponse<O>>(pipelineConfigurator,
                                                                                   new ServerRequiredConfigurator<I, O>());
-    }
-
-    static class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpRequest<I>, HttpResponse<O>> {
-
-        private final RequestHandler<I, O> requestHandler;
-
-        public HttpConnectionHandler(RequestHandler<I, O> requestHandler) {
-            this.requestHandler = requestHandler;
-        }
-
-        @Override
-        public Observable<Void> handle(final ObservableConnection<HttpRequest<I>, HttpResponse<O>> newConnection) {
-
-            return newConnection.getInput().flatMap(new Func1<HttpRequest<I>, Observable<Void>>() {
-                @Override
-                public Observable<Void> call(HttpRequest<I> newRequest) {
-                    final HttpResponse<O> response = new HttpResponse<O>(newConnection.getChannelHandlerContext(),
-                                                                   newRequest.getHttpVersion());
-                    return requestHandler.handle(newRequest, response).finallyDo(new Action0() {
-                        @Override
-                        public void call() {
-                            response.close();
-                        }
-                    });
-                }
-            });
-        }
     }
 }

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
@@ -22,8 +22,8 @@ import io.reactivex.netty.pipeline.PipelineConfigurator;
 import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
 import io.reactivex.netty.server.RxServer;
 import rx.Observable;
-import rx.util.functions.Action0;
-import rx.util.functions.Func1;
+import rx.functions.Action0;
+import rx.functions.Func1;
 
 /**
  * @author Nitesh Kant

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
@@ -33,7 +33,7 @@ public class HttpServer<I, O> extends RxServer<HttpRequest<I>, HttpResponse<O>> 
         this(bootstrap, port, pipelineConfigurator, new HttpConnectionHandler<I, O>(requestHandler));
     }
 
-    HttpServer(ServerBootstrap bootstrap, int port,
+    protected HttpServer(ServerBootstrap bootstrap, int port,
                PipelineConfigurator<HttpRequest<I>, HttpResponse<O>> pipelineConfigurator,
                HttpConnectionHandler<I, O> connectionHandler) {
         super(bootstrap, port, addRequiredConfigurator(pipelineConfigurator), connectionHandler);

--- a/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerBuilder.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerBuilder.java
@@ -19,8 +19,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.server.AbstractServerBuilder;
 
-import static io.reactivex.netty.protocol.http.server.HttpServer.HttpConnectionHandler;
-
 /**
  * A convenience builder to create instances of {@link HttpServer}
  *

--- a/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
+++ b/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
@@ -93,7 +93,7 @@ public class ServerRequestResponseConverter extends ChannelDuplexHandler {
                 // encoding as chunked as we always send data in multiple HttpContent.
                 // On the other hand, if someone wants to not have chunked encoding, adding content-length will work
                 // as expected.
-                rxResponse.getHeaders().add(HttpHeaders.Names.TRANSFER_ENCODING, "chunked");
+                rxResponse.getHeaders().add(HttpHeaders.Names.TRANSFER_ENCODING, HttpHeaders.Values.CHUNKED);
             }
             super.write(ctx, rxResponse.getNettyResponse(), promise);
         } else if (ByteBuf.class.isAssignableFrom(recievedMsgClass)) {

--- a/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
+++ b/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
@@ -30,8 +30,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import rx.Observable;
 import rx.Observer;
-import rx.util.functions.Action1;
-import rx.util.functions.Func1;
+import rx.functions.Action1;
+import rx.functions.Func1;
 
 import java.net.ConnectException;
 import java.nio.charset.Charset;

--- a/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
+++ b/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
@@ -47,7 +47,7 @@ public class CookieTest {
     @Test
     public void testSetCookie() throws Exception {
         DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
-        HttpResponse<ByteBuf> response = new HttpResponse<ByteBuf>(new NoOpChannelHandlerContext(), HttpVersion.HTTP_1_1,
+        HttpResponse<ByteBuf> response = new HttpResponse<ByteBuf>(new NoOpChannelHandlerContext(),
                                                                    nettyResponse);
         String cookieName = "name";
         String cookieValue = "value";

--- a/src/test/java/io/reactivex/netty/protocol/http/server/HttpErrorHandlerTest.java
+++ b/src/test/java/io/reactivex/netty/protocol/http/server/HttpErrorHandlerTest.java
@@ -1,0 +1,92 @@
+package io.reactivex.netty.protocol.http.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.server.RxServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import rx.Observable;
+
+/**
+ * @author Nitesh Kant
+ */
+public class HttpErrorHandlerTest {
+
+    public static final String X_TEST_RESP_GEN_CALLED_HEADER_NAME = "X-TEST-RESP-GEN-CALLED";
+
+    private RxServer<HttpRequest<ByteBuf>, HttpResponse<ByteBuf>> server;
+
+    @After
+    public void tearDown() throws Exception {
+        if (null != server) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testErrorGenerator() throws Exception {
+        int port = 9999;
+        server = RxNetty.createHttpServer(port, new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(
+                    HttpRequest<ByteBuf> request,
+                    HttpResponse<ByteBuf> response) {
+                return Observable
+                        .error(new IllegalStateException(
+                                "I always throw an error."));
+            }
+        }).withErrorResponseGenerator(new ErrorResponseGenerator<ByteBuf>() {
+            @Override
+            public void updateResponse(
+                    HttpResponse<ByteBuf> response,
+                    Throwable error) {
+                response.setStatus(
+                        HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                response.getHeaders().add(
+                        X_TEST_RESP_GEN_CALLED_HEADER_NAME,
+                        "true");
+            }
+        }).start();
+
+        io.reactivex.netty.protocol.http.client.HttpRequest<ByteBuf> request =
+                io.reactivex.netty.protocol.http.client.HttpRequest.createGet("/");
+
+        io.reactivex.netty.protocol.http.client.HttpResponse<ByteBuf> response =
+                RxNetty.createHttpClient("localhost", port).submit(request).toBlockingObservable().last();
+
+        Assert.assertEquals("Unexpected response status", HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                            response.getStatus().code());
+        Assert.assertTrue("Error response generator not called.", response.getHeaders().contains(
+                X_TEST_RESP_GEN_CALLED_HEADER_NAME));
+    }
+
+    @Test
+    public void testErrorGeneratorThrowException() throws Exception {
+        int port = 9998;
+        server = RxNetty.createHttpServer(port, new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpRequest<ByteBuf> request, HttpResponse<ByteBuf> response) {
+                throw new IllegalStateException("I always throw an error.");
+            }
+        }).withErrorResponseGenerator(new ErrorResponseGenerator<ByteBuf>() {
+            @Override
+            public void updateResponse(HttpResponse<ByteBuf> response, Throwable error) {
+                response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+                response.getHeaders().add(X_TEST_RESP_GEN_CALLED_HEADER_NAME, "true");
+            }
+        }).start();
+
+        io.reactivex.netty.protocol.http.client.HttpRequest<ByteBuf> request =
+                io.reactivex.netty.protocol.http.client.HttpRequest.createGet("/");
+
+        io.reactivex.netty.protocol.http.client.HttpResponse<ByteBuf> response =
+                RxNetty.createHttpClient("localhost", port).submit(request).toBlockingObservable().last();
+
+        Assert.assertEquals("Unexpected response status", HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                            response.getStatus().code());
+        Assert.assertTrue("Error response generator not called.", response.getHeaders().contains(
+                X_TEST_RESP_GEN_CALLED_HEADER_NAME));
+    }
+}

--- a/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
+++ b/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
@@ -1,0 +1,93 @@
+package io.reactivex.netty.protocol.http.server;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.channel.ConnectionHandler;
+import io.reactivex.netty.channel.ObservableConnection;
+import io.reactivex.netty.server.ErrorHandler;
+import io.reactivex.netty.server.RxServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.testng.Assert;
+import rx.Observable;
+import rx.functions.Func1;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author Nitesh Kant
+ */
+public class UnexpectedErrorsTest {
+
+    public static final int PORT = 1999;
+    private RxServer<ByteBuf,ByteBuf> server;
+
+    @Before
+    public void setUp() throws Exception {
+        server = RxNetty.createTcpServer(PORT, new ConnectionHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(ObservableConnection<ByteBuf, ByteBuf> newConnection) {
+                return Observable.error(new IllegalStateException("I always throw an error."));
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void testErrorHandlerReturnsNull() throws Exception {
+        TestableErrorHandler errorHandler = new TestableErrorHandler(null);
+        server.withErrorHandler(errorHandler).start();
+
+        blockTillConnected();
+
+        Thread.sleep(1000); // Sucks but we want to wait for the server connection handling to finish
+
+        Assert.assertTrue(errorHandler.invoked, "Error handler not invoked.");
+    }
+
+    @Test
+    public void testConnectionHandlerReturnsError() throws Exception {
+        TestableErrorHandler errorHandler = new TestableErrorHandler(
+                Observable.<Void>error(new IllegalStateException("I always throw an error.")));
+
+        server.withErrorHandler(errorHandler).start();
+
+        blockTillConnected();
+
+        Thread.sleep(1000); // Sucks but we want to wait for the server connection handling to finish
+
+        Assert.assertTrue(errorHandler.invoked, "Error handler not invoked.");
+    }
+
+    private static void blockTillConnected() throws InterruptedException, ExecutionException {
+        RxNetty.createTcpClient("localhost", PORT).connect().flatMap(
+                new Func1<ObservableConnection<ByteBuf, ByteBuf>, Observable<?>>() {
+                    @Override
+                    public Observable<Void> call(ObservableConnection<ByteBuf, ByteBuf> connection) {
+                        return connection.close();
+                    }
+                }).toBlockingObservable().toFuture().get();
+    }
+
+
+    private static class TestableErrorHandler implements ErrorHandler {
+
+        private final Observable<Void> toReturn;
+        private boolean invoked;
+
+        private TestableErrorHandler(Observable<Void> toReturn) {
+            this.toReturn = toReturn;
+        }
+
+        @Override
+        public Observable<Void> handleError(Throwable throwable) {
+            invoked = true;
+            return toReturn;
+        }
+    }
+}


### PR DESCRIPTION
Moved all usages of rx.util.functions to rx.functions as the former is deprecated.
Removed unimplemented methods pertaining to on-demand de-serialization. These will be added with issue #54
