### PR TITLE
Fix for issue #89

### DIFF
--- a/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
@@ -1,0 +1,32 @@
+package io.reactivex.netty.channel;
+
+import io.netty.channel.EventLoopGroup;
+import io.reactivex.netty.client.ClientBuilder;
+import io.reactivex.netty.client.RxClient;
+import io.reactivex.netty.server.RxServer;
+import io.reactivex.netty.server.ServerBuilder;
+
+/**
+ * A provider for netty's {@link EventLoopGroup} to be used for RxNetty's clients and servers when they are not
+ * provided explicitly.
+ *
+ * @author Nitesh Kant
+ */
+public interface RxEventLoopProvider {
+
+    /**
+     * The {@link EventLoopGroup} to be used by all {@link RxClient} instances if it is not explicitly provided using
+     * {@link ClientBuilder#eventloop(EventLoopGroup)}.
+     *
+     * @return The {@link EventLoopGroup} to be used for all clients.
+     */
+    EventLoopGroup globalClientEventLoop();
+
+    /**
+     * The {@link EventLoopGroup} to be used by all {@link RxServer} instances if it is not explicitly provided using
+     * {@link ServerBuilder#eventLoop(EventLoopGroup)} or {@link ServerBuilder#eventLoops(EventLoopGroup, EventLoopGroup)} .
+     *
+     * @return The {@link EventLoopGroup} to be used for all servers.
+     */
+    EventLoopGroup globalServerEventLoop();
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
@@ -1,0 +1,26 @@
+package io.reactivex.netty.channel;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+
+/**
+ * An implementation of {@link RxEventLoopProvider} that returns the same {@link EventLoopGroup} instance for both
+ * client and server.
+ *
+ * @author Nitesh Kant
+ */
+public class SingleNioLoopProvider implements RxEventLoopProvider {
+
+    private final EventLoopGroup eventLoop = new NioEventLoopGroup(0/*means default in netty*/,
+                                                                   new RxDefaultThreadFactory("rx-selector"));
+
+    @Override
+    public EventLoopGroup globalClientEventLoop() {
+        return eventLoop;
+    }
+
+    @Override
+    public EventLoopGroup globalServerEventLoop() {
+        return eventLoop;
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
@@ -18,9 +18,9 @@ package io.reactivex.netty.client;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.client.pool.ChannelPool;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 
@@ -87,13 +87,13 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
         if (null == socketChannel) {
             socketChannel = NioSocketChannel.class;
             if (null == eventLoopGroup) {
-                eventLoopGroup = new NioEventLoopGroup(0 /*means default in netty*/, new RxClientThreadFactory());
+                eventLoopGroup = RxNetty.getRxEventLoopProvider().globalClientEventLoop();
             }
         }
 
         if (null == eventLoopGroup) {
             if (NioSocketChannel.class == socketChannel) {
-                eventLoopGroup = new NioEventLoopGroup(0 /*means default in netty*/, new RxClientThreadFactory());
+                eventLoopGroup = RxNetty.getRxEventLoopProvider().globalClientEventLoop();
             } else {
                 // Fail fast for defaults we do not support.
                 throw new IllegalStateException("Specified a channel class but not the event loop group.");

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
@@ -19,8 +19,8 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ConnectionHandler;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 
@@ -88,13 +88,13 @@ public abstract class AbstractServerBuilder<I, O, B extends AbstractServerBuilde
             serverChannelClass = NioServerSocketChannel.class;
             EventLoopGroup acceptorGroup = serverBootstrap.group();
             if (null == acceptorGroup) {
-                serverBootstrap.group(new NioEventLoopGroup(0 /*means default in netty*/, new RxServerThreadFactory()));
+                serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerEventLoop());
             }
         }
 
         if (null == serverBootstrap.group()) {
             if (NioServerSocketChannel.class == serverChannelClass) {
-                serverBootstrap.group(new NioEventLoopGroup(0 /*means default in netty*/, new RxServerThreadFactory()));
+                serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerEventLoop());
             } else {
                 // Fail fast for defaults we do not support.
                 throw new IllegalStateException("Specified a channel class but not the event loop group.");


### PR DESCRIPTION
Adds a capability to specify a provider for netty's eventloops for Rx clients and servers when they have not been specified explicitly.

By default, we will use the same eventloop for both client & server.
