### PR TITLE
Adding an option to use a threadpool for Request/Connection processing.

### DIFF
--- a/rx-netty-examples/README.md
+++ b/rx-netty-examples/README.md
@@ -12,6 +12,7 @@ Protocol | Example / Test | Description
 HTTP | [Plain text](src/main/java/io/reactivex/netty/examples/http/plaintext)              | A performance optimized helloworld. Use this as a template for any simple perf tests.
 HTTP | [Hello World](src/main/java/io/reactivex/netty/examples/http/helloworld)            | Simple HTTP GET client/server implementation.
 HTTP | [SSL Hello World](src/main/java/io/reactivex/netty/examples/http/ssl)               | Hello World version with SSL connection.
+HTTP | [CPU intensive work](src/main/java/io/reactivex/netty/examples/http/cpuintensive)   | Hello World for CPU intensive request processing.
 HTTP | [Simple POST](src/main/java/io/reactivex/netty/examples/http/post)                  | Simple HTTP POST client/server implementation.
 HTTP | [Chunked GET](src/main/java/io/reactivex/netty/examples/http/chunk)                 | An example of how to handle large, chunked reply that is not pre-aggregated by the default pipline configurator.
 HTTP | [Server Side Events](src/main/java/io/reactivex/netty/examples/http/sse)            | This examples demonstrates how to implement server side event stream, and how to handle it on the client side.
@@ -21,6 +22,7 @@ TCP  | [Echo Server](src/main/java/io/reactivex/netty/examples/tcp/echo)        
 TCP  | [SSL Echo Server](src/main/java/io/reactivex/netty/examples/tcp/ssl)                | A simple echo client with SSL connection.
 TCP  | [TCP Server Side Event Stream](src/main/java/io/reactivex/netty/examples/tcp/event) | TCP server side event stream example, with configurable client side processing delay.
 TCP  | [Interval](src/main/java/io/reactivex/netty/examples/tcp/interval)                  | A bit more sophisticated event stream example, with explicit subscribe/unsubscribe control mechanism.
+TCP  | [CPU intensive work](src/main/java/io/reactivex/netty/examples/tcp/cpuintensive)    | A simple example for cpu intensive connection handling.
 UDP  | [Hello World](src/main/java/io/reactivex/netty/examples/udp)                        | UDP version of a simple request - reply client/server implementation.
 
 Build

--- a/rx-netty-examples/build.gradle
+++ b/rx-netty-examples/build.gradle
@@ -18,6 +18,8 @@
 
 
 
+
+
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 
@@ -60,6 +62,40 @@ task runPlainTextClient (dependsOn: [classes], type: JavaExec) {
     description = "Run Plain text HTTP client"
 
     args "8111"
+    main = "io.reactivex.netty.examples.http.helloworld.HelloWorldClient"
+    classpath = sourceSets.main.runtimeClasspath
+}
+
+task runCpuIntensiveHttpServer (dependsOn: [classes], type: JavaExec) {
+    group = "Examples"
+    description = "Run an HTTP server which does CPU intensive work."
+
+    main = "io.reactivex.netty.examples.http.plaintext.PlainTextServer"
+    classpath = sourceSets.main.runtimeClasspath
+}
+
+task runCpuIntensiveHttpClient (dependsOn: [classes], type: JavaExec) {
+    group = "Examples"
+    description = "Run an HTTP client for the CPU intensive server."
+
+    args "8790"
+    main = "io.reactivex.netty.examples.http.helloworld.HelloWorldClient"
+    classpath = sourceSets.main.runtimeClasspath
+}
+
+task runCpuIntensiveTcpServer (dependsOn: [classes], type: JavaExec) {
+    group = "Examples"
+    description = "Run a TCP server which does CPU intensive work."
+
+    main = "io.reactivex.netty.examples.http.plaintext.PlainTextServer"
+    classpath = sourceSets.main.runtimeClasspath
+}
+
+task runCpuIntensiveTcpClient (dependsOn: [classes], type: JavaExec) {
+    group = "Examples"
+    description = "Run a TCP client for the CPU intensive server."
+
+    args "8790"
     main = "io.reactivex.netty.examples.http.helloworld.HelloWorldClient"
     classpath = sourceSets.main.runtimeClasspath
 }

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/CPUIntensiveServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/CPUIntensiveServer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.examples.http.cpuintensive;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.pipeline.PipelineConfigurators;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+import rx.Observable;
+
+import java.util.Map;
+
+/**
+ * @author Nitesh Kant
+ */
+public final class CPUIntensiveServer {
+
+    static final int DEFAULT_PORT = 8790;
+    public static final String IN_EVENT_LOOP_HEADER_NAME = "in_event_loop";
+
+    private final int port;
+
+    public CPUIntensiveServer(int port) {
+        this.port = port;
+    }
+
+    public HttpServer<ByteBuf, ByteBuf> createServer() {
+        HttpServer<ByteBuf, ByteBuf> server =
+                RxNetty.newHttpServerBuilder(port, new RequestHandler<ByteBuf, ByteBuf>() {
+                    @Override
+                    public Observable<Void> handle(HttpServerRequest<ByteBuf> request,
+                                                   final HttpServerResponse<ByteBuf> response) {
+                        printRequestHeader(request);
+                        response.getHeaders().set(IN_EVENT_LOOP_HEADER_NAME,
+                                                  response.getChannelHandlerContext().channel().eventLoop()
+                                                          .inEventLoop());
+                        response.writeString("Welcome!!");
+                        return response.close(false);
+                    }
+                }).pipelineConfigurator(PipelineConfigurators.<ByteBuf, ByteBuf>httpServerConfigurator())
+                       .withRequestProcessingThreads(50) /*Uses a thread pool of 50 threads to process the requests.*/
+                       .build();
+        return server;
+    }
+
+    public void printRequestHeader(HttpServerRequest<ByteBuf> request) {
+        System.out.println("New request received");
+        System.out.println(request.getHttpMethod() + " " + request.getUri() + ' ' + request.getHttpVersion());
+        for (Map.Entry<String, String> header : request.getHeaders().entries()) {
+            System.out.println(header.getKey() + ": " + header.getValue());
+        }
+    }
+
+    public static void main(final String[] args) {
+        new CPUIntensiveServer(DEFAULT_PORT).createServer().startAndWait();
+    }
+}

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/README.md
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/README.md
@@ -1,0 +1,26 @@
+Overview
+========
+
+An example of how to write a server which does some CPU intensive or Blocking work and hence is not suitable for running
+the request processing in the channel's event loop.
+This is achieved by using netty's [`EventExecutorGroup`](https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java) 
+as a threadpool.
+`RxNetty` makes sure that the [`RequestHandler`](https://github.com/Netflix/RxNetty/blob/master/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandler.java)
+as well as the subscribers of `HttpServerRequest`'s content happens on this executor.
+
+Running
+=======
+
+To run the example execute:
+
+```
+$ cd RxNetty/rx-netty-examples
+$ ../gradlew runCpuIntensiveHttpServer
+```
+
+and in another console:
+
+```
+$ cd RxNetty/rx-netty-examples
+$ ../gradlew runCpuIntensiveHttpClient
+```

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/cpuintensive/CPUIntensiveServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/cpuintensive/CPUIntensiveServer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.examples.tcp.cpuintensive;
+
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.channel.ConnectionHandler;
+import io.reactivex.netty.channel.ObservableConnection;
+import io.reactivex.netty.channel.RxDefaultThreadFactory;
+import io.reactivex.netty.pipeline.PipelineConfigurators;
+import io.reactivex.netty.server.RxServer;
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * @author Nitesh Kant
+ */
+public final class CPUIntensiveServer {
+
+    static final int DEFAULT_PORT = 8791;
+
+    private final int port;
+
+    public CPUIntensiveServer(int port) {
+        this.port = port;
+    }
+
+    public RxServer<String, String> createServer() {
+        RxServer<String, String> server =
+                RxNetty.newTcpServerBuilder(port, new ConnectionHandler<String, String>() {
+                                            @Override
+                                            public Observable<Void> handle(
+                                                    final ObservableConnection<String, String> connection) {
+                                                System.out.println("New client connection established.");
+                                                connection.writeAndFlush("Welcome! \n\n");
+                                                return connection.getInput()
+                                                                 .flatMap(new Func1<String, Observable<Void>>() {
+                                                                     @Override
+                                                                     public Observable<Void> call(String msg) {
+                                                                         System.out.println("onNext: " + msg);
+                                                                         msg = msg.trim();
+                                                                         if (!msg.isEmpty()) {
+                                                                             return connection.writeAndFlush(
+                                                                                     "echo => " + msg + '\n');
+                                                                         } else {
+                                                                             return Observable.empty();
+                                                                         }
+                                                                     }
+                                                                 });
+                                            }
+                                        })
+                       .pipelineConfigurator(PipelineConfigurators.textOnlyConfigurator())
+                       .withEventExecutorGroup(new DefaultEventExecutorGroup(50, new RxDefaultThreadFactory(
+                               "rx-connection-processor"))) /*Uses 50 threads to process connections.*/
+                       .build();
+        return server;
+    }
+
+    public static void main(final String[] args) {
+        new CPUIntensiveServer(DEFAULT_PORT).createServer().startAndWait();
+    }
+}

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/cpuintensive/README.md
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/cpuintensive/README.md
@@ -1,0 +1,26 @@
+Overview
+========
+
+An example of how to write a server which does some CPU intensive or Blocking work and hence is not suitable for running
+the connection processing in the channel's event loop.
+This is achieved by using netty's [`EventExecutorGroup`](https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java) 
+as a threadpool.
+`RxNetty` makes sure that the [`ConnectionHandler`](https://github.com/Netflix/RxNetty/blob/master/rx-netty/src/main/java/io/reactivex/netty/channel/ConnectionHandler.java)
+as well as the subscribers of `ObservableConnection`'s content happens on this executor.
+
+Running
+=======
+
+To run the example execute:
+
+```
+$ cd RxNetty/rx-netty-examples
+$ ../gradlew runCpuIntensiveTcpServer
+```
+
+and in another console:
+
+```
+$ cd RxNetty/rx-netty-examples
+$ ../gradlew runCpuIntensiveTcpClient
+```

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/TcpEchoClient.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/TcpEchoClient.java
@@ -102,6 +102,10 @@ public final class TcpEchoClient {
     }
 
     public static void main(String[] args) {
-        new TcpEchoClient(DEFAULT_PORT).sendEchos();
+        int port = DEFAULT_PORT;
+        if (args.length > 0) {
+            port = Integer.parseInt(args[0]);
+        }
+        new TcpEchoClient(port).sendEchos();
     }
 }

--- a/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/cpuintensive/CpuIntensiveServerTest.java
+++ b/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/cpuintensive/CpuIntensiveServerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.examples.http.cpuintensive;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.reactivex.netty.examples.ExamplesEnvironment;
+import io.reactivex.netty.examples.http.helloworld.HelloWorldClient;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.reactivex.netty.examples.http.cpuintensive.CPUIntensiveServer.DEFAULT_PORT;
+
+/**
+ * @author Tomasz Bak
+ */
+public class CpuIntensiveServerTest extends ExamplesEnvironment {
+
+    private HttpServer<ByteBuf, ByteBuf> server;
+
+    @Before
+    public void setupHttpHelloServer() {
+        server = new CPUIntensiveServer(DEFAULT_PORT).createServer();
+        server.start();
+    }
+
+    @After
+    public void stopServer() throws InterruptedException {
+        server.shutdown();
+    }
+
+    @Test
+    public void testRequestReplySequence() {
+        HelloWorldClient client = new HelloWorldClient(DEFAULT_PORT); // The client is no different than hello world.
+        HttpResponseStatus statusCode = client.sendHelloRequest();
+        Assert.assertEquals(HttpResponseStatus.OK, statusCode);
+    }
+}

--- a/rx-netty-examples/src/test/java/io/reactivex/netty/examples/tcp/cpuintensive/CPUIntensiveServerTest.java
+++ b/rx-netty-examples/src/test/java/io/reactivex/netty/examples/tcp/cpuintensive/CPUIntensiveServerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.examples.tcp.cpuintensive;
+
+import io.reactivex.netty.examples.ExamplesEnvironment;
+import io.reactivex.netty.examples.tcp.echo.TcpEchoClient;
+import io.reactivex.netty.server.RxServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.reactivex.netty.examples.tcp.cpuintensive.CPUIntensiveServer.DEFAULT_PORT;
+
+/**
+ * @author Tomasz Bak
+ */
+public class CPUIntensiveServerTest extends ExamplesEnvironment {
+
+    private RxServer<String, String> server;
+
+    @Before
+    public void setupServer() {
+        server = new CPUIntensiveServer(DEFAULT_PORT).createServer();
+        server.start();
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void testRequestReplySequence() {
+        TcpEchoClient client = new TcpEchoClient(DEFAULT_PORT);
+        List<String> reply = client.sendEchos();
+        Assert.assertEquals(10, reply.size());
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/server/UdpServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/server/UdpServer.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.udp.server;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.ConnectionHandler;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 import io.reactivex.netty.server.AbstractServer;
@@ -29,12 +31,22 @@ import io.reactivex.netty.server.AbstractServer;
 public class UdpServer<I, O> extends AbstractServer<I, O, Bootstrap, Channel, UdpServer<I, O>> {
 
     public UdpServer(Bootstrap bootstrap, int port, final ConnectionHandler<I, O> connectionHandler) {
-        this(bootstrap, port, null, connectionHandler);
+        this(bootstrap, port, connectionHandler, null);
+    }
+
+    public UdpServer(Bootstrap bootstrap, int port, final ConnectionHandler<I, O> connectionHandler,
+                     EventExecutorGroup connHandlingExecutor) {
+        this(bootstrap, port, null, connectionHandler, connHandlingExecutor);
     }
 
     public UdpServer(Bootstrap bootstrap, int port, final PipelineConfigurator<I, O> pipelineConfigurator,
                     final ConnectionHandler<I, O> connectionHandler) {
+        this(bootstrap, port, pipelineConfigurator, connectionHandler, null);
+    }
+
+    public UdpServer(Bootstrap bootstrap, int port, final PipelineConfigurator<I, O> pipelineConfigurator,
+                    final ConnectionHandler<I, O> connectionHandler, EventExecutorGroup connHandlingExecutor) {
         super(bootstrap, port);
-        bootstrap.handler(newChannelInitializer(pipelineConfigurator, connectionHandler));
+        bootstrap.handler(newChannelInitializer(pipelineConfigurator, connectionHandler, connHandlingExecutor));
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/server/UdpServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/server/UdpServerBuilder.java
@@ -60,9 +60,9 @@ public class UdpServerBuilder<I, O> extends AbstractServerBuilder<I, O, Bootstra
     @Override
     protected UdpServer<I, O> createServer() {
         if (null != pipelineConfigurator) {
-            return new UdpServer<I, O>(serverBootstrap, port, pipelineConfigurator, connectionHandler);
+            return new UdpServer<I, O>(serverBootstrap, port, pipelineConfigurator, connectionHandler, eventExecutorGroup);
         } else {
-            return new UdpServer<I, O>(serverBootstrap, port, connectionHandler);
+            return new UdpServer<I, O>(serverBootstrap, port, connectionHandler, eventExecutorGroup);
         }
     }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServer.java
@@ -28,6 +28,8 @@ import io.reactivex.netty.metrics.MetricEventsPublisher;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.Subscription;
 
 import java.net.InetSocketAddress;
@@ -41,6 +43,8 @@ import java.util.concurrent.atomic.AtomicReference;
 @SuppressWarnings("rawtypes")
 public class AbstractServer<I, O, B extends AbstractBootstrap<B, C>, C extends Channel, S extends AbstractServer>
         implements MetricEventsPublisher<ServerMetricsEvent<?>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractServer.class);
 
     protected enum ServerState {Created, Starting, Started, Shutdown}
 
@@ -87,6 +91,8 @@ public class AbstractServer<I, O, B extends AbstractBootstrap<B, C>, C extends C
         }
 
         serverStateRef.set(ServerState.Started); // It will come here only if this was the thread that transitioned to Starting
+
+        logger.info("Rx server started at port: " + getServerPort());
 
         return returnServer();
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServer.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.server;
 
 import io.netty.bootstrap.AbstractBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.ConnectionHandler;
 import io.reactivex.netty.channel.UnpooledConnectionFactory;
 import io.reactivex.netty.metrics.MetricEventsListener;
@@ -171,13 +173,14 @@ public class AbstractServer<I, O, B extends AbstractBootstrap<B, C>, C extends C
     }
 
     protected ChannelInitializer<Channel> newChannelInitializer(final PipelineConfigurator<I, O> pipelineConfigurator,
-                                                                      final ConnectionHandler<I, O> connectionHandler) {
+                                                                final ConnectionHandler<I, O> connectionHandler,
+                                                                final EventExecutorGroup connHandlingExecutor) {
         return new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ServerRequiredConfigurator<I, O> requiredConfigurator =
                         new ServerRequiredConfigurator<I, O>(connectionHandler, connectionFactory, errorHandler,
-                                                             eventsSubject);
+                                                             eventsSubject, connHandlingExecutor);
                 PipelineConfigurator<I, O> configurator;
                 if (null == pipelineConfigurator) {
                     configurator = requiredConfigurator;

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ConnectionHandler;
 import io.reactivex.netty.metrics.MetricEventsListener;
@@ -45,7 +46,8 @@ public abstract class AbstractServerBuilder<I, O, T extends AbstractBootstrap<T,
     protected final int port;
     protected LogLevel wireLogginLevel;
     protected MetricEventsListenerFactory eventListenersFactory;
-    private SSLEngineFactory sslEngineFactory;
+    protected EventExecutorGroup eventExecutorGroup;
+    protected SSLEngineFactory sslEngineFactory;
 
     protected AbstractServerBuilder(int port, T bootstrap, ConnectionHandler<I, O> connectionHandler) {
         if (null == connectionHandler) {
@@ -120,6 +122,22 @@ public abstract class AbstractServerBuilder<I, O, T extends AbstractBootstrap<T,
         this.eventListenersFactory = eventListenersFactory;
         return returnBuilder();
     }
+
+    /**
+     * If the passed executor is not {@code null} , the configured {@link ConnectionHandler} will be invoked in
+     * the passed {@link EventExecutorGroup}
+     *
+     * @param eventExecutorGroup The {@link EventExecutorGroup} in which to invoke the configured
+     *                           {@link ConnectionHandler}. Can be {@code null}, in which case, the
+     *                           {@link ConnectionHandler} is invoked in the channel's eventloop.
+     *
+     * @return This builder.
+     */
+    public B withEventExecutorGroup(EventExecutorGroup eventExecutorGroup) {
+        this.eventExecutorGroup = eventExecutorGroup;
+        return returnBuilder();
+    }
+
     public PipelineConfigurator<I, O> getPipelineConfigurator() {
         return pipelineConfigurator;
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/server/RxServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/RxServer.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.server;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ServerChannel;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.ConnectionHandler;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
 
@@ -30,8 +32,18 @@ public class RxServer<I, O> extends AbstractServer<I, O, ServerBootstrap, Server
 
     public RxServer(ServerBootstrap bootstrap, int port, final PipelineConfigurator<I, O> pipelineConfigurator,
                     final ConnectionHandler<I, O> connectionHandler) {
+        this(bootstrap, port, pipelineConfigurator, connectionHandler, null);
+    }
+
+    public RxServer(ServerBootstrap bootstrap, int port, final ConnectionHandler<I, O> connectionHandler,
+                    EventExecutorGroup connHandlingExecutor) {
+        this(bootstrap, port, null, connectionHandler, connHandlingExecutor);
+    }
+
+    public RxServer(ServerBootstrap bootstrap, int port, final PipelineConfigurator<I, O> pipelineConfigurator,
+                    final ConnectionHandler<I, O> connectionHandler, EventExecutorGroup connHandlingExecutor) {
         super(bootstrap, port);
         this.pipelineConfigurator = pipelineConfigurator;
-        bootstrap.childHandler(newChannelInitializer(pipelineConfigurator, connectionHandler));
+        bootstrap.childHandler(newChannelInitializer(pipelineConfigurator, connectionHandler, connHandlingExecutor));
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/server/ServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/ServerBuilder.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.server;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -37,7 +38,7 @@ public class ServerBuilder<I, O> extends ConnectionBasedServerBuilder<I,O, Serve
 
     @Override
     protected RxServer<I, O> createServer() {
-        return new RxServer<I, O>(serverBootstrap, port, pipelineConfigurator, connectionHandler);
+        return new RxServer<I, O>(serverBootstrap, port, pipelineConfigurator, connectionHandler, eventExecutorGroup);
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/server/ServerRequiredConfigurator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/ServerRequiredConfigurator.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.server;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.ConnectionHandler;
 import io.reactivex.netty.channel.ObservableConnectionFactory;
 import io.reactivex.netty.metrics.MetricEventsSubject;
@@ -43,7 +45,14 @@ public class ServerRequiredConfigurator<I, O> extends RxRequiredConfigurator<I,O
     public ServerRequiredConfigurator(final ConnectionHandler<I, O> connectionHandler,
                                       ObservableConnectionFactory<I, O> connectionFactory, ErrorHandler errorHandler,
                                       MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject) {
-        super(eventsSubject, ServerChannelMetricEventProvider.INSTANCE);
+        this(connectionHandler, connectionFactory, errorHandler, eventsSubject, null);
+    }
+
+    public ServerRequiredConfigurator(final ConnectionHandler<I, O> connectionHandler,
+                                      ObservableConnectionFactory<I, O> connectionFactory, ErrorHandler errorHandler,
+                                      MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject,
+                                      EventExecutorGroup connHandlingExecutor) {
+        super(eventsSubject, ServerChannelMetricEventProvider.INSTANCE, connHandlingExecutor);
         this.connectionHandler = connectionHandler;
         this.connectionFactory = connectionFactory;
         this.errorHandler = errorHandler;

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UnexpectedErrorsTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
@@ -72,7 +73,7 @@ public class UnexpectedErrorsTest {
     public void testErrorHandlerReturnsNull() throws Exception {
         TestableErrorHandler errorHandler = new TestableErrorHandler(null);
         server.withErrorHandler(errorHandler).start();
-
+        System.err.println("[testErrorHandlerReturnsNull] Server port: " + server.getServerPort());
         blockTillConnected(server.getServerPort());
         channelCloseListener.waitForClose(1, TimeUnit.MINUTES);
 
@@ -85,6 +86,8 @@ public class UnexpectedErrorsTest {
                 Observable.<Void>error(new IllegalStateException("I always throw an error.")));
 
         server.withErrorHandler(errorHandler).start();
+
+        System.err.println("[testConnectionHandlerReturnsError] Server port: " + server.getServerPort());
 
         blockTillConnected(server.getServerPort());
 


### PR DESCRIPTION
If HTTP Request processing or TCP connection handling is blocking or is cpu intensive, there isn't a straightforward way to handoff this processing from the channel's eventloop to a different threadpool.

 This change adds this feature. The examples for TCP and HTTP are added to rx-netty-examples under cpuintensive package.
