### PR TITLE
Fixes issue #145 (ReadTimeoutHandler remove causes deadlock)

### DIFF
--- a/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
@@ -69,7 +69,7 @@ public class ObservableConnection<I, O> extends DefaultChannelWriter<O> {
 
     protected void cleanupConnection() {
         cancelPendingWrites(true);
-        ReadTimeoutPipelineConfigurator.removeTimeoutHandler(getChannelHandlerContext().pipeline());
+        ReadTimeoutPipelineConfigurator.disableReadTimeout(getChannelHandlerContext().pipeline());
     }
 
     protected Observable<Void> _closeChannel() {

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
@@ -30,7 +30,9 @@ import org.junit.Test;
 import rx.Observable;
 import rx.functions.Func1;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertTrue;
 
@@ -92,14 +94,15 @@ public class UnexpectedErrorsTest {
         assertTrue("Error handler not invoked.", errorHandler.invoked);
     }
 
-    private static void blockTillConnected(int serverPort) {
+    private static void blockTillConnected(int serverPort)
+            throws ExecutionException, InterruptedException, TimeoutException {
         RxNetty.createTcpClient("localhost", serverPort).connect().flatMap(
                 new Func1<ObservableConnection<ByteBuf, ByteBuf>, Observable<?>>() {
                     @Override
                     public Observable<Void> call(ObservableConnection<ByteBuf, ByteBuf> connection) {
                         return connection.close();
                     }
-                }).toBlocking().singleOrDefault(null);
+                }).toBlocking().toFuture().get(1, TimeUnit.MINUTES);
     }
 
 

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
@@ -28,7 +28,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
-import rx.functions.Func1;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -96,13 +95,9 @@ public class UnexpectedErrorsTest {
 
     private static void blockTillConnected(int serverPort)
             throws ExecutionException, InterruptedException, TimeoutException {
-        RxNetty.createTcpClient("localhost", serverPort).connect().flatMap(
-                new Func1<ObservableConnection<ByteBuf, ByteBuf>, Observable<?>>() {
-                    @Override
-                    public Observable<Void> call(ObservableConnection<ByteBuf, ByteBuf> connection) {
-                        return connection.close();
-                    }
-                }).toBlocking().toFuture().get(1, TimeUnit.MINUTES);
+        ObservableConnection<ByteBuf, ByteBuf> conn = RxNetty.createTcpClient("localhost", serverPort).connect()
+                                                                  .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
+        conn.close();
     }
 
 


### PR DESCRIPTION
ChannelPipeline.remove() is a blocking call when not called from the associated eventloop.

Now, instead of removing the handler from the pipeline, it is deactivated on close and re-activated when the pipeline is used again.
