### PR TITLE
Fixes #195

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # RxNetty Releases #
 
+### Version 0.3.11 ###
+
+[Milestone](https://github.com/Netflix/RxNetty/issues?milestone=9&state=closed)
+
+* [Issue 195] (https://github.com/Netflix/RxNetty/issues/195) RxClientImpl.shutdown() should not shutdown the eventloop.
+
+Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.rxnetty%22%20AND%20v%3A%220.3.11%22)
+
 ### Version 0.3.10 ###
 
 [Milestone](https://github.com/Netflix/RxNetty/issues?milestone=8&state=closed)

--- a/rx-netty/src/main/java/io/reactivex/netty/client/RxClientImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/RxClientImpl.java
@@ -169,12 +169,8 @@ public class RxClientImpl<I, O> implements RxClient<I, O> {
             return;
         }
 
-        try {
-            if (null != pool) {
-                pool.shutdown();
-            }
-        } finally {
-            clientBootstrap.group().shutdownGracefully();
+        if (null != pool) {
+            pool.shutdown();
         }
     }
 


### PR DESCRIPTION
RxClient.shutdown() was shutting down the eventloop.

This caused the following scenario impossible to work:

1) Create some clients
2) Shutdown all of them
3) Create another client & try to use it.

In the above scenario, at stage 3, the eventloop is shutdown and hence can not be used by the newly created client.

Removing the eventloop shutdown. Since, the eventloop is always a daemon, shutting it down isn't really necessary.
We will think about graceful JVM shutdown scenarios and hence a need to provide a global shutdown on RxNetty later.
