### PR TITLE
Fixes #167 #166 #164

### DIFF
--- a/rx-netty/src/main/java/io/reactivex/netty/RxNetty.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/RxNetty.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty;
 
 import io.netty.buffer.ByteBuf;
@@ -53,7 +54,9 @@ import static io.reactivex.netty.client.MaxConnectionsBasedStrategy.DEFAULT_MAX_
 
 public final class RxNetty {
 
-    private static volatile RxEventLoopProvider rxEventLoopProvider = new SingleNioLoopProvider();
+    private static volatile RxEventLoopProvider rxEventLoopProvider =
+            new SingleNioLoopProvider(1, Runtime.getRuntime().availableProcessors());
+
     private static final CompositeHttpClient<ByteBuf, ByteBuf> globalClient =
             new CompositeHttpClientBuilder<ByteBuf, ByteBuf>().withMaxConnections(DEFAULT_MAX_CONNECTIONS).build();
     private static MetricEventsListenerFactory metricEventsListenerFactory;

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.channel;
 
 import io.netty.channel.EventLoopGroup;
@@ -44,4 +45,14 @@ public interface RxEventLoopProvider {
      * @return The {@link EventLoopGroup} to be used for all servers.
      */
     EventLoopGroup globalServerEventLoop();
+
+    /**
+     * The {@link EventLoopGroup} to be used by all {@link RxServer} instances as a parent eventloop group
+     * (First argument to this method: {@link io.netty.bootstrap.ServerBootstrap#group(EventLoopGroup, EventLoopGroup)}),
+     * if it is not explicitly provided using {@link ServerBuilder#eventLoop(EventLoopGroup)} or
+     * {@link ServerBuilder#eventLoops(EventLoopGroup, EventLoopGroup)}.
+     *
+     * @return The {@link EventLoopGroup} to be used for all servers.
+     */
+    EventLoopGroup globalServerParentEventLoop();
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.channel;
 
 import io.netty.channel.EventLoopGroup;
@@ -31,13 +32,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SingleNioLoopProvider implements RxEventLoopProvider {
 
     private final SharedNioEventLoopGroup eventLoop;
+    private final SharedNioEventLoopGroup parentEventLoop;
 
     public SingleNioLoopProvider() {
-        eventLoop = new SharedNioEventLoopGroup();
+        this(Runtime.getRuntime().availableProcessors());
     }
 
     public SingleNioLoopProvider(int threadCount) {
         eventLoop = new SharedNioEventLoopGroup(threadCount);
+        parentEventLoop = eventLoop;
+    }
+
+    public SingleNioLoopProvider(int parentEventLoopCount, int childEventLoopCount) {
+        eventLoop = new SharedNioEventLoopGroup(childEventLoopCount);
+        parentEventLoop = new SharedNioEventLoopGroup(parentEventLoopCount);
     }
 
     @Override
@@ -50,6 +58,11 @@ public class SingleNioLoopProvider implements RxEventLoopProvider {
     public EventLoopGroup globalServerEventLoop() {
         eventLoop.retain();
         return eventLoop;
+    }
+
+    @Override
+    public EventLoopGroup globalServerParentEventLoop() {
+        return parentEventLoop;
     }
 
     public static class SharedNioEventLoopGroup extends NioEventLoopGroup {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -123,7 +123,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                             requestHandlingResult = Observable.error(throwable);
                         }
 
-                        requestHandlingResult.subscribe(new Observer<Void>() {
+                        requestHandlingResult.subscribe(new Subscriber<Void>() {
                             @Override
                             public void onCompleted() {
                                 eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_SUCCESS,

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -104,9 +104,14 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                          */
                         send10ResponseFor10Request ? newRequest.getHttpVersion() : HttpVersion.HTTP_1_1, eventsSubject);
                         if (newRequest.getHeaders().isKeepAlive()) {
-                            // Add keep alive header as per:
-                            // - http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
-                            response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                            if (!newRequest.getHttpVersion().isKeepAliveDefault()) {
+                                // Avoid sending keep-alive header if keep alive is default. Issue: https://github.com/Netflix/RxNetty/issues/167
+                                // This optimizes data transferred on the wire.
+
+                                // Add keep alive header as per:
+                                // - http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
+                                response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                            }
                         } else {
                             response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
                         }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.handler.codec.http.HttpHeaders;
@@ -23,8 +24,7 @@ import io.reactivex.netty.metrics.Clock;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 import rx.Observable;
 import rx.Observer;
-import rx.functions.Action0;
-import rx.functions.Func1;
+import rx.Subscriber;
 
 /**
 * @author Nitesh Kant
@@ -57,32 +57,45 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
     @Override
     public Observable<Void> handle(final ObservableConnection<HttpServerRequest<I>, HttpServerResponse<O>> newConnection) {
 
-        return newConnection.getInput().flatMap(new Func1<HttpServerRequest<I>, Observable<Void>>() {
+        return newConnection.getInput().lift(new Observable.Operator<Void, HttpServerRequest<I>>() {
             @Override
-            @SuppressWarnings("unchecked")
-            public Observable<Void> call(HttpServerRequest<I> newRequest) {
-                final long startTimeMillis = Clock.newStartTimeMillis();
-                eventsSubject.onEvent(HttpServerMetricsEvent.NEW_REQUEST_RECEIVED);
-                newRequest.getContent().subscribe(new Observer<I>() {
-                    // There is no guarantee that the RequestHandler will subscribe to the content, but we want this
-                    // metric anyways, so we subscribe to the content here.
+            public Subscriber<? super HttpServerRequest<I>> call(final Subscriber<? super Void> child) {
+                return new Subscriber<HttpServerRequest<I>>() {
                     @Override
                     public void onCompleted() {
-                        eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_RECEIVE_COMPLETE,
-                                              Clock.onEndMillis(startTimeMillis));
+                        child.onCompleted();
                     }
 
                     @Override
                     public void onError(Throwable e) {
+                        child.onError(e);
                     }
 
+                    @SuppressWarnings("unchecked")
                     @Override
-                    public void onNext(I i) {
-                    }
-                });
+                    public void onNext(HttpServerRequest<I> newRequest) {
+                        final long startTimeMillis = Clock.newStartTimeMillis();
+                        eventsSubject.onEvent(HttpServerMetricsEvent.NEW_REQUEST_RECEIVED);
+                        newRequest.getContent().subscribe(new Observer<I>() {
+                            // There is no guarantee that the RequestHandler will subscribe to the content, but we want this
+                            // metric anyways, so we subscribe to the content here.
+                            @Override
+                            public void onCompleted() {
+                                eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_RECEIVE_COMPLETE,
+                                                      Clock.onEndMillis(startTimeMillis));
+                            }
 
-                final HttpServerResponse<O> response = new HttpServerResponse<O>(
-                        newConnection.getChannelHandlerContext(),
+                            @Override
+                            public void onError(Throwable e) {
+                            }
+
+                            @Override
+                            public void onNext(I i) {
+                            }
+                        });
+
+                        final HttpServerResponse<O> response = new HttpServerResponse<O>(
+                                newConnection.getChannelHandlerContext(),
                         /*
                          * Server should send the highest version it is compatible with.
                          * http://tools.ietf.org/html/rfc2145#section-2.3
@@ -90,51 +103,51 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                          * unless overriden explicitly.
                          */
                         send10ResponseFor10Request ? newRequest.getHttpVersion() : HttpVersion.HTTP_1_1, eventsSubject);
-                if (newRequest.getHeaders().isKeepAlive()) {
-                    // Add keep alive header as per:
-                    // - http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
-                    response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-                } else {
-                    response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
-                }
-                Observable<Void> toReturn;
+                        if (newRequest.getHeaders().isKeepAlive()) {
+                            // Add keep alive header as per:
+                            // - http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
+                            response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                        } else {
+                            response.getHeaders().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
+                        }
+                        Observable<Void> requestHandlingResult;
 
-                try {
-                    eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_START,
-                                          Clock.onEndMillis(startTimeMillis));
-                    toReturn = requestHandler.handle(newRequest, response);
-                    if (null == toReturn) {
-                        toReturn = Observable.empty();
-                    }
-                } catch (Throwable throwable) {
-                    toReturn = Observable.error(throwable);
-                }
+                        try {
+                            eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_START,
+                                                  Clock.onEndMillis(startTimeMillis));
+                            requestHandlingResult = requestHandler.handle(newRequest, response);
+                            if (null == requestHandlingResult) {
+                                requestHandlingResult = Observable.empty();
+                            }
+                        } catch (Throwable throwable) {
+                            requestHandlingResult = Observable.error(throwable);
+                        }
 
-                return toReturn
-                        .doOnCompleted(new Action0() {
+                        requestHandlingResult.subscribe(new Observer<Void>() {
                             @Override
-                            public void call() {
+                            public void onCompleted() {
                                 eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_SUCCESS,
                                                       Clock.onEndMillis(startTimeMillis));
+                                response.close();
                             }
-                        })
-                        .onErrorResumeNext(new Func1<Throwable, Observable<Void>>() {
+
                             @Override
-                            public Observable<Void> call(Throwable throwable) {
+                            public void onError(Throwable throwable) {
                                 eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_FAILED,
                                                       Clock.onEndMillis(startTimeMillis), throwable);
                                 if (!response.isHeaderWritten()) {
                                     responseGenerator.updateResponse(response, throwable);
                                 }
-                                return Observable.empty();
-                            }
-                        })
-                        .finallyDo(new Action0() {
-                            @Override
-                            public void call() {
                                 response.close();
                             }
+
+                            @Override
+                            public void onNext(Void aVoid) {
+                                // Not significant.
+                            }
                         });
+                    }
+                };
             }
         });
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.server;
 
 import io.netty.bootstrap.AbstractBootstrap;
@@ -128,13 +129,13 @@ public abstract class AbstractServerBuilder<I, O, T extends AbstractBootstrap<T,
             serverChannelClass = defaultServerChannelClass();
             EventLoopGroup acceptorGroup = serverBootstrap.group();
             if (null == acceptorGroup) {
-                serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerEventLoop());
+                configureDefaultEventloopGroup();
             }
         }
 
         if (null == serverBootstrap.group()) {
             if (defaultServerChannelClass() == serverChannelClass) {
-                serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerEventLoop());
+                configureDefaultEventloopGroup();
             } else {
                 // Fail fast for defaults we do not support.
                 throw new IllegalStateException("Specified a channel class but not the event loop group.");
@@ -156,6 +157,10 @@ public abstract class AbstractServerBuilder<I, O, T extends AbstractBootstrap<T,
             server.subscribe(listener);
         }
         return server;
+    }
+
+    protected void configureDefaultEventloopGroup() {
+        serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerEventLoop());
     }
 
     protected abstract Class<? extends C> defaultServerChannelClass();

--- a/rx-netty/src/main/java/io/reactivex/netty/server/ConnectionBasedServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/ConnectionBasedServerBuilder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.server;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -21,6 +22,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ConnectionHandler;
 
 /**
@@ -52,6 +54,12 @@ public abstract class ConnectionBasedServerBuilder<I, O, B extends ConnectionBas
     @Override
     protected Class<? extends ServerChannel> defaultServerChannelClass() {
         return NioServerSocketChannel.class;
+    }
+
+    @Override
+    protected void configureDefaultEventloopGroup() {
+        serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerParentEventLoop(),
+                              RxNetty.getRxEventLoopProvider().globalServerEventLoop());
     }
 
     @Override

--- a/rx-netty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
@@ -138,7 +138,7 @@ public class ConnectionPoolTest {
 
     @Test
     public void testAcquireRelease() throws Exception {
-        serverConnHandler.closeNewConnectionsOnReceive(false);
+        serverConnHandler.closeNewConnectionsOnReceive(true);
         ObservableConnection<String, String> conn = acquireAndTestStats();
         conn.close();
         waitForClose();
@@ -147,7 +147,7 @@ public class ConnectionPoolTest {
 
     @Test
     public void testReleaseAfterClose() throws Exception {
-        serverConnHandler.closeNewConnectionsOnReceive(false);
+        serverConnHandler.closeNewConnectionsOnReceive(true);
         ObservableConnection<String, String> conn = acquireAndTestStats();
         waitForClose();
         conn.close();

--- a/rx-netty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.client;
 
 import io.netty.bootstrap.Bootstrap;
@@ -64,7 +65,7 @@ public class ConnectionPoolTest {
     private MaxConnectionsBasedStrategy strategy;
     private RxServer<String,String> server;
     private final ChannelCloseListener channelCloseListener = new ChannelCloseListener();
-    private PoolStats stats;
+    @SuppressWarnings("deprecation") private PoolStats stats;
     private ConnectionHandlerImpl serverConnHandler;
     private PipelineConfigurator<String,String> pipelineConfigurator;
     private String testId;
@@ -72,6 +73,7 @@ public class ConnectionPoolTest {
     private PoolConfig poolConfig;
 
     @Before
+    @SuppressWarnings("deprecation")
     public void setUp() throws Exception {
         testId = name.getMethodName();
         long currentTime = System.currentTimeMillis();
@@ -136,6 +138,7 @@ public class ConnectionPoolTest {
 
     @Test
     public void testAcquireRelease() throws Exception {
+        serverConnHandler.closeNewConnectionsOnReceive(false);
         ObservableConnection<String, String> conn = acquireAndTestStats();
         conn.close();
         waitForClose();
@@ -144,6 +147,7 @@ public class ConnectionPoolTest {
 
     @Test
     public void testReleaseAfterClose() throws Exception {
+        serverConnHandler.closeNewConnectionsOnReceive(false);
         ObservableConnection<String, String> conn = acquireAndTestStats();
         waitForClose();
         conn.close();
@@ -247,8 +251,10 @@ public class ConnectionPoolTest {
         assertAllConnectionsReturned();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConnectFail() throws Exception {
+        serverConnHandler.closeNewConnectionsOnReceive(false);
         RxClient.ServerInfo unavailableServer = new RxClient.ServerInfo("trampledunderfoot", 999);
         MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject = new MetricEventsSubject<ClientMetricsEvent<?>>();
         factory = new ClientChannelFactoryImpl<String, String>(clientBootstrap, eventsSubject);
@@ -345,6 +351,7 @@ public class ConnectionPoolTest {
         assertAllConnectionsReturned();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testIdleCleanupThread() throws Exception {
         serverConnHandler.closeNewConnectionsOnReceive(false);


### PR DESCRIPTION
#164: Removed flatMap() usage in HttpConnectionHandler in favor of a custom operator.
#166: Defined a facility to also specify the acceptor event loop. RxNetty defaults to an acceptor event loop with 1 thread. Also, the number of worker threads == number of available processors.
#167: Not sending Connection: keep-alive for HTTP 1.1. protocol
