### PR TITLE
Fixes issue #172

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 # RxNetty Releases #
 
 
+### Version 0.3.7 ###
+
+[Milestone](https://github.com/Netflix/RxNetty/issues?milestone=2&state=closed)
+
+* [Issue 98] (https://github.com/Netflix/RxNetty/issues/98) Added pluggable metrics infrastructure with rx-netty-servo implementation.
+* [Issue 106] (https://github.com/Netflix/RxNetty/issues/106) Added TLS support for TCP & HTTP (HTTPS)
+* [Issue 115] (https://github.com/Netflix/RxNetty/issues/115) ByteBuf leak fixed for both HTTP client and server.
+* [Issue 141] (https://github.com/Netflix/RxNetty/issues/141) ServerSentEventEncoder modified to match the specifications and the decoder.
+* [Issue 158] (https://github.com/Netflix/RxNetty/issues/158) HttpClientResponse and HttpServerRequest modified to take Subject instead of PublishSubject in the constructors.
+* [Issue 160] (https://github.com/Netflix/RxNetty/issues/160) ServerRequestResponseConverter was using the same content subject for all requests on a channel.
+* [Issue 164] (https://github.com/Netflix/RxNetty/issues/164) Removed flatmap() usage from HttpConnectionHandler for performance reasons.
+* [Issue 166] (https://github.com/Netflix/RxNetty/issues/166) RxServer modified to optionally use a separate acceptor eventloop group.
+* [Issue 167] (https://github.com/Netflix/RxNetty/issues/167) Not sending "Connection: keep-alive" header for HTTP 1.1 requests.
+
+Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.rxnetty%22%20AND%20v%3A%220.3.7%22)
+
 ### Version 0.3.6 ###
 
 [Milestone](https://github.com/Netflix/RxNetty/issues?milestone=2&state=closed)

--- a/rx-netty-contexts/build.gradle
+++ b/rx-netty-contexts/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+
+
 apply plugin: 'osgi'
 
 sourceCompatibility = JavaVersion.VERSION_1_6
@@ -21,6 +23,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 dependencies {
     compile project(':rx-netty')
+    testCompile project(':rx-netty-servo')
     testCompile 'junit:junit:4.10'
 }
 

--- a/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RxContexts.java
+++ b/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RxContexts.java
@@ -119,10 +119,11 @@ public final class RxContexts {
             RequestIdProvider provider, RequestCorrelator correlator, 
             PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> httpConfigurator) {
         HttpClientBuilder<I, O> builder = RxNetty.newHttpClientBuilder(host, port);
-        return builder.pipelineConfigurator(ContextPipelineConfigurators.<I, O>httpClientConfigurator(provider,
-                correlator, httpConfigurator))
-                .withChannelFactory(new HttpContextClientChannelFactory<I, O>(builder.getBootstrap(),
-                        correlator));
+        return builder.pipelineConfigurator(ContextPipelineConfigurators.httpClientConfigurator(provider,
+                                                                                                correlator,
+                                                                                                httpConfigurator))
+                .withChannelFactory(new HttpContextClientChannelFactory<I, O>(builder.getBootstrap(), correlator,
+                                                                              builder.getEventsSubject()));
     }
 
 

--- a/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RxContexts.java
+++ b/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RxContexts.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.contexts;
 
 import io.netty.buffer.ByteBuf;
@@ -88,7 +89,8 @@ public final class RxContexts {
         return builder.pipelineConfigurator(ContextPipelineConfigurators.<I, O>httpClientConfigurator(provider,
                                                                                                       correlator))
                       .withChannelFactory(new HttpContextClientChannelFactory<I, O>(builder.getBootstrap(),
-                                                                                    correlator));
+                                                                                    correlator,
+                                                                                    builder.getEventsSubject()));
     }
 
     public static HttpServer<ByteBuf, ByteBuf> createHttpServer(int port, RequestHandler<ByteBuf, ByteBuf> requestHandler) {

--- a/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/http/HttpContextClientChannelFactory.java
+++ b/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/http/HttpContextClientChannelFactory.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.contexts.http;
 
 import io.netty.bootstrap.Bootstrap;
@@ -20,9 +21,11 @@ import io.netty.channel.ChannelFuture;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.client.ClientChannelFactoryImpl;
 import io.reactivex.netty.client.ClientConnectionFactory;
+import io.reactivex.netty.client.ClientMetricsEvent;
 import io.reactivex.netty.client.RxClient;
 import io.reactivex.netty.contexts.ContextsContainer;
 import io.reactivex.netty.contexts.RequestCorrelator;
+import io.reactivex.netty.metrics.MetricEventsSubject;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
 import io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import rx.Subscriber;
@@ -37,8 +40,9 @@ public class HttpContextClientChannelFactory<I, O> extends
 
     private final RequestCorrelator correlator;
 
-    public HttpContextClientChannelFactory(Bootstrap clientBootstrap, RequestCorrelator correlator) {
-        super(clientBootstrap);
+    public HttpContextClientChannelFactory(Bootstrap clientBootstrap, RequestCorrelator correlator,
+                                           MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject) {
+        super(clientBootstrap, eventsSubject);
         this.correlator = correlator;
     }
 

--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/MetricsTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/MetricsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.contexts;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.client.CompositePoolLimitDeterminationStrategy;
+import io.reactivex.netty.client.MaxConnectionsBasedStrategy;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientBuilder;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import io.reactivex.netty.servo.http.HttpClientListener;
+import org.junit.Assert;
+import org.junit.Test;
+import rx.Observable;
+import rx.functions.Func1;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author Nitesh Kant
+ */
+public class MetricsTest {
+
+    @Test
+    public void testConnectionPoolMetrics() throws InterruptedException, ExecutionException, TimeoutException {
+        HttpClientBuilder<ByteBuf, ByteBuf> builder = RxContexts.newHttpClientBuilder("www.google.com", 80, RxContexts.DEFAULT_CORRELATOR);
+        HttpClient<ByteBuf, ByteBuf> client = builder.withConnectionPoolLimitStrategy(new CompositePoolLimitDeterminationStrategy(
+                new MaxConnectionsBasedStrategy(100), new MaxConnectionsBasedStrategy(100))).build();
+        HttpClientListener listener = HttpClientListener.newHttpListener("default");
+        client.subscribe(listener);
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.createGet("/");
+        client.submit(request).flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>>(){
+            @Override
+            public Observable<ByteBuf> call(HttpClientResponse<ByteBuf> t1) {
+                return t1.getContent();
+            }
+        }).map(new Func1<ByteBuf, String>(){
+            @Override
+            public String call(ByteBuf t1) {
+                return t1.toString(Charset.defaultCharset());
+            }
+        }).toBlocking().toFuture().get(1, TimeUnit.MINUTES);
+        Assert.assertEquals("Unexpected connection count.", 1, listener.getConnectionCount());
+        Assert.assertEquals("Unexpected pool acquire count.", 1, listener.getPoolAcquires());
+    }
+}

--- a/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/HttpClientListener.java
+++ b/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/HttpClientListener.java
@@ -214,7 +214,7 @@ public class HttpClientListener extends TcpClientListener<ClientMetricsEvent<?>>
 
         @Override
         protected void onPoolAcquireSuccess(long duration, TimeUnit timeUnit) {
-            HttpClientListener.this.onPoolReleaseSuccess(duration, timeUnit);
+            HttpClientListener.this.onPoolAcquireSuccess(duration, timeUnit);
         }
 
         @Override


### PR DESCRIPTION
The client connection factory created by RxContexts was not having the reference to the eventsubject.
This made the connection factory create a fresh subject.
Fixed the same and added the testcase for this.
