### PR TITLE
HTTP client/server metrics are not getting published to servo.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@
 
 [Milestone](https://github.com/Netflix/RxNetty/issues?milestone=7&state=closed)
 
-* [Pull 179] (https://github.com/Netflix/RxNetty/issues/179) Monitors were not getting registered with servo
+* [Pull 179] (https://github.com/Netflix/RxNetty/issues/179) Monitors were not getting registered with servo.
+* [Pull 180] (https://github.com/Netflix/RxNetty/issues/180) HTTP client/server metrics are not getting published to servo.
 
 Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.rxnetty%22%20AND%20v%3A%220.3.9%22)
 

--- a/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/HttpClientListener.java
+++ b/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/HttpClientListener.java
@@ -36,10 +36,27 @@ import static io.reactivex.netty.servo.ServoUtils.newLongGauge;
  */
 public class HttpClientListener extends TcpClientListener<ClientMetricsEvent<?>> {
 
+    private final LongGauge requestBacklog;
+    private final LongGauge inflightRequests;
+    private final Counter processedRequests;
+    private final Counter requestWriteFailed;
+    private final Counter failedResponses;
+    private final Timer requestWriteTimes;
+    private final Timer responseReadTimes;
+    private final Timer requestProcessingTimes;
+
     private final HttpClientMetricEventsListenerImpl delegate = new HttpClientMetricEventsListenerImpl();
 
     protected HttpClientListener(String monitorId) {
         super(monitorId);
+        requestBacklog = newLongGauge("requestBacklog");
+        inflightRequests = newLongGauge("inflightRequests");
+        requestWriteTimes = newTimer("requestWriteTimes");
+        responseReadTimes = newTimer("responseReadTimes");
+        processedRequests = newCounter("processedRequests");
+        requestWriteFailed = newCounter("requestWriteFailed");
+        failedResponses = newCounter("failedResponses");
+        requestProcessingTimes = newTimer("requestProcessingTimes");
     }
 
     @Override
@@ -53,54 +70,34 @@ public class HttpClientListener extends TcpClientListener<ClientMetricsEvent<?>>
     }
 
     public long getRequestBacklog() {
-        return delegate.requestBacklog.getNumber().get();
+        return requestBacklog.getNumber().get();
     }
 
     public long getInflightRequests() {
-        return delegate.inflightRequests.getNumber().get();
+        return inflightRequests.getNumber().get();
     }
 
     public long getProcessedRequests() {
-        return delegate.processedRequests.getValue().longValue();
+        return processedRequests.getValue().longValue();
     }
 
     public long getRequestWriteFailed() {
-        return delegate.requestWriteFailed.getValue().longValue();
+        return requestWriteFailed.getValue().longValue();
     }
 
     public long getFailedResponses() {
-        return delegate.failedResponses.getValue().longValue();
+        return failedResponses.getValue().longValue();
     }
 
     public Timer getRequestWriteTimes() {
-        return delegate.requestWriteTimes;
+        return requestWriteTimes;
     }
 
     public Timer getResponseReadTimes() {
-        return delegate.responseReadTimes;
+        return responseReadTimes;
     }
 
     private class HttpClientMetricEventsListenerImpl extends HttpClientMetricEventsListener {
-
-        private final LongGauge requestBacklog;
-        private final LongGauge inflightRequests;
-        private final Counter processedRequests;
-        private final Counter requestWriteFailed;
-        private final Counter failedResponses;
-        private final Timer requestWriteTimes;
-        private final Timer responseReadTimes;
-        private final Timer requestProcessingTimes;
-
-        private HttpClientMetricEventsListenerImpl() {
-            requestBacklog = newLongGauge("requestBacklog");
-            inflightRequests = newLongGauge("inflightRequests");
-            requestWriteTimes = newTimer("requestWriteTimes");
-            responseReadTimes = newTimer("responseReadTimes");
-            processedRequests = newCounter("processedRequests");
-            requestWriteFailed = newCounter("requestWriteFailed");
-            failedResponses = newCounter("failedResponses");
-            requestProcessingTimes = newTimer("requestProcessingTimes");
-        }
 
         @Override
         protected void onRequestProcessingComplete(long duration, TimeUnit timeUnit) {

--- a/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/HttpServerListener.java
+++ b/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/HttpServerListener.java
@@ -36,10 +36,26 @@ import static io.reactivex.netty.servo.ServoUtils.newLongGauge;
  */
 public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>> {
 
-    private final HttpServerMetricEventsListenerImpl delegate = new HttpServerMetricEventsListenerImpl();
+    private final LongGauge requestBacklog;
+    private final LongGauge inflightRequests;
+    private final Counter processedRequests;
+    private final Counter failedRequests;
+    private final Counter responseWriteFailed;
+    private final Timer responseWriteTimes;
+    private final Timer requestReadTimes;
+
+    private final HttpServerMetricEventsListenerImpl delegate;
 
     protected HttpServerListener(String monitorId) {
         super(monitorId);
+        requestBacklog = newLongGauge("requestBacklog");
+        inflightRequests = newLongGauge("inflightRequests");
+        responseWriteTimes = newTimer("responseWriteTimes");
+        requestReadTimes = newTimer("requestReadTimes");
+        processedRequests = newCounter("processedRequests");
+        failedRequests = newCounter("failedRequests");
+        responseWriteFailed = newCounter("responseWriteFailed");
+        delegate = new HttpServerMetricEventsListenerImpl();
     }
 
     @Override
@@ -49,31 +65,31 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
     }
 
     public long getRequestBacklog() {
-        return delegate.requestBacklog.getValue().longValue();
+        return requestBacklog.getValue().longValue();
     }
 
     public long getInflightRequests() {
-        return delegate.inflightRequests.getValue().longValue();
+        return inflightRequests.getValue().longValue();
     }
 
     public long getProcessedRequests() {
-        return delegate.processedRequests.getValue().longValue();
+        return processedRequests.getValue().longValue();
     }
 
     public long getFailedRequests() {
-        return delegate.failedRequests.getValue().longValue();
+        return failedRequests.getValue().longValue();
     }
 
     public long getResponseWriteFailed() {
-        return delegate.responseWriteFailed.getValue().longValue();
+        return responseWriteFailed.getValue().longValue();
     }
 
     public Timer getResponseWriteTimes() {
-        return delegate.responseWriteTimes;
+        return responseWriteTimes;
     }
 
     public Timer getRequestReadTimes() {
-        return delegate.requestReadTimes;
+        return requestReadTimes;
     }
 
     public static HttpServerListener newHttpListener(String monitorId) {
@@ -81,24 +97,6 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
     }
 
     private class HttpServerMetricEventsListenerImpl extends HttpServerMetricEventsListener {
-
-        private final LongGauge requestBacklog;
-        private final LongGauge inflightRequests;
-        private final Counter processedRequests;
-        private final Counter failedRequests;
-        private final Counter responseWriteFailed;
-        private final Timer responseWriteTimes;
-        private final Timer requestReadTimes;
-
-        private HttpServerMetricEventsListenerImpl() {
-            requestBacklog = newLongGauge("requestBacklog");
-            inflightRequests = newLongGauge("inflightRequests");
-            responseWriteTimes = newTimer("responseWriteTimes");
-            requestReadTimes = newTimer("requestReadTimes");
-            processedRequests = newCounter("processedRequests");
-            failedRequests = newCounter("failedRequests");
-            responseWriteFailed = newCounter("responseWriteFailed");
-        }
 
         @Override
         protected void onRequestHandlingFailed(long duration, TimeUnit timeUnit, Throwable throwable) {


### PR DESCRIPTION
The object holding the metrics was not identified by servo as it was not a monitor.
Moved the monitors to the parent class.
