### PR TITLE
Minor client changes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # RxNetty Releases #
 
+
+### Version 0.3.6 ###
+
+[Milestone](https://github.com/Netflix/RxNetty/issues?milestone=2&state=closed)
+
+
+Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.rxnetty%22%20AND%20v%3A%220.3.6%22)
+
 ### Version 0.3.5 ###
 
 [Milestone](https://github.com/Netflix/RxNetty/issues?milestone=1&page=1&state=closed)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 * [Issue 117] (https://github.com/Netflix/RxNetty/issues/117) RxClientImpl mutates netty's bootstrap per connection
 * [Issue 119] (https://github.com/Netflix/RxNetty/issues/119) "Transfer-encoding: chunked" not set for HTTP POST request.
 
+Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.rxnetty%22%20AND%20v%3A%220.3.5%22)
+
 ### Version 0.3.4 ###
 
 Skipped release due to manual tag creation.

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ public class RxNettyExample {
         client.submit(HttpClientRequest.createGet("/"))
                 .flatMap(response -> response.getContent())
                 .map(data -> "Client => " + data.toString(Charset.defaultCharset()))
-                .toBlockingObservable().forEach(System.out::println);
+                .toBlocking().forEach(System.out::println);
 
         client.submit(HttpClientRequest.createGet("/error"))
                 .flatMap(response -> response.getContent())
                 .map(data -> "Client => " + data.toString(Charset.defaultCharset()))
-                .toBlockingObservable().forEach(System.out::println);
+                .toBlocking().forEach(System.out::println);
 
         client.submit(HttpClientRequest.createGet("/data"))
                 .flatMap(response -> response.getContent())
                 .map(data -> "Client => " + data.toString(Charset.defaultCharset()))
-                .toBlockingObservable().forEach(System.out::println);
+                .toBlocking().forEach(System.out::println);
 
         server.shutdown();
     }

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
@@ -109,7 +109,7 @@ public class ContextPropagationTest {
     @After
     public void tearDown() throws Exception {
         mockServer.shutdown();
-        mockServer.waitTillShutdown();
+        mockServer.waitTillShutdown(1, TimeUnit.MINUTES);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class ContextPropagationTest {
                                 RxContexts.DEFAULT_CORRELATOR.makeClosure(new Callable<HttpClientResponse<ByteBuf>>() {
                                     @Override
                                     public HttpClientResponse<ByteBuf> call() throws Exception {
-                                        return client.submit(HttpClientRequest.createGet("/")).toBlockingObservable()
+                                        return client.submit(HttpClientRequest.createGet("/")).toBlocking()
                                                      .last();
                                     }
                                 });

--- a/rx-netty-remote-observable/src/test/java/io/reactivex/netty/MetricsTest.java
+++ b/rx-netty-remote-observable/src/test/java/io/reactivex/netty/MetricsTest.java
@@ -16,10 +16,8 @@
 package io.reactivex.netty;
 
 import io.reactivex.netty.codec.Codecs;
-
 import org.junit.Assert;
 import org.junit.Test;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
@@ -46,7 +44,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> rc = RemoteObservable.connect(cc);
 		// assert
-		MathObservable.sumInteger(rc.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(rc.getObservable()).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -76,7 +74,7 @@ public class MetricsTest {
 		
 		Observable<Integer> oc = RemoteObservable.connect(cc).getObservable();
 		// assert
-		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -106,7 +104,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro1 = RemoteObservable.connect(cc);
 		// assert
-		MathObservable.sumInteger(ro1.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(ro1.getObservable()).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -115,7 +113,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro2 = RemoteObservable.connect(cc);
 		// assert
-		MathObservable.sumInteger(ro2.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(ro2.getObservable()).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -168,7 +166,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro1 = RemoteObservable.connect(cc);
 		try{
-			MathObservable.sumInteger(ro1.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+			MathObservable.sumInteger(ro1.getObservable()).toBlocking().forEach(new Action1<Integer>(){
 				@Override
 				public void call(Integer t1) {
 					Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -180,7 +178,7 @@ public class MetricsTest {
 		
 		RemoteRxConnection<Integer> ro2 = RemoteObservable.connect(cc);
 		try{
-			MathObservable.sumInteger(ro2.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+			MathObservable.sumInteger(ro2.getObservable()).toBlocking().forEach(new Action1<Integer>(){
 				@Override
 				public void call(Integer t1) {
 					Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100
@@ -238,7 +236,7 @@ public class MetricsTest {
 		
 		// assert
 		try{
-			MathObservable.sumInteger(rc.getObservable()).toBlockingObservable().forEach(new Action1<Integer>(){
+			MathObservable.sumInteger(rc.getObservable()).toBlocking().forEach(new Action1<Integer>(){
 				@Override
 				public void call(Integer t1) {
 					Assert.assertEquals(500500, t1.intValue()); // sum of number 0-100

--- a/rx-netty-remote-observable/src/test/java/io/reactivex/netty/RemoteObservableTest.java
+++ b/rx-netty-remote-observable/src/test/java/io/reactivex/netty/RemoteObservableTest.java
@@ -19,13 +19,8 @@ import io.reactivex.netty.codec.Codecs;
 import io.reactivex.netty.codec.Decoder;
 import io.reactivex.netty.filter.ServerSideFilters;
 import io.reactivex.netty.slotting.SlottingStrategies;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Test;
-
 import rx.Notification;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
@@ -39,6 +34,9 @@ import rx.observables.MathObservable;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 import rx.subjects.ReplaySubject;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +55,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		// assert
-		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -83,7 +81,7 @@ public class RemoteObservableTest {
 					.build())
 				.getObservable();
 		// assert
-        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -105,7 +103,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", wrongPort, Codecs.integer());
 		// assert
-        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -146,7 +144,7 @@ public class RemoteObservableTest {
 					.build())
 				.getObservable();
 		try{
-			oc.toBlockingObservable().first();
+			oc.toBlocking().first();
 		}catch(Throwable t){
 			notSuppressed.setValue(true);
 		}
@@ -194,7 +192,7 @@ public class RemoteObservableTest {
 					.build())
 			.getObservable();
 		try{
-			oc.toBlockingObservable().first();
+			oc.toBlocking().first();
 		}catch(Throwable t){
 			notSuppressed.setValue(true);
 		}
@@ -339,7 +337,7 @@ public class RemoteObservableTest {
 			.getObservable();
 
 		// assert
-        MathObservable.sumInteger(ro1).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(ro1).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -350,7 +348,7 @@ public class RemoteObservableTest {
 			public String call(String t1, String t2) {
 				return t1+t2; // concat string
 			}
-		}).toBlockingObservable().forEach(new Action1<String>(){
+		}).toBlocking().forEach(new Action1<String>(){
 			@Override
 			public void call(String t1) {
 				Assert.assertEquals("abcde", t1);
@@ -385,7 +383,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", port, Codecs.integer());
 		// assert
-        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(20200, t1.intValue()); // sum of number 0-200
@@ -415,7 +413,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		// assert
-        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -454,7 +452,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		// assert
-        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(45150, t1.intValue()); // sum of number 0-200
@@ -496,7 +494,7 @@ public class RemoteObservableTest {
 		subject.onCompleted();
 		
 		// assert
-        MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+        MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(80200, t1.intValue()); // sum of number 0-200
@@ -528,7 +526,7 @@ public class RemoteObservableTest {
 		// merge results
 		Observable<Integer> merged = Observable.merge(oc1,oc2);
 		// assert
-		MathObservable.sumInteger(merged).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(merged).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -581,7 +579,7 @@ public class RemoteObservableTest {
 			.getObservable();
 
 		
-		MathObservable.sumInteger(oc2).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc2).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -603,7 +601,7 @@ public class RemoteObservableTest {
 		RemoteObservable.serve(serverPort, os, Codecs.integer())
 			.start();
 		Observable<Integer> oc = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
-		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(5050, t1.intValue()); // sum of number 0-100
@@ -723,7 +721,7 @@ public class RemoteObservableTest {
 			.getObservable();
 
 		// assert
-		MathObservable.sumInteger(oc).toBlockingObservable().forEach(new Action1<Integer>(){
+		MathObservable.sumInteger(oc).toBlocking().forEach(new Action1<Integer>(){
 			@Override
 			public void call(Integer t1) {
 				Assert.assertEquals(2550, t1.intValue()); // sum of number 0-100
@@ -753,7 +751,7 @@ public class RemoteObservableTest {
 		// connect
 		Observable<Integer> ro = RemoteObservable.connect("localhost", serverPort, Codecs.integer());
 		final MutableReference<Boolean> completed = new MutableReference<Boolean>();
-		ro.materialize().toBlockingObservable().forEach(new Action1<Notification<Integer>>(){
+		ro.materialize().toBlocking().forEach(new Action1<Notification<Integer>>(){
 			@Override
 			public void call(Notification<Integer> notification) {
 				if (notification.isOnCompleted()){

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/HttpClientRequestResponse.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/HttpClientRequestResponse.groovy
@@ -15,13 +15,12 @@
  */
 package io.reactivex.netty.examples
 
-
-import java.nio.charset.Charset;
-
 import io.netty.buffer.ByteBuf
 import io.reactivex.netty.RxNetty
 import io.reactivex.netty.protocol.http.client.HttpClientRequest
 import io.reactivex.netty.protocol.http.client.HttpClientResponse
+
+import java.nio.charset.Charset
 
 public class HttpClientRequestResponse {
 
@@ -34,6 +33,6 @@ public class HttpClientRequestResponse {
                     return response.getContent().map({
                         println(it.toString(Charset.defaultCharset()))
                     });
-                }).toBlockingObservable().last();
+                }).toBlocking().last();
     }
 }

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/HttpSseClient.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/HttpSseClient.groovy
@@ -35,7 +35,7 @@ class HttpSseClient {
                     return response.content();
                 })
                 .take(10)
-                .toBlockingObservable().forEach({ println(it)});
+                .toBlocking().forEach({ println(it)});
 */
     }
 }

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEchoClient.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEchoClient.groovy
@@ -76,7 +76,7 @@ class TcpEchoClient {
                 .doOnCompleted({
                      println("COMPLETED!")   
                 })
-                .toBlockingObservable().forEach({ String o ->
+                .toBlocking().forEach({ String o ->
                     println("onNext: " + o)
                 });
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEventStreamClientFast.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEventStreamClientFast.groovy
@@ -31,7 +31,7 @@ class TcpEventStreamClientFast {
                     return connection.getInput().map({ String msg ->
                         return msg.trim()
                     });
-                }).toBlockingObservable().forEach({ String o ->
+                }).toBlocking().forEach({ String o ->
                     println("onNext event => " + o)
                 });
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEventStreamClientSlow.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpEventStreamClientSlow.groovy
@@ -50,7 +50,7 @@ class TcpEventStreamClientSlow {
                         Thread.sleep(1000)
                         return msg.trim()
                     });
-                }).toBlockingObservable().forEach({ String o ->
+                }).toBlocking().forEach({ String o ->
                     println("onNext event => " + o + "\n")
                 });
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpIntervalClientTakeN.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpIntervalClientTakeN.groovy
@@ -50,7 +50,7 @@ class TcpIntervalClientTakeN {
                     return Observable.concat(subscribeWrite, data);
                 })
                 .take(3)
-                .toBlockingObservable().forEach({ String o ->
+                .toBlocking().forEach({ String o ->
                     println("onNext: " + o) }
                 );
 

--- a/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpIntervalServer.groovy
+++ b/rx-netty/src/examples/groovy/io/reactivex/netty/examples/TcpIntervalServer.groovy
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit
 class TcpIntervalServer {
 
     public static void main(String[] args) {
-        createServer(8181).toBlockingObservable().last();
+        createServer(8181).toBlocking().last();
     }
 
     public static Observable<String> createServer(final int port) {

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/HelloHttpClient.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/HelloHttpClient.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public final class HelloHttpClient {
 
     public static void main(String[] args) {
-        RxNetty.createHttpGet("http://localhost:8080/hello").toBlockingObservable().forEach(new Action1<HttpClientResponse<ByteBuf>>() {
+        RxNetty.createHttpGet("http://localhost:8080/hello").toBlocking().forEach(new Action1<HttpClientResponse<ByteBuf>>() {
             @Override
             public void call(HttpClientResponse<ByteBuf> response) {
                 System.out.println("New response recieved.");

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/HelloUdpClient.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/HelloUdpClient.java
@@ -38,7 +38,7 @@ public final class HelloUdpClient {
                        connection.writeStringAndFlush("Is there anybody out there?");
                        return connection.getInput();
                    }
-               }).toBlockingObservable().forEach(new Action1<DatagramPacket>() {
+               }).toBlocking().forEach(new Action1<DatagramPacket>() {
             @Override
             public void call(DatagramPacket datagramPacket) {
                 System.out.println("Received a new message: "

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/HttpSseClient.java
@@ -37,7 +37,7 @@ public final class HttpSseClient {
                 RxNetty.createHttpClient("localhost", 8080, PipelineConfigurators.<ByteBuf>sseClientConfigurator());
 
         Observable<HttpClientResponse<ServerSentEvent>> response = client.submit(HttpClientRequest.createGet("/hello"));
-        response.toBlockingObservable().forEach(new Action1<HttpClientResponse<ServerSentEvent>>() {
+        response.toBlocking().forEach(new Action1<HttpClientResponse<ServerSentEvent>>() {
             @Override
             public void call(HttpClientResponse<ServerSentEvent> response) {
                 System.out.println("New response recieved.");

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpEchoClient.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpEchoClient.java
@@ -81,7 +81,7 @@ public final class TcpEchoClient {
             public void call() {
                 System.out.println("COMPLETED!");
             }
-        }).toBlockingObservable().forEach(new Action1<Object>() {
+        }).toBlocking().forEach(new Action1<Object>() {
             @Override
             public void call(Object o) {
                 System.out.println("onNext: " + o);

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientFast.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientFast.java
@@ -40,7 +40,7 @@ public final class TcpEventStreamClientFast {
                     }
                 });
             }
-        }).toBlockingObservable().forEach(new Action1<Object>() {
+        }).toBlocking().forEach(new Action1<Object>() {
             @Override
             public void call(Object o) {
                 System.out.println("onNext event => " + o);

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientSlow.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpEventStreamClientSlow.java
@@ -45,7 +45,7 @@ public final class TcpEventStreamClientSlow {
                     }
                 });
             }
-        }).toBlockingObservable().forEach(new Action1<Object>() {
+        }).toBlocking().forEach(new Action1<Object>() {
             @Override
             public void call(Object o) {
                 System.out.println("onNext event => " + o);

--- a/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpIntervalClientTakeN.java
+++ b/rx-netty/src/examples/java/io/reactivex/netty/examples/java/TcpIntervalClientTakeN.java
@@ -59,7 +59,7 @@ public final class TcpIntervalClientTakeN {
 
                 return Observable.concat(subscribeWrite, data);
             }
-        }).take(3).toBlockingObservable().forEach(new Action1<Object>() {
+        }).take(3).toBlocking().forEach(new Action1<Object>() {
             @Override
             public void call(Object o) {
                 System.out.println("onNext: " + o);

--- a/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
@@ -179,6 +179,17 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
         return returnBuilder();
     }
 
+    /**
+     * Overrides all the connection pool settings done previous to this call and disables connection pooling for this
+     * client, unless enabled again after this call returns.
+     *
+     * @return This builder.
+     */
+    public B withNoConnectionPooling() {
+        poolBuilder = null;
+        return returnBuilder();
+    }
+
     public Bootstrap getBootstrap() {
         return bootstrap;
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ClientChannelFactoryImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ClientChannelFactoryImpl.java
@@ -53,8 +53,7 @@ public class ClientChannelFactoryImpl<I, O> implements ClientChannelFactory<I,O>
             @Override
             public void call() {
                 if (!connectFuture.isDone()) {
-                    connectFuture.cancel(
-                            true); // Unsubscribe here means, no more connection is required. A close on connection is explicit.
+                    connectFuture.cancel( true); // Unsubscribe here means, no more connection is required. A close on connection is explicit.
                 }
             }
         }));

--- a/rx-netty/src/main/java/io/reactivex/netty/client/RxClientImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/RxClientImpl.java
@@ -121,20 +121,23 @@ public class RxClientImpl<I, O> implements RxClient<I, O> {
             return Observable.error(new IllegalStateException("Client is already shutdown."));
         }
 
+        Observable<ObservableConnection<O, I>> toReturn;
         if (null != pool) {
-            return pool.acquire();
+            toReturn = pool.acquire();
+        } else {
+            toReturn = Observable.create(new OnSubscribe<ObservableConnection<O, I>>() {
+                @Override
+                public void call(final Subscriber<? super ObservableConnection<O, I>> subscriber) {
+                    try {
+                        channelFactory.connect(subscriber, serverInfo, connectionFactory);
+                    } catch (Throwable throwable) {
+                        subscriber.onError(throwable);
+                    }
+                }
+            });
         }
 
-        return Observable.create(new OnSubscribe<ObservableConnection<O, I>>() {
-            @Override
-            public void call(final Subscriber<? super ObservableConnection<O, I>> subscriber) {
-                try {
-                    channelFactory.connect(subscriber, serverInfo, connectionFactory);
-                } catch (Throwable throwable) {
-                    subscriber.onError(throwable);
-                }
-            }
-        });
+        return toReturn.take(1); // We only need one connection, even if the underlying source emits multiple.
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -21,7 +21,7 @@ import rx.Observer;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Action1;
-import rx.subscriptions.SubscriptionList;
+import rx.internal.util.SubscriptionList;
 import rx.subscriptions.Subscriptions;
 
 /**
@@ -44,7 +44,7 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
         child.add(cs);// Unsubscribe when the child unsubscribes.
 
         Subscriber<ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>>> toReturn =
-                new Subscriber<ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>>>(cs) {
+                new Subscriber<ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>>>() {
 
                     @Override
                     public void onCompleted() {
@@ -59,18 +59,18 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
                     @Override
                     public void onNext(final ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>> connection) {
 
-                        add(Subscriptions.create(new Action0() {
+                        cs.add(Subscriptions.create(new Action0() {
                             @Override
                             public void call() {
                                 connection.close();
                             }
                         }));
 
-                        add(connection.getInput()
+                        cs.add(connection.getInput()
                                          .doOnNext(new Action1<HttpClientResponse<O>>() {
                                              @Override
                                              public void call(final HttpClientResponse<O> response) {
-                                                 add(response.getContent().subscribe(new Observer<O>() {
+                                                 cs.add(response.getContent().subscribe(new Observer<O>() {
                                                      @Override
                                                      public void onCompleted() {
                                                          child.onCompleted();

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServer.java
@@ -26,6 +26,7 @@ import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -114,6 +115,22 @@ public class AbstractServer<I, O, B extends AbstractBootstrap<B, C>, C extends C
                 throw new IllegalStateException("Server not started yet.");
             case Started:
                 bindFuture.channel().closeFuture().await();
+                break;
+            case Shutdown:
+                // Nothing to do as it is already shutdown.
+                break;
+        }
+    }
+
+    @SuppressWarnings("fallthrough")
+    public void waitTillShutdown(long duration, TimeUnit timeUnit) throws InterruptedException {
+        ServerState serverState = serverStateRef.get();
+        switch (serverState) {
+            case Created:
+            case Starting:
+                throw new IllegalStateException("Server not started yet.");
+            case Started:
+                bindFuture.channel().closeFuture().await(duration, timeUnit);
                 break;
             case Shutdown:
                 // Nothing to do as it is already shutdown.

--- a/rx-netty/src/test/java/io/reactivex/netty/RxNettyHttpShorthandsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/RxNettyHttpShorthandsTest.java
@@ -75,13 +75,13 @@ public class RxNettyHttpShorthandsTest {
     @After
     public void tearDown() throws Exception {
         mockServer.shutdown();
-        mockServer.waitTillShutdown();
+        mockServer.waitTillShutdown(1, TimeUnit.MINUTES);
     }
 
     @Test
     public void testGet() throws Exception {
         HttpClientResponse<ByteBuf> response = RxNetty.createHttpGet("http://localhost:" + mockServer.getServerPort()
-                                                                     + '/').toBlockingObservable()
+                                                                     + '/').toBlocking()
                                                       .toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected HTTP method sent.", "GET", response.getHeaders().get(METHOD_HEADER));
     }
@@ -89,7 +89,7 @@ public class RxNettyHttpShorthandsTest {
     @Test
     public void testDelete() throws Exception {
         HttpClientResponse<ByteBuf> response = RxNetty.createHttpDelete("http://localhost:" + mockServer.getServerPort()
-                                                                        + '/').toBlockingObservable().last();
+                                                                        + '/').toBlocking().last();
         Assert.assertEquals("Unexpected HTTP method sent.", "DELETE", response.getHeaders().get(METHOD_HEADER));
     }
 
@@ -99,7 +99,7 @@ public class RxNettyHttpShorthandsTest {
                 Unpooled.buffer().writeBytes("Hello!".getBytes()));
         HttpClientResponse<ByteBuf> response =
                 RxNetty.createHttpPost("http://localhost:" + mockServer.getServerPort() + '/', content)
-                       .toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
+                       .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected HTTP method sent.", "POST", response.getHeaders().get(METHOD_HEADER));
         Assert.assertEquals("Content not sent by the client.", "true", response.getHeaders().get(CONTENT_RECEIEVED_HEADER));
     }
@@ -110,7 +110,7 @@ public class RxNettyHttpShorthandsTest {
                 Unpooled.buffer().writeBytes("Hello!".getBytes()));
         HttpClientResponse<ByteBuf> response =
                 RxNetty.createHttpPut("http://localhost:" + mockServer.getServerPort() + '/', content)
-                       .toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
+                       .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected HTTP method sent.", "PUT", response.getHeaders().get(METHOD_HEADER));
         Assert.assertEquals("Content not sent by the client.", "true", response.getHeaders().get(CONTENT_RECEIEVED_HEADER));
     }
@@ -120,7 +120,7 @@ public class RxNettyHttpShorthandsTest {
         RawContentSource<String> content = getRawContentSource();
         HttpClientResponse<ByteBuf> response =
                 RxNetty.createHttpPost("http://localhost:" + mockServer.getServerPort() + '/', content)
-                       .toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
+                       .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected HTTP method sent.", "POST", response.getHeaders().get(METHOD_HEADER));
         Assert.assertEquals("Content not sent by the client.", "true", response.getHeaders().get(CONTENT_RECEIEVED_HEADER));
     }
@@ -130,7 +130,7 @@ public class RxNettyHttpShorthandsTest {
         RawContentSource<String> content = getRawContentSource();
         HttpClientResponse<ByteBuf> response =
                 RxNetty.createHttpPut("http://localhost:" + mockServer.getServerPort() + '/', content)
-                       .toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
+                       .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected HTTP method sent.", "PUT", response.getHeaders().get(METHOD_HEADER));
         Assert.assertEquals("Content not sent by the client.", "true", response.getHeaders().get(CONTENT_RECEIEVED_HEADER));
     }

--- a/rx-netty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
@@ -126,7 +126,7 @@ public class ConnectionPoolTest {
                 // Do nothing if there are no connections
             }
             server.shutdown();
-            server.waitTillShutdown();
+            server.waitTillShutdown(1, TimeUnit.MINUTES);
         }
     }
 
@@ -216,9 +216,9 @@ public class ConnectionPoolTest {
         serverConnHandler.closeNewConnectionsOnReceive(false);
         strategy.incrementMaxConnections(2);
 
-        ObservableConnection<String, String> connection1 = pool.acquire().toBlockingObservable().last();
-        ObservableConnection<String, String> connection2 = pool.acquire().toBlockingObservable().last();
-        ObservableConnection<String, String> connection3 = pool.acquire().toBlockingObservable().last();
+        ObservableConnection<String, String> connection1 = pool.acquire().toBlocking().last();
+        ObservableConnection<String, String> connection2 = pool.acquire().toBlocking().last();
+        ObservableConnection<String, String> connection3 = pool.acquire().toBlocking().last();
 
         Assert.assertEquals("Unexpected pool idle count.", 0, stats.getIdleCount());
         Assert.assertEquals("Unexpected pool in-use count.", 3, stats.getInUseCount());
@@ -253,7 +253,7 @@ public class ConnectionPoolTest {
         pool.poolStateChangeObservable().subscribe(stateChangeListener);
 
         try {
-            pool.acquire().toBlockingObservable().last();
+            pool.acquire().toBlocking().last();
             throw new AssertionError("Connect to a nonexistent server did not fail.");
         } catch (Exception e) {
             // Expected.
@@ -270,7 +270,7 @@ public class ConnectionPoolTest {
         strategy.incrementMaxConnections(1);
 
         PooledConnection<String, String> conn =
-                (PooledConnection<String, String>) pool.acquire().toBlockingObservable().last();
+                (PooledConnection<String, String>) pool.acquire().toBlocking().last();
         Assert.assertEquals("Unexpected acquire attempted count.", 1, stateChangeListener.getAcquireAttemptedCount());
         Assert.assertEquals("Unexpected acquire succeeded count.", 1, stateChangeListener.getAcquireSucceededCount());
         Assert.assertEquals("Unexpected acquire failed count.", 0, stateChangeListener.getAcquireFailedCount());
@@ -284,7 +284,7 @@ public class ConnectionPoolTest {
         Assert.assertEquals("Unexpected create connection count.", 1, stateChangeListener.getCreationCount());
 
         PooledConnection<String, String> reusedConn =
-                (PooledConnection<String, String>) pool.acquire().toBlockingObservable().last();
+                (PooledConnection<String, String>) pool.acquire().toBlocking().last();
 
         Assert.assertEquals("Reused connection not same as original.", conn, reusedConn);
 
@@ -318,7 +318,7 @@ public class ConnectionPoolTest {
         PooledConnection<String, String> connection = (PooledConnection<String, String>) acquireAndTestStats();
 
         try {
-            pool.acquire().toBlockingObservable().last();
+            pool.acquire().toBlocking().last();
             throw new AssertionError("Pool did not exhaust.");
         } catch (Exception e) {
             // expected
@@ -383,7 +383,7 @@ public class ConnectionPoolTest {
     }
 
     private ObservableConnection<String, String> acquireAndTestStats() throws InterruptedException {
-        ObservableConnection<String, String> conn = pool.acquire().toBlockingObservable().last();
+        ObservableConnection<String, String> conn = pool.acquire().toBlocking().last();
         Assert.assertEquals("Unexpected pool idle count.", 0, stats.getIdleCount());
         Assert.assertEquals("Unexpected pool in-use count.", 1, stats.getInUseCount());
         Assert.assertEquals("Unexpected pool total connections count.", 1, stats.getTotalConnectionCount());

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientPoolTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientPoolTest.java
@@ -58,7 +58,7 @@ public class HttpClientPoolTest {
 
     @BeforeClass
     public static void init() throws Exception {
-        mockServer = RxNetty.newHttpServerBuilder(port, new RequestProcessor()).enableWireLogging(LogLevel.ERROR)
+        mockServer = RxNetty.newHttpServerBuilder(0, new RequestProcessor()).enableWireLogging(LogLevel.ERROR)
                             .build().start();
         port = mockServer.getServerPort();
     }
@@ -66,7 +66,7 @@ public class HttpClientPoolTest {
     @AfterClass
     public static void shutdown() throws InterruptedException {
         mockServer.shutdown();
-        mockServer.waitTillShutdown();
+        mockServer.waitTillShutdown(1, TimeUnit.MINUTES);
     }
 
     @After
@@ -221,7 +221,7 @@ public class HttpClientPoolTest {
             public void call() {
                 completionLatch.countDown();
             }
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
             @Override
             public void call(String s) {
                 toReturn.add(s);
@@ -247,7 +247,7 @@ public class HttpClientPoolTest {
             public void call() {
                 completionLatch.countDown();
             }
-        }).toBlockingObservable().last();
+        }).toBlocking().last();
 
         completionLatch.await(1, TimeUnit.MINUTES);
 

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
@@ -88,7 +88,7 @@ public class HttpClientTest {
         Observable<ObservableConnection<HttpClientResponse<ByteBuf>,HttpClientRequest<ByteBuf>>> connectionObservable = client.connect().cache();
 
         final Observable<HttpClientResponse<ByteBuf>> response = client.submit(HttpClientRequest.createGet("test/singleEntity"), connectionObservable);
-        ObservableConnection<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>> conn = connectionObservable.toBlockingObservable().last();
+        ObservableConnection<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>> conn = connectionObservable.toBlocking().last();
         Assert.assertFalse("Connection already closed.", conn.isCloseIssued());
 
         final CountDownLatch responseCompleteLatch = new CountDownLatch(1);
@@ -152,7 +152,7 @@ public class HttpClientTest {
         });
 
        final List<String> result = new ArrayList<String>();
-        transformed.toBlockingObservable().forEach(new Action1<String>() {
+        transformed.toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t1) {
@@ -178,7 +178,7 @@ public class HttpClientTest {
                     }
                 });
             }
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t1) {
@@ -207,7 +207,7 @@ public class HttpClientTest {
                     }
                 });
             }
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t1) {
@@ -230,7 +230,7 @@ public class HttpClientTest {
                     }
                 });
             }
-        }).toBlockingObservable().forEach(new Action1<String>() {
+        }).toBlocking().forEach(new Action1<String>() {
 
             @Override
             public void call(String t1) {
@@ -269,7 +269,7 @@ public class HttpClientTest {
                     }
                 });
             }
-        }).toBlockingObservable().single();
+        }).toBlocking().single();
         assertEquals("Hello world", result);
     }
     
@@ -285,7 +285,7 @@ public class HttpClientTest {
             public Observable<ServerSentEvent> call(HttpClientResponse<ServerSentEvent> httpResponse) {
                 return httpResponse.getContent();
             }
-        }).toBlockingObservable().forEach(new Action1<ServerSentEvent>() {
+        }).toBlocking().forEach(new Action1<ServerSentEvent>() {
             @Override
             public void call(ServerSentEvent event) {
                 result.add(event.getEventData());
@@ -428,7 +428,7 @@ public class HttpClientTest {
                         return sseEventHttpResponse.getContent();
                     }
                 })
-                .toBlockingObservable().forEach(new Action1<ServerSentEvent>() {
+                .toBlocking().forEach(new Action1<ServerSentEvent>() {
             @Override
             public void call(ServerSentEvent serverSentEvent) {
                 result.add(serverSentEvent.getEventData());

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
@@ -83,24 +83,24 @@ public class HttpClientTest {
 
     @Test
     public void testConnectionClose() throws Exception {
-        HttpClientImpl<ByteBuf, ByteBuf> client = (HttpClientImpl<ByteBuf, ByteBuf>) RxNetty.createHttpClient( "localhost", port);
+        HttpClientImpl<ByteBuf, ByteBuf> client = (HttpClientImpl<ByteBuf, ByteBuf>) RxNetty.createHttpClient(
+                "localhost", port);
         Observable<ObservableConnection<HttpClientResponse<ByteBuf>,HttpClientRequest<ByteBuf>>> connectionObservable = client.connect().cache();
 
         final Observable<HttpClientResponse<ByteBuf>> response = client.submit(HttpClientRequest.createGet("test/singleEntity"), connectionObservable);
         ObservableConnection<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>> conn = connectionObservable.toBlockingObservable().last();
         Assert.assertFalse("Connection already closed.", conn.isCloseIssued());
-        final Object responseCompleteMonitor = new Object();
+
+        final CountDownLatch responseCompleteLatch = new CountDownLatch(1);
         response.finallyDo(new Action0() {
             @Override
             public void call() {
-                synchronized (responseCompleteMonitor) {
-                    responseCompleteMonitor.notifyAll();
-                }
+                responseCompleteLatch.countDown();
             }
         }).subscribe();
-        synchronized (responseCompleteMonitor) {
-            responseCompleteMonitor.wait(60*1000);
-        }
+
+        responseCompleteLatch.await(1, TimeUnit.MINUTES);
+
         assertTrue("Connection not closed after response recieved.", conn.isCloseIssued());
     }
 

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpRedirectTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/HttpRedirectTest.java
@@ -113,7 +113,7 @@ public class HttpRedirectTest {
         HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
                 .config(config)
                 .build();
-        HttpClientResponse<ByteBuf> response = client.submit(request).toBlockingObservable().single();
+        HttpClientResponse<ByteBuf> response = client.submit(request).toBlocking().single();
         assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), response.getStatus().code());
     }
 
@@ -140,7 +140,7 @@ public class HttpRedirectTest {
         HttpClient<ByteBuf, ByteBuf> client = new HttpClientBuilder<ByteBuf, ByteBuf>("localhost", port)
                 .config(config)
                 .build();
-        HttpClientResponse<ByteBuf> response = client.submit(request).toBlockingObservable().single();
+        HttpClientResponse<ByteBuf> response = client.submit(request).toBlocking().single();
         assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), response.getStatus().code());
     }
 
@@ -158,7 +158,7 @@ public class HttpRedirectTest {
                         }
                     });
                 }
-            }).toBlockingObservable().toFuture().get(1, TimeUnit.MINUTES);
+            }).toBlocking().toFuture().get(1, TimeUnit.MINUTES);
         } catch (ExecutionException e) {
             if (e.getCause() instanceof HttpRedirectException) {
                 throw e.getCause();

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/Http10Test.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/Http10Test.java
@@ -57,7 +57,7 @@ public class Http10Test {
     public void tearDown() throws Exception {
         if (null != mockServer) {
             mockServer.shutdown();
-            mockServer.waitTillShutdown();
+            mockServer.waitTillShutdown(1, TimeUnit.MINUTES);
         }
     }
 
@@ -73,7 +73,7 @@ public class Http10Test {
         HttpClientRequest<ByteBuf> request = HttpClientRequest.create(HttpVersion.HTTP_1_0, HttpMethod.GET, "/");
         HttpClientResponse<ByteBuf> response =
                 RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder("localhost", mockServer.getServerPort())
-                       .enableWireLogging(LogLevel.ERROR).build().submit(request).toBlockingObservable()
+                       .enableWireLogging(LogLevel.ERROR).build().submit(request).toBlocking()
                        .toFuture().get(1, TimeUnit.MINUTES);
         HttpVersion httpVersion = response.getHttpVersion();
         Assert.assertEquals("Unexpected HTTP version.", HttpVersion.HTTP_1_0, httpVersion);
@@ -86,7 +86,7 @@ public class Http10Test {
         HttpClientRequest<ByteBuf> request = HttpClientRequest.create(HttpVersion.HTTP_1_0, HttpMethod.GET, "/");
         HttpClientResponse<ByteBuf> response = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder("localhost", mockServerPort)
                                                       .enableWireLogging(LogLevel.ERROR).build()
-                                                      .submit(request).toBlockingObservable()
+                                                      .submit(request).toBlocking()
                                                       .toFuture().get(1, TimeUnit.MINUTES);
         HttpVersion httpVersion = response.getHttpVersion();
         Assert.assertEquals("Unexpected HTTP version.", HttpVersion.HTTP_1_1, httpVersion);
@@ -107,7 +107,7 @@ public class Http10Test {
                                                                           HttpClientResponse<ByteBuf> response) {
                                                                       return response.getContent();
                                                                   }
-                                                              }).toBlockingObservable()
+                                                              }).toBlocking()
                                                       .toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected Content.", WELCOME_SERVER_MSG, response.toString(Charset.defaultCharset()));
     }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpErrorHandlerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpErrorHandlerTest.java
@@ -72,7 +72,7 @@ public class HttpErrorHandlerTest {
                 HttpClientRequest.createGet("/");
 
         HttpClientResponse<ByteBuf> response =
-                RxNetty.createHttpClient("localhost", port).submit(request).toBlockingObservable().last();
+                RxNetty.createHttpClient("localhost", port).submit(request).toBlocking().last();
 
         Assert.assertEquals("Unexpected response status", HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                             response.getStatus().code());
@@ -101,7 +101,7 @@ public class HttpErrorHandlerTest {
                 HttpClientRequest.createGet("/");
 
         HttpClientResponse<ByteBuf> response =
-                RxNetty.createHttpClient("localhost", port).submit(request).toBlockingObservable().last();
+                RxNetty.createHttpClient("localhost", port).submit(request).toBlocking().last();
 
         Assert.assertEquals("Unexpected response status", HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                             response.getStatus().code());

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
@@ -54,7 +54,7 @@ public class HttpServerTest {
     public static void tearDown() throws InterruptedException {
         if (null != mockServer) {
             mockServer.shutdown();
-            mockServer.waitTillShutdown();
+            mockServer.waitTillShutdown(1, TimeUnit.MINUTES);
         }
     }
 
@@ -75,7 +75,7 @@ public class HttpServerTest {
                                                           public void call() {
                                                               finishLatch.countDown();
                                                           }
-                                                      }).toBlockingObservable().toFuture().get(10, TimeUnit.SECONDS);
+                                                      }).toBlocking().toFuture().get(10, TimeUnit.SECONDS);
         Assert.assertTrue("The returned observable did not finish.", finishLatch.await(1, TimeUnit.MINUTES));
         Assert.assertEquals("Request failed.", response.getStatus(), HttpResponseStatus.NOT_FOUND);
     }
@@ -103,7 +103,7 @@ public class HttpServerTest {
                                                           public void call() {
                                                               finishLatch.countDown();
                                                           }
-                                                      }).toBlockingObservable().toFuture().get(10, TimeUnit.SECONDS);
+                                                      }).toBlocking().toFuture().get(10, TimeUnit.SECONDS);
         Assert.assertTrue("The returned observable did not finish.", finishLatch.await(1, TimeUnit.MINUTES));
         Assert.assertEquals("Request failed.", response.getStatus(), HttpResponseStatus.NOT_FOUND);
     }
@@ -134,7 +134,7 @@ public class HttpServerTest {
                                                           public void call() {
                                                               finishLatch.countDown();
                                                           }
-                                                      }).toBlockingObservable().toFuture().get(10, TimeUnit.SECONDS);
+                                                      }).toBlocking().toFuture().get(10, TimeUnit.SECONDS);
         Assert.assertTrue("The returned observable did not finish.", finishLatch.await(10, TimeUnit.SECONDS));
         Assert.assertEquals("Request failed.", response.getStatus(), HttpResponseStatus.OK);
     }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
@@ -65,7 +65,7 @@ public class UnexpectedErrorsTest {
     @After
     public void tearDown() throws Exception {
         server.shutdown();
-        server.waitTillShutdown();
+        server.waitTillShutdown(1, TimeUnit.MINUTES);
     }
 
     @Test
@@ -100,7 +100,7 @@ public class UnexpectedErrorsTest {
                     public Observable<Void> call(ObservableConnection<ByteBuf, ByteBuf> connection) {
                         return connection.close();
                     }
-                }).toBlockingObservable().toFuture().get();
+                }).toBlocking().toFuture().get();
     }
 
 


### PR DESCRIPTION
1) Modified RxClientImpl.connect() to do a take(1) on the underlying source so that in no case it will emit two onNext().
2) Modified RequestProcessingOperator to use SubscriptionList instead of CompositeSubscription. Instead of creating a new subscription on every onNext(), it is done once and used by the subscriber.
3) Provided an override to remove all connection pooling for a client.
