### PR TITLE
Fixes issues #129 #130 #131

### DIFF
--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ClientHandlerTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ClientHandlerTest.java
@@ -29,7 +29,9 @@ import io.reactivex.netty.contexts.ContextKeySupplier;
 import io.reactivex.netty.contexts.ContextsContainer;
 import io.reactivex.netty.contexts.ContextsContainerImpl;
 import io.reactivex.netty.contexts.RxContexts;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -39,6 +41,18 @@ public class ClientHandlerTest {
 
     public static final String CTX_1_NAME = "ctx1";
     public static final BidirectionalTestContext CTX_1_VAL = new BidirectionalTestContext(CTX_1_NAME);
+
+    @Before
+    public void setUp() throws Exception {
+        System.err.print(">>>> ClientHandlerTest.setUp()");
+        RxContexts.DEFAULT_CORRELATOR.dumpThreadState(System.err);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.err.print(">>>> ClientHandlerTest.tearDown()");
+        RxContexts.DEFAULT_CORRELATOR.dumpThreadState(System.err);
+    }
 
     @Test
     public void testRequest() throws Exception {

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ClientHandlerTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ClientHandlerTest.java
@@ -42,13 +42,13 @@ public class ClientHandlerTest {
 
     @Test
     public void testRequest() throws Exception {
-        HandlerHolder holder = new HandlerHolder(false);
+        HandlerHolder holder = new HandlerHolder(false, "ClientHandlerTest.testRequest");
         sendRequestAndAssert(holder);
     }
 
     @Test
     public void testResponse() throws Exception {
-        HandlerHolder holder = new HandlerHolder(false);
+        HandlerHolder holder = new HandlerHolder(false, "ClientHandlerTest.testResponse");
         sendRequestAndAssert(holder);
 
 

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
@@ -65,8 +65,6 @@ public class ContextPropagationTest {
 
     private HttpServer<ByteBuf, ByteBuf> mockServer;
     private static final String REQUEST_ID_HEADER_NAME = "request_id";
-    private static final String REQUEST_ID = "id1";
-    private static final String REQUEST_ID_2 = "id2";
     private static final String CTX_1_NAME = "ctx1";
     private static final String CTX_1_VAL = "ctx1_val";
     private static final String CTX_2_NAME = "ctx2";
@@ -127,7 +125,8 @@ public class ContextPropagationTest {
         HttpClient<ByteBuf, ByteBuf> testClient = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder("localhost", server.getServerPort())
                                                          .enableWireLogging(LogLevel.DEBUG).build();
 
-        sendTestRequest(testClient, REQUEST_ID);
+        String reqId = "testE2E";
+        sendTestRequest(testClient, reqId);
     }
 
     @Test(expected = MockBackendRequestFailedException.class)
@@ -148,7 +147,8 @@ public class ContextPropagationTest {
 
         HttpClient<ByteBuf, ByteBuf> testClient = RxNetty.createHttpClient("localhost", server.getServerPort());
 
-        sendTestRequest(testClient, REQUEST_ID);
+        String reqId = "testWithThreadSwitchNegative";
+        sendTestRequest(testClient, reqId);
     }
 
     @Test
@@ -173,7 +173,8 @@ public class ContextPropagationTest {
 
         HttpClient<ByteBuf, ByteBuf> testClient = RxNetty.createHttpClient("localhost", server.getServerPort());
 
-        sendTestRequest(testClient, REQUEST_ID);
+        String reqId = "testWithThreadSwitch";
+        sendTestRequest(testClient, reqId);
     }
 
     @Test
@@ -187,11 +188,12 @@ public class ContextPropagationTest {
         container.addContext(CTX_1_NAME, CTX_1_VAL);
         container.addContext(CTX_2_NAME, CTX_2_VAL, new TestContextSerializer());
 
-        RxContexts.DEFAULT_CORRELATOR.onNewServerRequest(REQUEST_ID, container);
+        String reqId = "testWithPooledConnections";
+        RxContexts.DEFAULT_CORRELATOR.onNewServerRequest(reqId, container);
 
-        invokeMockServer(testClient, REQUEST_ID, false);
+        invokeMockServer(testClient, reqId, false);
 
-        invokeMockServer(testClient, REQUEST_ID, true);
+        invokeMockServer(testClient, reqId, true);
     }
 
     @Test(expected = MockBackendRequestFailedException.class)
@@ -206,15 +208,16 @@ public class ContextPropagationTest {
         container.addContext(CTX_1_NAME, CTX_1_VAL);
         container.addContext(CTX_2_NAME, CTX_2_VAL, new TestContextSerializer());
 
-        RxContexts.DEFAULT_CORRELATOR.onNewServerRequest(REQUEST_ID, container);
+        String reqId = "testNoStateLeakOnThreadReuse";
+        RxContexts.DEFAULT_CORRELATOR.onNewServerRequest(reqId, container);
 
         try {
-            invokeMockServer(testClient, REQUEST_ID, true);
+            invokeMockServer(testClient, reqId, true);
         } catch (MockBackendRequestFailedException e) {
             throw new AssertionError("First request to mock backend failed. Error: " + e.getMessage());
         }
 
-        invokeMockServer(testClient, REQUEST_ID_2, false);
+        invokeMockServer(testClient, reqId, false);
     }
 
     private HttpServerBuilder<ByteBuf, ByteBuf> newTestServerBuilder(final Func1<HttpClient<ByteBuf, ByteBuf>,

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/HandlerHolder.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/HandlerHolder.java
@@ -43,10 +43,10 @@ class HandlerHolder {
     final NoOpChannelHandlerContext ctx = new NoOpChannelHandlerContext();
     final RequestCorrelator correlator;
 
-    HandlerHolder(boolean server) {
+    HandlerHolder(boolean server, final String reqId) {
         String headerName = "requestId";
         correlator = new ThreadLocalRequestCorrelator();
-        requestId = "baaaa";
+        requestId = reqId;
         RequestIdGenerator generator = new RequestIdGenerator() {
             @Override
             public String newRequestId(ContextKeySupplier keySupplier, AttributeMap channelAttributeMap) {

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ServerHandlerTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ServerHandlerTest.java
@@ -40,13 +40,13 @@ public class ServerHandlerTest {
 
     @Test
     public void testRequest() throws Exception {
-        HandlerHolder holder = new HandlerHolder(true);
+        HandlerHolder holder = new HandlerHolder(true, "ServerHandlerTest.testRequest");
         readRequestAndAssert(holder);
     }
 
     @Test
     public void testResponse() throws Exception {
-        HandlerHolder holder = new HandlerHolder(true);
+        HandlerHolder holder = new HandlerHolder(true, "ServerHandlerTest.testResponse");
         readRequestAndAssert(holder);
 
 

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ServerHandlerTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ServerHandlerTest.java
@@ -27,7 +27,10 @@ import io.reactivex.netty.contexts.ContextAttributeStorageHelper;
 import io.reactivex.netty.contexts.ContextKeySupplier;
 import io.reactivex.netty.contexts.ContextsContainer;
 import io.reactivex.netty.contexts.ContextsContainerImpl;
+import io.reactivex.netty.contexts.RxContexts;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -37,16 +40,34 @@ public class ServerHandlerTest {
 
     public static final String CTX_1_NAME = "ctx1";
     public static final String CTX_1_VAL = "doom";
+    private String requestId;
+
+    @Before
+    public void setUp() throws Exception {
+        System.err.print(">>>> ServerHandlerTest.setUp()");
+        RxContexts.DEFAULT_CORRELATOR.dumpThreadState(System.err);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (null != requestId) {
+            RxContexts.DEFAULT_CORRELATOR.onServerProcessingEnd(requestId);
+        }
+        System.err.print(">>>> ServerHandlerTest.tearDown()");
+        RxContexts.DEFAULT_CORRELATOR.dumpThreadState(System.err);
+    }
 
     @Test
     public void testRequest() throws Exception {
-        HandlerHolder holder = new HandlerHolder(true, "ServerHandlerTest.testRequest");
+        requestId = "ServerHandlerTest.testRequest";
+        HandlerHolder holder = new HandlerHolder(true, requestId);
         readRequestAndAssert(holder);
     }
 
     @Test
     public void testResponse() throws Exception {
-        HandlerHolder holder = new HandlerHolder(true, "ServerHandlerTest.testResponse");
+        requestId = "ServerHandlerTest.testResponse";
+        HandlerHolder holder = new HandlerHolder(true, requestId);
         readRequestAndAssert(holder);
 
 

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
@@ -30,7 +30,15 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class SingleNioLoopProvider implements RxEventLoopProvider {
 
-    private final SharedNioEventLoopGroup eventLoop = new SharedNioEventLoopGroup();
+    private final SharedNioEventLoopGroup eventLoop;
+
+    public SingleNioLoopProvider() {
+        eventLoop = new SharedNioEventLoopGroup();
+    }
+
+    public SingleNioLoopProvider(int threadCount) {
+        eventLoop = new SharedNioEventLoopGroup(threadCount);
+    }
 
     @Override
     public EventLoopGroup globalClientEventLoop() {
@@ -44,12 +52,16 @@ public class SingleNioLoopProvider implements RxEventLoopProvider {
         return eventLoop;
     }
 
-    private static class SharedNioEventLoopGroup extends NioEventLoopGroup {
+    public static class SharedNioEventLoopGroup extends NioEventLoopGroup {
 
         private final AtomicInteger refCount = new AtomicInteger();
 
         public SharedNioEventLoopGroup() {
             super(0, new RxDefaultThreadFactory("rx-selector"));
+        }
+
+        public SharedNioEventLoopGroup(int threadCount) {
+            super(threadCount, new RxDefaultThreadFactory("rx-selector"));
         }
 
         @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/client/RxClient.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/RxClient.java
@@ -52,7 +52,7 @@ public interface RxClient<I, O> extends PoolInsightProvider {
     /**
      * A configuration to be used for this client.
      */
-    class ClientConfig {
+    class ClientConfig implements Cloneable {
 
         public static final long NO_TIMEOUT = -1;
 
@@ -60,6 +60,10 @@ public interface RxClient<I, O> extends PoolInsightProvider {
 
         protected ClientConfig() {
             // Only the builder can create this instance, so that we can change the constructor signature at will.
+        }
+
+        protected ClientConfig(ClientConfig config) {
+            readTimeoutInMillis = config.readTimeoutInMillis;
         }
 
         /**
@@ -77,6 +81,11 @@ public interface RxClient<I, O> extends PoolInsightProvider {
 
         public boolean isReadTimeoutSet() {
             return NO_TIMEOUT != readTimeoutInMillis;
+        }
+
+        @Override
+        public ClientConfig clone() throws CloneNotSupportedException {
+            return (ClientConfig) super.clone();
         }
 
         @SuppressWarnings("rawtypes")
@@ -182,7 +191,7 @@ public interface RxClient<I, O> extends PoolInsightProvider {
         }
 
         @Override
-        public java.lang.String toString() {
+        public String toString() {
             return "ServerInfo{" +
                 "host='" + host + '\'' +
                 ", port=" + port +

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/DefaultRedirectHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/DefaultRedirectHandler.java
@@ -54,7 +54,6 @@ public class DefaultRedirectHandler<I, O> implements RedirectOperator.RedirectHa
     @Override
     public Observable<HttpClientResponse<O>> doRedirect(RedirectionContext context,
                                                         HttpClientRequest<I> originalRequest,
-                                                        HttpClientResponse<O> redirectedResponse,
                                                         HttpClient.HttpClientConfig config) {
         URI nextRedirect = context.getNextRedirect(); // added by validate()
 
@@ -64,7 +63,7 @@ public class DefaultRedirectHandler<I, O> implements RedirectOperator.RedirectHa
         }
 
         HttpClientRequest<I> redirectRequest = createRedirectRequest(originalRequest, nextRedirect,
-                                                                     redirectedResponse.getStatus().code());
+                                                                     context.getLastRedirectStatus().code());
 
         return redirect(redirectRequest, config);
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/DefaultRedirectHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/DefaultRedirectHandler.java
@@ -18,7 +18,6 @@ package io.reactivex.netty.protocol.http.client;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
-import io.reactivex.netty.client.RxClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -46,24 +45,17 @@ public class DefaultRedirectHandler<I, O> implements RedirectOperator.RedirectHa
 
     private final int maxHops;
     private final HttpClient<I, O> client;
-    private final RxClient.ClientConfig config;
 
     public DefaultRedirectHandler(int maxHops, HttpClient<I, O> client) {
         this.maxHops = maxHops;
         this.client = client;
-        config = null;
-    }
-
-    public DefaultRedirectHandler(int maxHops, HttpClient<I, O> client, RxClient.ClientConfig config) {
-        this.maxHops = maxHops;
-        this.client = client;
-        this.config = config;
     }
 
     @Override
     public Observable<HttpClientResponse<O>> doRedirect(RedirectionContext context,
                                                         HttpClientRequest<I> originalRequest,
-                                                        HttpClientResponse<O> redirectedResponse) {
+                                                        HttpClientResponse<O> redirectedResponse,
+                                                        HttpClient.HttpClientConfig config) {
         URI nextRedirect = context.getNextRedirect(); // added by validate()
 
         if (logger.isDebugEnabled()) {
@@ -74,10 +66,11 @@ public class DefaultRedirectHandler<I, O> implements RedirectOperator.RedirectHa
         HttpClientRequest<I> redirectRequest = createRedirectRequest(originalRequest, nextRedirect,
                                                                      redirectedResponse.getStatus().code());
 
-        return redirect(redirectRequest);
+        return redirect(redirectRequest, config);
     }
 
-    protected Observable<HttpClientResponse<O>> redirect(HttpClientRequest<I> redirectRequest) {
+    protected Observable<HttpClientResponse<O>> redirect(HttpClientRequest<I> redirectRequest,
+                                                         HttpClient.HttpClientConfig config) {
         return client.submit(redirectRequest, config);
     }
 
@@ -137,10 +130,10 @@ public class DefaultRedirectHandler<I, O> implements RedirectOperator.RedirectHa
         }
     }
 
-    protected <I> HttpClientRequest<I> createRedirectRequest(HttpClientRequest<I> original, URI redirectLocation,
-                                                             int redirectStatus) {
+    protected HttpClientRequest<I> createRedirectRequest(HttpClientRequest<I> original, URI redirectLocation,
+                                                         int redirectStatus) {
         HttpRequest nettyRequest = original.getNettyRequest();
-        nettyRequest.setUri(redirectLocation.toString() /*Uses the string with which this was created*/);
+        nettyRequest.setUri(getNettyRequestUri(redirectLocation));
 
         if (redirectStatus == 303) {
             // according to HTTP spec, 303 mandates the change of request type to GET
@@ -155,5 +148,19 @@ public class DefaultRedirectHandler<I, O> implements RedirectOperator.RedirectHa
             newRequest.rawContentFactory = original.rawContentFactory;
         }
         return newRequest;
+    }
+
+    private static String getNettyRequestUri(URI uri) {
+        StringBuilder sb = new StringBuilder();
+        if (uri.getRawPath() != null) {
+            sb.append(uri.getRawPath());
+        }
+        if (uri.getRawQuery() != null) {
+            sb.append('?').append(uri.getRawQuery());
+        }
+        if (uri.getRawFragment() != null) {
+            sb.append('#').append(uri.getRawFragment());
+        }
+        return sb.toString();
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClient.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClient.java
@@ -37,11 +37,16 @@ public interface HttpClient<I, O> extends RxClient<HttpClientRequest<I>, HttpCli
         public enum RedirectsHandling {Enable, Disable, Undefined}
 
         private String userAgent = "RxNetty Client";
-        
+
         private RedirectsHandling followRedirect = RedirectsHandling.Undefined;
+        private int maxRedirects = RedirectOperator.DEFAULT_MAX_HOPS;
 
         protected HttpClientConfig() {
             // Only the builder can create this instance, so that we can change the constructor signature at will.
+        }
+
+        protected HttpClientConfig(ClientConfig config) {
+            super(config);
         }
 
         public String getUserAgent() {
@@ -50,6 +55,15 @@ public interface HttpClient<I, O> extends RxClient<HttpClientRequest<I>, HttpCli
 
         public RedirectsHandling getFollowRedirect() {
             return followRedirect;
+        }
+
+        public int getMaxRedirects() {
+            return maxRedirects;
+        }
+
+        @Override
+        public HttpClientConfig clone() throws CloneNotSupportedException {
+            return (HttpClientConfig) super.clone();
         }
 
         public static class Builder extends AbstractBuilder<Builder, HttpClientConfig> {
@@ -72,10 +86,27 @@ public interface HttpClient<I, O> extends RxClient<HttpClientRequest<I>, HttpCli
                 return returnBuilder();
             }
 
+            public Builder followRedirect(int maxRedirects) {
+                setFollowRedirect(true);
+                config.maxRedirects = maxRedirects;
+                return returnBuilder();
+            }
+
             public static HttpClientConfig newDefaultConfig() {
                 return new Builder().build();
             }
 
+            public static Builder fromDefaultConfig() {
+                return from(newDefaultConfig());
+            }
+
+            public static Builder from(HttpClientConfig source) {
+                try {
+                    return new Builder(null == source ? newDefaultConfig() : source.clone());
+                } catch (CloneNotSupportedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -61,30 +61,17 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpClientRequest<I>, Htt
                                                      ? HttpClientConfig.Builder.newDefaultConfig() : clientConfig);
     }
     
-    protected boolean shouldFollowRedirectForRequest(ClientConfig config, HttpClientRequest<I> request) {
-        HttpClientConfig.RedirectsHandling redirectsHandling = HttpClientConfig.RedirectsHandling.Undefined;
-
-        if (config instanceof HttpClientConfig) {
-            redirectsHandling = ((HttpClientConfig) config).getFollowRedirect();
-        }
-
-        switch (redirectsHandling) {
-            case Enable:
-                return true;
-            case Disable:
-                return false;
-            case Undefined:
-                return request.getMethod() == HttpMethod.HEAD || request.getMethod() == HttpMethod.GET;
-            default:
-                return false;
-        }
-    }
-
     protected Observable<HttpClientResponse<O>> submit(final HttpClientRequest<I> request,
                                                        final Observable<ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>>> connectionObservable,
                                                        final ClientConfig config) {
 
-        boolean followRedirect = shouldFollowRedirectForRequest(clientConfig, request);
+        HttpClientConfig httpClientConfig;
+        if (config instanceof HttpClientConfig) {
+            httpClientConfig = (HttpClientConfig) config;
+        } else {
+            httpClientConfig = new HttpClientConfig(config);
+        }
+        boolean followRedirect = shouldFollowRedirectForRequest(httpClientConfig, request);
 
         final HttpClientRequest<I> _request;
 
@@ -96,13 +83,12 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpClientRequest<I>, Htt
             _request = request;
         }
 
-        enrichRequest(_request, config);
+        enrichRequest(_request, httpClientConfig);
         Observable<HttpClientResponse<O>> toReturn =
                 connectionObservable.lift(new RequestProcessingOperator<I, O>(_request));
 
         if (followRedirect) {
-            toReturn = toReturn.lift(new RedirectOperator<I, O>(_request, RedirectOperator.DEFAULT_MAX_HOPS, this,
-                                                                config));
+            toReturn = toReturn.lift(new RedirectOperator<I, O>(_request, this, httpClientConfig));
         }
         return toReturn;
     }
@@ -114,6 +100,21 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpClientRequest<I>, Htt
         PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> configurator =
                 new PipelineConfiguratorComposite<HttpClientResponse<O>, HttpClientRequest<I>>(pipelineConfigurator, new ClientRequiredConfigurator<I, O>());
         return super.adaptPipelineConfigurator(configurator, clientConfig);
+    }
+
+    protected boolean shouldFollowRedirectForRequest(HttpClientConfig config, HttpClientRequest<I> request) {
+        HttpClientConfig.RedirectsHandling redirectsHandling = config.getFollowRedirect();
+
+        switch (redirectsHandling) {
+            case Enable:
+                return true;
+            case Disable:
+                return false;
+            case Undefined:
+                return request.getMethod() == HttpMethod.HEAD || request.getMethod() == HttpMethod.GET;
+            default:
+                return false;
+        }
     }
 
     /*visible for testing*/ ConnectionPool<HttpClientResponse<O>, HttpClientRequest<I>> getConnectionPool() {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -68,7 +68,7 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
                         cs.add(connection.getInput()
                                          .doOnNext(new Action1<HttpClientResponse<O>>() {
                                              @Override
-                                             public void call(HttpClientResponse<O> response) {
+                                             public void call(final HttpClientResponse<O> response) {
                                                  cs.add(response.getContent().subscribe(new Observer<O>() {
                                                      @Override
                                                      public void onCompleted() {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
@@ -74,8 +74,10 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
 
         writeHeadersIfNotWritten();
 
-        if (headers.isTransferEncodingChunked()) {
-            writeOnChannel(new DefaultLastHttpContent());
+        if (headers.isTransferEncodingChunked() || headers.isKeepAlive()) {
+            writeOnChannel(new DefaultLastHttpContent()); // This indicates end of response for netty. If this is not
+            // sent for keep-alive connections, netty's HTTP codec will not know that the response has ended and hence
+            // will ignore the subsequent HTTP header writes. See issue: https://github.com/Netflix/RxNetty/issues/130
         }
         return flush();
     }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpRedirectTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpRedirectTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.protocol.http.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.logging.LogLevel;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.server.HttpServerBuilder;
+import io.reactivex.netty.server.RxServerThreadFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import rx.Observable;
+import rx.functions.Action0;
+import rx.functions.Func1;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Nitesh Kant
+ */
+public class HttpRedirectTest {
+
+    private static HttpServer<ByteBuf, ByteBuf> server;
+
+    private static int port;
+
+    @BeforeClass
+    public static void init() {
+        server = new HttpServerBuilder<ByteBuf, ByteBuf>(port, new RequestProcessor())
+                .eventLoop(new NioEventLoopGroup(10, new RxServerThreadFactory()))
+                .enableWireLogging(LogLevel.DEBUG).build().start();
+        port = server.getServerPort(); // Using ephemeral ports
+        System.out.println("Mock server using ephemeral port; " + port);
+    }
+
+    @AfterClass
+    public static void shutDown() throws InterruptedException {
+        server.shutdown();
+    }
+
+    @Test(expected = HttpRedirectException.class)
+    public void testTooManyRedirect() throws Throwable {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null);
+        HttpClient.HttpClientConfig config = builder.readTimeout(20000, TimeUnit.MILLISECONDS)
+                                                    .followRedirect(2).build();
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config).enableWireLogging(LogLevel.ERROR)
+                .build();
+        String content = invokeBlockingCall(client, HttpClientRequest.createGet("test/redirectLimited?redirectsRequested=6&port=" + port));
+        assertEquals("Hello world", content);
+    }
+
+    @Test(expected = HttpRedirectException.class)
+    public void testRedirectLoop() throws Throwable {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null);
+        HttpClient.HttpClientConfig config = builder.readTimeout(20000, TimeUnit.MILLISECONDS)
+                                                    .followRedirect(2).build();
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config).enableWireLogging(LogLevel.ERROR)
+                .build();
+        String content = invokeBlockingCall(client, HttpClientRequest.createGet("test/redirectLoop?redirectsRequested=6&port=" + port));
+        assertEquals("Hello world", content);
+    }
+
+    @Test
+    public void testRedirectNoConnPool() throws Throwable {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null);
+        HttpClient.HttpClientConfig config = builder.readTimeout(20000, TimeUnit.MILLISECONDS)
+                                                    .build();
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config).enableWireLogging(LogLevel.ERROR)
+                .build();
+        String content = invokeBlockingCall(client, HttpClientRequest.createGet("test/redirect?port=" + port));
+        assertEquals("Hello world", content);
+    }
+
+    @Test
+    public void testRedirectWithConnPool() throws Throwable {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null);
+        HttpClient.HttpClientConfig config = builder.readTimeout(20000, TimeUnit.MILLISECONDS)
+                                                    .build();
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config).enableWireLogging(LogLevel.ERROR).withMaxConnections(10).build();
+        String content = invokeBlockingCall(client, HttpClientRequest.createGet("test/redirect?port=" + port));
+        assertEquals("Hello world", content);
+    }
+
+    @Test
+    public void testNoRedirect() {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null).setFollowRedirect(false);
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.createGet("test/redirect?port=" + port);
+        HttpClient.HttpClientConfig config = builder.readTimeout(20000, TimeUnit.MILLISECONDS)
+                                                    .build();
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config)
+                .build();
+        HttpClientResponse<ByteBuf> response = client.submit(request).toBlockingObservable().single();
+        assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), response.getStatus().code());
+    }
+
+
+    @Test
+    public void testRedirectPost() throws Throwable {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null);
+        HttpClient.HttpClientConfig config = builder.setFollowRedirect(true).build();
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.createPost("test/redirectPost?port=" + port)
+                                                              .withContent("Hello world");
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config)
+                .build();
+        String content = invokeBlockingCall(client, request);
+        assertEquals("Hello world", content);
+    }
+
+    @Test
+    public void testNoRedirectPost() {
+        HttpClient.HttpClientConfig.Builder builder = new HttpClient.HttpClientConfig.Builder(null);
+        HttpClient.HttpClientConfig config = builder.build();
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.createPost("test/redirectPost?port=" + port)
+                                                              .withContent("Hello world");
+        HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
+                .config(config)
+                .build();
+        HttpClientResponse<ByteBuf> response = client.submit(request).toBlockingObservable().single();
+        assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), response.getStatus().code());
+    }
+
+    private static String invokeBlockingCall(HttpClient<ByteBuf, ByteBuf> client, HttpClientRequest<ByteBuf> request)
+            throws Throwable {
+        Observable<HttpClientResponse<ByteBuf>> response = client.submit(request);
+        try {
+            return response.flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<String>>() {
+                @Override
+                public Observable<String> call(HttpClientResponse<ByteBuf> response) {
+                    return response.getContent().map(new Func1<ByteBuf, String>() {
+                        @Override
+                        public String call(ByteBuf byteBuf) {
+                            return byteBuf.toString(Charset.defaultCharset());
+                        }
+                    });
+                }
+            }).doOnTerminate(new Action0() {
+                @Override
+                public void call() {
+                    System.out.println("HttpRedirectTest.call");
+                }
+            }).toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof HttpRedirectException) {
+                throw e.getCause();
+            }
+            throw e;
+        }
+    }
+}

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpRedirectTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpRedirectTest.java
@@ -26,7 +26,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import rx.Observable;
-import rx.functions.Action0;
 import rx.functions.Func1;
 
 import java.nio.charset.Charset;
@@ -158,11 +157,6 @@ public class HttpRedirectTest {
                             return byteBuf.toString(Charset.defaultCharset());
                         }
                     });
-                }
-            }).doOnTerminate(new Action0() {
-                @Override
-                public void call() {
-                    System.out.println("HttpRedirectTest.call");
                 }
             }).toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
         } catch (ExecutionException e) {

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RedirectOperatorTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RedirectOperatorTest.java
@@ -77,7 +77,8 @@ public class RedirectOperatorTest {
         @Override
         public Observable<HttpClientResponse<O>> doRedirect(RedirectionContext context,
                                                             HttpClientRequest<I> originalRequest,
-                                                            HttpClientResponse<O> redirectedResponse) {
+                                                            HttpClientResponse<O> redirectedResponse,
+                                                            HttpClient.HttpClientConfig config) {
             redirectsRequested.incrementAndGet();
             return Observable.just(response);
         }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RedirectOperatorTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RedirectOperatorTest.java
@@ -77,7 +77,6 @@ public class RedirectOperatorTest {
         @Override
         public Observable<HttpClientResponse<O>> doRedirect(RedirectionContext context,
                                                             HttpClientRequest<I> originalRequest,
-                                                            HttpClientResponse<O> redirectedResponse,
                                                             HttpClient.HttpClientConfig config) {
             redirectsRequested.incrementAndGet();
             return Observable.just(response);
@@ -147,7 +146,7 @@ public class RedirectOperatorTest {
         }
     }
 
-    private class Setup {
+    private static class Setup {
 
         private TestableRedirectHandler<ByteBuf, ByteBuf> handler;
         private UnsafeRedirectSubscriber subscriber;


### PR DESCRIPTION
#129: The issue here was that as part of sending (onNext()) the first response (redirect response), we were submitting the redirect request.

If the connection is reused (for connection pool), it resets the content subject (reacting to ConnectionReuseEvent) in ClientRequestResponseConverter.
The ClientRequestResponseConverter was referring to the "current content subject" while invoking an onComplete(), which is invoked when the content on the first response is over.
Now, in the above situation, since the content subject is changed between processing headers and processing content (in the same method), the onComplete() is called on the content subject of the second response and not the first as it is expected.

The fix is two folds:

1) Move the redirect call in RedirectOperator to onComplete()/onError() of the first observer.
2) In ClientRequestResponseConverter use the subject that was present when the channelRead() was received and do not refer to the instance level state of the subject.

From the perspective of this bug, 1) is sufficient but 2) is the correct way of handling the shared state.
#130: The LastHttpContent was not sent for Keep-alive requests with no chunked encoding.
#131: Fixed the redirect loop and infinite redirects detection in the RedirectOperator.
