### PR TITLE
Fixes #187

### DIFF
--- a/rx-netty-examples/build.gradle
+++ b/rx-netty-examples/build.gradle
@@ -16,10 +16,6 @@
 
 
 
-
-
-
-
 sourceCompatibility = JavaVersion.VERSION_1_6
 targetCompatibility = JavaVersion.VERSION_1_6
 

--- a/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/cpuintensive/CpuIntensiveServerTest.java
+++ b/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/cpuintensive/CpuIntensiveServerTest.java
@@ -26,6 +26,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import static io.reactivex.netty.examples.http.cpuintensive.CPUIntensiveServer.DEFAULT_PORT;
 
 /**
@@ -47,9 +50,9 @@ public class CpuIntensiveServerTest extends ExamplesEnvironment {
     }
 
     @Test
-    public void testRequestReplySequence() {
+    public void testRequestReplySequence() throws InterruptedException, ExecutionException, TimeoutException {
         HelloWorldClient client = new HelloWorldClient(DEFAULT_PORT); // The client is no different than hello world.
-        HttpResponseStatus statusCode = client.sendHelloRequest();
+        HttpResponseStatus statusCode = client.sendHelloRequest().getStatus();
         Assert.assertEquals(HttpResponseStatus.OK, statusCode);
     }
 }

--- a/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/helloworld/HelloWorldTest.java
+++ b/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/helloworld/HelloWorldTest.java
@@ -25,6 +25,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import static io.reactivex.netty.examples.http.helloworld.HelloWorldServer.DEFAULT_PORT;
 
 /**
@@ -46,9 +49,9 @@ public class HelloWorldTest extends ExamplesEnvironment {
     }
 
     @Test
-    public void testRequestReplySequence() {
+    public void testRequestReplySequence() throws InterruptedException, ExecutionException, TimeoutException {
         HelloWorldClient client = new HelloWorldClient(DEFAULT_PORT);
-        HttpResponseStatus statusCode = client.sendHelloRequest();
+        HttpResponseStatus statusCode = client.sendHelloRequest().getStatus();
         Assert.assertEquals(HttpResponseStatus.OK, statusCode);
     }
 }

--- a/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/plaintext/PlainTextServerTest.java
+++ b/rx-netty-examples/src/test/java/io/reactivex/netty/examples/http/plaintext/PlainTextServerTest.java
@@ -26,6 +26,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import static io.reactivex.netty.examples.http.plaintext.PlainTextServer.DEFAULT_PORT;
 
 /**
@@ -47,9 +50,9 @@ public class PlainTextServerTest extends ExamplesEnvironment {
     }
 
     @Test
-    public void testRequestReplySequence() {
+    public void testRequestReplySequence() throws InterruptedException, ExecutionException, TimeoutException {
         HelloWorldClient client = new HelloWorldClient(DEFAULT_PORT); // The client is no different than hello world.
-        HttpResponseStatus statusCode = client.sendHelloRequest();
+        HttpResponseStatus statusCode = client.sendHelloRequest().getStatus();
         Assert.assertEquals(HttpResponseStatus.OK, statusCode);
     }
 }

--- a/rx-netty/build.gradle
+++ b/rx-netty/build.gradle
@@ -1,10 +1,3 @@
-apply plugin: 'osgi'
-apply plugin: 'groovy'
-
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
-
-
 /*
  * Copyright 2014 Netflix, Inc.
  *
@@ -20,7 +13,13 @@ targetCompatibility = JavaVersion.VERSION_1_6
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-sourceSets.test.java.srcDir 'src/main/java'
+
+
+apply plugin: 'osgi'
+apply plugin: 'groovy'
+
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
 
 tasks.withType(Javadoc).each {
     it.classpath = sourceSets.main.compileClasspath

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/FlatResponseOperator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/FlatResponseOperator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http.client;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+/**
+ * An operator to be used for a source of {@link HttpClientResponse} containing aggregated responses i.e. which does not
+ * have multiple HTTP chunks. This operator simplifies the handling of such a responses by flattening the content
+ * {@link Observable} into a single element producing a {@link ResponseHolder} object.
+ * See <a href="https://github.com/Netflix/RxNetty/issues/187">related issue</a> for details.
+ *
+ * @author Nitesh Kant
+ */
+public class FlatResponseOperator<T>
+        implements Observable.Operator<ResponseHolder<T>, HttpClientResponse<T>> {
+
+    public static <T> FlatResponseOperator<T> flatResponse() {
+        return new FlatResponseOperator<T>();
+    }
+
+    @Override
+    public Subscriber<? super HttpClientResponse<T>> call(final Subscriber<? super ResponseHolder<T>> child) {
+        return new Subscriber<HttpClientResponse<T>>() {
+            @Override
+            public void onCompleted() {
+                // Content complete propagates to the child subscriber.
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                child.onError(e);
+            }
+
+            @Override
+            public void onNext(final HttpClientResponse<T> response) {
+                response.getContent()
+                        .take(1)
+                        .map(new Func1<T, ResponseHolder<T>>() {
+                            @Override
+                            public ResponseHolder<T> call(T t) {
+                                return new ResponseHolder<T>(response, t);
+                            }
+                        }).subscribe(child);
+            }
+        };
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ResponseHolder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ResponseHolder.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http.client;
+
+/**
+ * @author Nitesh Kant
+ */
+public class ResponseHolder<T> {
+
+    private final HttpClientResponse<T> response;
+    private final T content;
+
+    public ResponseHolder(HttpClientResponse<T> response, T content) {
+        this.response = response;
+        this.content = content;
+    }
+
+    public HttpClientResponse<T> getResponse() {
+        return response;
+    }
+
+    public T getContent() {
+        return content;
+    }
+}


### PR DESCRIPTION
Added a `FlatResponseOperator` to flatten the content observable in`HTTPClientResponse` into a `ResponseHolder`

Updated the client examples to use this where applicable.
