### PR TITLE
Fix issue #74

### DIFF
--- a/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
@@ -16,6 +16,7 @@
 package io.reactivex.netty.client;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -42,6 +43,7 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
         this.bootstrap = bootstrap;
         serverInfo = new RxClientImpl.ServerInfo(host, port);
         clientConfig = RxClient.ClientConfig.DEFAULT_CONFIG;
+        defaultChannelOptions();
     }
 
     protected AbstractClientBuilder(String host, int port) {
@@ -50,6 +52,7 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
 
     public B defaultChannelOptions() {
         channelOption(ChannelOption.SO_KEEPALIVE, true);
+        channelOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
         return channelOption(ChannelOption.TCP_NODELAY, true);
     }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
@@ -16,6 +16,7 @@
 package io.reactivex.netty.server;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
@@ -69,12 +70,13 @@ public abstract class AbstractServerBuilder<I, O, B extends AbstractServerBuilde
     }
 
     public <T> B channelOption(ChannelOption<T> option, T value) {
-        serverBootstrap.option(option, value);
+        serverBootstrap.childOption(option, value);
         return returnBuilder();
     }
 
     public B defaultChannelOptions() {
         channelOption(ChannelOption.SO_KEEPALIVE, true);
+        channelOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
         return returnBuilder();
     }
 


### PR DESCRIPTION
- Also invokes `defaultChannelOptions()` in the builder constructor.
- For server builder, use `bootstrap.childOption()` instead of `bootstrap.option()`
