### PR TITLE
Fix build failure

### DIFF
--- a/rx-netty-remote-observable/build.gradle
+++ b/rx-netty-remote-observable/build.gradle
@@ -6,6 +6,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
 	compile project(':rx-netty')
 	compile 'com.netflix.numerus:numerus:1.+'
+    compile 'com.netflix.rxjava:rxjava-math:[0.17,)'
 	compile 'org.slf4j:slf4j-api:1.7.0'
 	compile 'org.slf4j:slf4j-log4j12:1.7.0'
     testCompile 'junit:junit:4.10'

--- a/rx-netty-remote-observable/src/test/java/io/reactivex/netty/MetricsTest.java
+++ b/rx-netty-remote-observable/src/test/java/io/reactivex/netty/MetricsTest.java
@@ -9,6 +9,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action1;
+import rx.observables.MathObservable;
 
 public class MetricsTest {
 	
@@ -30,7 +31,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> rc = RemoteObservable.connect(cc);
 		// assert
-		Observable.sumInteger(rc.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(rc.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -60,7 +61,7 @@ public class MetricsTest {
 		
 		Observable<Integer> oc = RemoteObservable.connect(cc).getObservable();
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -90,7 +91,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro1 = RemoteObservable.connect(cc);
 		// assert
-		Observable.sumInteger(ro1.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(ro1.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -99,7 +100,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro2 = RemoteObservable.connect(cc);
 		// assert
-		Observable.sumInteger(ro2.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(ro2.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -152,7 +153,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro1 = RemoteObservable.connect(cc);
 		try{
-			Observable.sumInteger(ro1.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+			MathObservable.sumInteger(ro1.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
 				@Override
 				public void call(Integer t1) {
 					Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -164,7 +165,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro2 = RemoteObservable.connect(cc);
 		try{
-			Observable.sumInteger(ro2.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+			MathObservable.sumInteger(ro2.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
 				@Override
 				public void call(Integer t1) {
 					Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -222,7 +223,7 @@ public class MetricsTest {
 		
 		// assert
 		try{
-			Observable.sumInteger(rc.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+			MathObservable.sumInteger(rc.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
 				@Override
 				public void call(Integer t1) {
 					Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100

--- a/rx-netty-remote-observable/src/test/java/io/reactivex/netty/RemoteObservableTest.java
+++ b/rx-netty-remote-observable/src/test/java/io/reactivex/netty/RemoteObservableTest.java
@@ -20,9 +20,13 @@ import rx.functions.Action1;
 import rx.functions.Action2;
 import rx.functions.Func1;
 import rx.functions.Func2;
+import rx.observables.MathObservable;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 import rx.subjects.ReplaySubject;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RemoteObservableTest {
 
@@ -38,7 +42,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -64,7 +68,7 @@ public class RemoteObservableTest {
 					.build())
 				.getObservable();
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -86,7 +90,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", wrongPort, Codecs.integer());
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -320,7 +324,7 @@ public class RemoteObservableTest {
 			.getObservable();
 
 		// assert
-		Observable.sumInteger(ro1).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(ro1).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -366,7 +370,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", port, Codecs.integer());
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(20200, t1.intValue()); // sum of number 0-200
@@ -384,7 +388,8 @@ public class RemoteObservableTest {
 		final MutableReference<Boolean> stopped = new MutableReference<Boolean>(false);
 		// run in background
 		new Thread(){
-			public void run(){
+			@Override
+            public void run(){
 				RemoteRxServer server = RemoteObservable.serve(serverPort, os, Codecs.integer());
 				server.start();
 				server.blockUntilCompleted();
@@ -395,7 +400,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -434,7 +439,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(45150, t1.intValue()); // sum of number 0-200
@@ -476,7 +481,7 @@ public class RemoteObservableTest {
 		subject.onCompleted();
 		
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(80200, t1.intValue()); // sum of number 0-200
@@ -508,7 +513,7 @@ public class RemoteObservableTest {
 		// merge results
 		Observable<Integer> merged = Observable.merge(oc1,oc2);
 		// assert
-		Observable.sumInteger(merged).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(merged).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -561,7 +566,7 @@ public class RemoteObservableTest {
 			.getObservable();
 
 		
-		Observable.sumInteger(oc2).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc2).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -583,7 +588,7 @@ public class RemoteObservableTest {
 		RemoteObservable.serve(serverPort, os, Codecs.integer())
 			.start();
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -616,12 +621,12 @@ public class RemoteObservableTest {
 		// connect to remote observable
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		Subscription sub = oc.subscribe();
-		
-		Assert.assertEquals(false, sub.isUnsubscribed());
+
+        assertFalse(sub.isUnsubscribed());
 		Thread.sleep(1000); // allow a few iterations
 		sub.unsubscribe();
 		Thread.sleep(1000); // allow time for unsubscribe to propagate
-		Assert.assertEquals(true, sub.isUnsubscribed());
+        assertTrue(sub.isUnsubscribed());
 		Assert.assertEquals(true, sourceSubscriptionUnsubscribed.getValue());
 	}
 	
@@ -659,7 +664,7 @@ public class RemoteObservableTest {
 		Subscription subscription = oc2.subscribe();
 
 		// check client subscription
-		Assert.assertEquals(false, subscription.isUnsubscribed());
+        assertFalse(subscription.isUnsubscribed());
 		
 		Thread.sleep(1000); // allow a few iterations to complete
 		
@@ -667,7 +672,7 @@ public class RemoteObservableTest {
 		subscription.unsubscribe();
 		Thread.sleep(3000); // allow time for unsubscribe to propagate
 		// check client
-		Assert.assertEquals(true, subscription.isUnsubscribed());
+        assertTrue(subscription.isUnsubscribed());
 		// check source
 		Assert.assertEquals(true, sourceSubscriptionUnsubscribed.getValue());
 	}
@@ -703,7 +708,7 @@ public class RemoteObservableTest {
 			.getObservable();
 
 		// assert
-		Observable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(2550, t1.intValue()); // sum of number 0-100

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/HttpSseServer.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/HttpSseServer.groovy
@@ -24,7 +24,7 @@ import io.reactivex.netty.channel.ObservableConnection
 import io.reactivex.netty.protocol.http.server.HttpServer
 import io.reactivex.netty.protocol.text.sse.ServerSentEvent
 import rx.Notification
-import rx.util.functions.Action1
+import rx.functions.Action1
 
 import java.util.concurrent.TimeUnit
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEchoServer.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEchoServer.groovy
@@ -19,7 +19,7 @@ import io.reactivex.netty.RxNetty
 import io.reactivex.netty.channel.ObservableConnection
 import io.reactivex.netty.pipeline.PipelineConfigurators
 import io.reactivex.netty.server.RxServer
-import rx.util.functions.Action1
+import rx.functions.Action1
 
 class TcpEchoServer {
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEventStreamServer.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEventStreamServer.groovy
@@ -21,7 +21,7 @@ import io.reactivex.netty.pipeline.PipelineConfigurators
 import io.reactivex.netty.server.RxServer
 import rx.Notification
 import rx.Observable
-import rx.util.functions.Action1
+import rx.functions.Action1
 
 import java.util.concurrent.TimeUnit
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpIntervalServer.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpIntervalServer.groovy
@@ -21,7 +21,7 @@ import io.reactivex.netty.pipeline.PipelineConfigurators
 import io.reactivex.netty.server.RxServer
 import rx.Notification
 import rx.Observable
-import rx.util.functions.Action1
+import rx.functions.Action1
 
 import java.util.concurrent.TimeUnit
 

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RequestProcessor.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RequestProcessor.java
@@ -28,6 +28,7 @@ import io.reactivex.netty.protocol.http.server.RequestHandler;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
@@ -107,7 +108,7 @@ public class RequestProcessor implements RequestHandler<ByteBuf, ByteBuf> {
                 new Func1<Throwable, Observable<ByteBuf>>() {
                     @Override
                     public Observable<ByteBuf> call(Throwable throwable) {
-                        if (throwable instanceof IllegalArgumentException) {
+                        if (throwable instanceof NoSuchElementException) {
                             return Observable.from(Unpooled.EMPTY_BUFFER);
                         }
                         return Observable.error(throwable);


### PR DESCRIPTION
rxjava-0.18.1 removes all math related methods. Using rxjava-math instead.
