### PR TITLE
Disabling doclint for Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ allprojects {
         mavenLocal()
         mavenCentral() // maven { url: 'http://jcenter.bintray.com' }
     }
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
 }
 
 apply from: file('gradle/convention.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,9 @@ allprojects {
         mavenCentral() // maven { url: 'http://jcenter.bintray.com' }
     }
     tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
+        if(JavaVersion.current().isJava8Compatible()) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
     }
 }
 


### PR DESCRIPTION
RxNetty doesn't build on Java 8 because some of the java docs are not complaint to W3C standards. Please see http://stackoverflow.com/questions/22528767/jdk8-and-javadoc-has-become-very-strict for reference.
