### PR TITLE
Fixes issue #177

### DIFF
--- a/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
+++ b/rx-netty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.contexts.http;
 
 import com.netflix.server.context.ContextSerializationException;
@@ -249,7 +250,7 @@ public class ContextPropagationTest {
                             @Override
                             public Observable<Void> call(HttpClientResponse<ByteBuf> response) {
                                 serverResponse.setStatus(response.getStatus());
-                                return Observable.empty();
+                                return serverResponse.close(true);
                             }
                         });
             }

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/helloworld/HelloWorldServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/helloworld/HelloWorldServer.java
@@ -46,7 +46,7 @@ public final class HelloWorldServer {
             public Observable<Void> handle(HttpServerRequest<ByteBuf> request, final HttpServerResponse<ByteBuf> response) {
                 printRequestHeader(request);
                 response.writeString("Welcome!!");
-                return response.close();
+                return response.close(false);
             }
         }).pipelineConfigurator(PipelineConfigurators.<ByteBuf, ByteBuf>httpServerConfigurator()).build();
 

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/post/SimplePostServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/post/SimplePostServer.java
@@ -59,7 +59,7 @@ public class SimplePostServer {
                     @Override
                     public Observable<Void> call(String clientMessage) {
                         response.writeString(clientMessage.toUpperCase());
-                        return response.close();
+                        return response.close(false);
                     }
                 });
             }

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/SslHelloWorldServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/SslHelloWorldServer.java
@@ -43,7 +43,7 @@ public final class SslHelloWorldServer {
             @Override
             public Observable<Void> handle(HttpServerRequest<ByteBuf> request, final HttpServerResponse<ByteBuf> response) {
                 response.writeStringAndFlush("Welcome!!");
-                return response.close();
+                return response.close(false);
             }
         }).withSslEngineFactory(DefaultFactories.SELF_SIGNED).build();
 

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/wordcounter/WordCounterServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/wordcounter/WordCounterServer.java
@@ -60,7 +60,7 @@ public final class WordCounterServer {
                                   @Override
                                   public Observable<Void> call(Integer counter) {
                                       response.writeString(counter.toString());
-                                      return response.close();
+                                      return response.close(false);
                                   }
                               });
             }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/ChannelWriter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/ChannelWriter.java
@@ -47,4 +47,8 @@ public interface ChannelWriter<O> {
     Observable<Void> writeBytesAndFlush(byte[] msg);
 
     Observable<Void> writeStringAndFlush(String msg);
+
+    Observable<Void> close();
+
+    Observable<Void> close(boolean flush);
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/DefaultChannelWriter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/DefaultChannelWriter.java
@@ -23,7 +23,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.reactivex.netty.metrics.Clock;
 import io.reactivex.netty.metrics.MetricEventsSubject;
-import io.reactivex.netty.protocol.http.MultipleFutureListener;
+import io.reactivex.netty.util.MultipleFutureListener;
 import rx.Observable;
 import rx.functions.Action0;
 import rx.functions.Action1;
@@ -147,7 +147,6 @@ public class DefaultChannelWriter<O> implements ChannelWriter<O> {
         return ctx;
     }
 
-    @SuppressWarnings("unchecked")
     protected ChannelFuture writeOnChannel(Object msg) {
         ChannelFuture writeFuture = getChannel().write(msg); // Calling write on context will be wrong as the context will be of a component not necessarily, the tail of the pipeline.
         unflushedWritesListener.get().listen(writeFuture);
@@ -162,16 +161,21 @@ public class DefaultChannelWriter<O> implements ChannelWriter<O> {
         return closeIssued.get();
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
     public Observable<Void> close() {
+        return close(false);
+    }
+
+    @Override
+    public Observable<Void> close(boolean flush) {
         if (closeIssued.compareAndSet(false, true)) {
-            return _close();
+            return _close(flush);
         } else {
             return CONNECTION_ALREADY_CLOSED;
         }
     }
 
-    protected Observable<Void> _close() {
+    protected Observable<Void> _close(boolean flush) {
         return Observable.empty();
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
@@ -37,7 +37,7 @@ import io.reactivex.netty.client.ClientMetricsEvent;
 import io.reactivex.netty.client.ConnectionReuseEvent;
 import io.reactivex.netty.metrics.Clock;
 import io.reactivex.netty.metrics.MetricEventsSubject;
-import io.reactivex.netty.protocol.http.MultipleFutureListener;
+import io.reactivex.netty.util.MultipleFutureListener;
 import rx.Observable;
 import rx.Subscriber;
 import rx.subjects.PublishSubject;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -133,7 +133,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                             public void onCompleted() {
                                 eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_SUCCESS,
                                                       Clock.onEndMillis(startTimeMillis));
-                                response.close();
+                                response.close(false);
                             }
 
                             @Override
@@ -143,7 +143,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                                 if (!response.isHeaderWritten()) {
                                     responseGenerator.updateResponse(response, throwable);
                                 }
-                                response.close();
+                                response.close(false);
                             }
 
                             @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
@@ -85,7 +86,27 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
     }
 
     @Override
-    public Observable<Void> _close() {
+    public Observable<Void> close() {
+        return close(true);
+    }
+
+    /**
+     * Closes this response with optionally flushing the writes. <br/>
+     *
+     * <b>Unless it is required by the usecase, it is generally more optimal to leave the decision of when to flush to
+     * the framework as that enables a gathering write on the underlying socket, which is more optimal.</b>
+     *
+     * @param flush If this close should also flush the writes.
+     *
+     * @return Observable representing the close result.
+     */
+    @Override
+    public Observable<Void> close(boolean flush) {
+        return super.close(flush);
+    }
+
+    @Override
+    public Observable<Void> _close(boolean flush) {
 
         writeHeadersIfNotWritten();
 
@@ -94,7 +115,7 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
             // sent for keep-alive connections, netty's HTTP codec will not know that the response has ended and hence
             // will ignore the subsequent HTTP header writes. See issue: https://github.com/Netflix/RxNetty/issues/130
         }
-        return flush();
+        return flush ? flush() : Observable.<Void>empty();
     }
 
     HttpResponse getNettyResponse() {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
@@ -114,7 +114,12 @@ public class ServerRequestResponseConverter extends ChannelDuplexHandler {
         } else {
             super.write(ctx, msg, promise); // pass through, since we do not understand this message.
         }
+    }
 
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        super.channelReadComplete(ctx);
+        ctx.pipeline().flush(); // If there is nothing to flush, this is a short-circuit in netty.
     }
 
     private void addWriteCompleteEvents(ChannelPromise promise, final long startTimeMillis,

--- a/rx-netty/src/main/java/io/reactivex/netty/util/MultipleFutureListener.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/util/MultipleFutureListener.java
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.reactivex.netty.protocol.http;
+
+package io.reactivex.netty.util;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -43,6 +44,9 @@ public class MultipleFutureListener implements ChannelFutureListener {
         completionObservable = Observable.create(new Observable.OnSubscribe<Void>() {
             @Override
             public void call(final Subscriber<? super Void> subscriber) {
+                if (listeningToCount.get() == 0) {
+                    MultipleFutureListener.this.completionPromise.trySuccess();
+                }
                 MultipleFutureListener.this.completionPromise.addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {

--- a/rx-netty/src/main/java/io/reactivex/netty/util/NoOpSubscriber.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/util/NoOpSubscriber.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.util;
+
+import rx.Subscriber;
+
+/**
+ * A subscriber that does nothing.
+ *
+ * @author Nitesh Kant
+ */
+public class NoOpSubscriber<T> extends Subscriber<T> {
+
+    @Override
+    public void onCompleted() {
+    }
+
+    @Override
+    public void onError(Throwable e) {
+    }
+
+    @Override
+    public void onNext(T next) {
+    }
+}

--- a/rx-netty/src/test/java/io/reactivex/netty/NoOpChannelHandlerContext.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/NoOpChannelHandlerContext.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty;
 
 import io.netty.buffer.ByteBufAllocator;
@@ -33,7 +34,6 @@ import io.netty.util.DefaultAttributeMap;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
-import javax.naming.OperationNotSupportedException;
 import java.net.SocketAddress;
 
 /**
@@ -43,7 +43,7 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
 
     private final DefaultAttributeMap attributeMap = new DefaultAttributeMap();
     private final Channel channel;
-    private final DefaultChannelPromise failedPromise;
+    private final DefaultChannelPromise completedPromise;
 
     public NoOpChannelHandlerContext() {
         this(new LocalChannel());
@@ -51,8 +51,8 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
 
     public NoOpChannelHandlerContext(Channel channel) {
         this.channel = channel;
-        failedPromise = new DefaultChannelPromise(this.channel, executor());
-        failedPromise.setFailure(new OperationNotSupportedException());
+        completedPromise = new DefaultChannelPromise(this.channel, executor());
+        completedPromise.setSuccess();
     }
 
     @Override
@@ -138,65 +138,65 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
 
     @Override
     public ChannelFuture bind(SocketAddress localAddress) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture connect(SocketAddress remoteAddress) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture disconnect() {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture close() {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     @Deprecated
     public ChannelFuture deregister() {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress,
                                  ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture disconnect(ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture close(ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     @Deprecated
     public ChannelFuture deregister(ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
@@ -206,22 +206,22 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
 
     @Override
     public ChannelFuture write(Object msg) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture write(Object msg, ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture writeAndFlush(Object msg) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
@@ -236,7 +236,7 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
 
     @Override
     public ChannelPromise newPromise() {
-        return failedPromise;
+        return new DefaultChannelPromise(channel, executor());
     }
 
     @Override
@@ -246,16 +246,16 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
 
     @Override
     public ChannelFuture newSucceededFuture() {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelFuture newFailedFuture(Throwable cause) {
-        return failedPromise;
+        return completedPromise;
     }
 
     @Override
     public ChannelPromise voidPromise() {
-        return failedPromise;
+        return completedPromise;
     }
 }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
@@ -90,7 +91,7 @@ public class HttpServerTest {
                                      @Override
                                      public Observable<Void> call(Long aLong) {
                                          serverResponse.setStatus(HttpResponseStatus.NOT_FOUND);
-                                         return Observable.empty();
+                                         return serverResponse.close(true); // Processing in a separate thread needs a flush.
                                      }
                                  });
             }
@@ -120,7 +121,7 @@ public class HttpServerTest {
                                   @Override
                                   public Observable<Void> call(HttpClientResponse<ByteBuf> response) {
                                       serverResponse.setStatus(response.getStatus());
-                                      return Observable.empty();
+                                      return serverResponse.close(true); // Processing in a separate thread needs a flush.
                                   }
                               });
             }

--- a/rx-netty/src/test/java/io/reactivex/netty/util/MultipleFutureListenerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/util/MultipleFutureListenerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.util;
+
+import io.reactivex.netty.NoOpChannelHandlerContext;
+import org.junit.Test;
+import rx.functions.Action0;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Nitesh Kant
+ */
+public class MultipleFutureListenerTest {
+
+    @Test
+    public void testCompletionWhenNoFuture() throws Exception {
+        NoOpChannelHandlerContext context = new NoOpChannelHandlerContext();
+        MultipleFutureListener listener = new MultipleFutureListener(context.newPromise());
+        final CountDownLatch completionLatch = new CountDownLatch(1);
+        listener.asObservable().doOnTerminate(new Action0() {
+            @Override
+            public void call() {
+                completionLatch.countDown();
+            }
+        }).subscribe();
+        completionLatch.await(1, TimeUnit.MINUTES);
+    }
+}


### PR DESCRIPTION
- Provided a ChannelWriter.close(boolean flush) method that provides a close without flush functionality.
- Added a flush in onChannelReadComplete() for ServerRequestResponseConverter.

With this change, if the server's RequestHandler calls response.close(false) then the flush will only be done when the channel read completes.
