### PR TITLE
Fixes issue #139

### DIFF
--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
@@ -70,7 +70,8 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
         return nettyResponse.getStatus();
     }
 
-    public Observable<Void> close() {
+    @Override
+    public Observable<Void> _close() {
 
         writeHeadersIfNotWritten();
 

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import rx.Observable;
 import rx.functions.Func1;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
@@ -93,14 +92,14 @@ public class UnexpectedErrorsTest {
         assertTrue("Error handler not invoked.", errorHandler.invoked);
     }
 
-    private static void blockTillConnected(int serverPort) throws InterruptedException, ExecutionException {
+    private static void blockTillConnected(int serverPort) {
         RxNetty.createTcpClient("localhost", serverPort).connect().flatMap(
                 new Func1<ObservableConnection<ByteBuf, ByteBuf>, Observable<?>>() {
                     @Override
                     public Observable<Void> call(ObservableConnection<ByteBuf, ByteBuf> connection) {
                         return connection.close();
                     }
-                }).toBlocking().toFuture().get();
+                }).toBlocking().singleOrDefault(null);
     }
 
 


### PR DESCRIPTION
Making HttpServerResponse.close() idempotent and reducing two flushes to one for most RequestHandlers.
