### PR TITLE
Fixes #206

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ ext.githubProjectName = "RxNetty"
 
 buildscript {
     repositories {
-        mavenLocal()
+        //mavenLocal() // Enable in local builds if needed. This causes build to fail when local repo is corrupted.
         mavenCentral() // maven { url 'http://jcenter.bintray.com' }
     }
     apply from: file('gradle/buildscript.gradle'), to: buildscript 
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     repositories { 
-        mavenLocal()
+        //mavenLocal() // Enable in local builds if needed. This causes build to fail when local repo is corrupted.
         mavenCentral() // maven { url: 'http://jcenter.bintray.com' }
     }
     tasks.withType(Javadoc) {
@@ -22,6 +22,21 @@ allprojects {
 
 apply from: file('gradle/convention.gradle')
 apply from: file('gradle/maven.gradle')
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 //apply from: file('gradle/check.gradle')
 apply from: file('gradle/license.gradle')
 apply from: file('gradle/release.gradle')

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/websocket/WebSocketHelloClient.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/websocket/WebSocketHelloClient.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.examples.http.websocket;
-
-import java.util.concurrent.TimeUnit;
 
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
@@ -12,7 +25,9 @@ import rx.Notification;
 import rx.Observable;
 import rx.functions.Func1;
 
-import static io.reactivex.netty.examples.http.websocket.WebSocketHelloServer.*;
+import java.util.concurrent.TimeUnit;
+
+import static io.reactivex.netty.examples.http.websocket.WebSocketHelloServer.DEFAULT_PORT;
 
 /**
  * @author Tomasz Bak

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/websocket/WebSocketHelloServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/websocket/WebSocketHelloServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.examples.http.websocket;
 
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;

--- a/rx-netty-examples/src/test/resources/io/reactivex/netty/examples/http/websocket/WebSocketHelloTest.java
+++ b/rx-netty-examples/src/test/resources/io/reactivex/netty/examples/http/websocket/WebSocketHelloTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.examples.http.websocket;
 
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;

--- a/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/websocket/WebSocketClientListener.java
+++ b/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/websocket/WebSocketClientListener.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.servo.http.websocket;
-
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.monitor.LongGauge;
@@ -10,8 +23,13 @@ import io.reactivex.netty.metrics.WebSocketClientMetricEventsListener;
 import io.reactivex.netty.protocol.http.websocket.WebSocketClientMetricsEvent;
 import io.reactivex.netty.servo.tcp.TcpClientListener;
 
-import static com.netflix.servo.monitor.Monitors.*;
-import static io.reactivex.netty.servo.ServoUtils.*;
+import java.util.concurrent.TimeUnit;
+
+import static com.netflix.servo.monitor.Monitors.newCounter;
+import static com.netflix.servo.monitor.Monitors.newTimer;
+import static io.reactivex.netty.servo.ServoUtils.decrementLongGauge;
+import static io.reactivex.netty.servo.ServoUtils.incrementLongGauge;
+import static io.reactivex.netty.servo.ServoUtils.newLongGauge;
 
 /**
  * @author Tomasz Bak

--- a/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/websocket/WebSocketServerListener.java
+++ b/rx-netty-servo/src/main/java/io/reactivex/netty/servo/http/websocket/WebSocketServerListener.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.servo.http.websocket;
-
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.monitor.LongGauge;
@@ -9,8 +22,11 @@ import io.reactivex.netty.protocol.http.websocket.WebSocketServerMetricsEvent;
 import io.reactivex.netty.server.ServerMetricsEvent;
 import io.reactivex.netty.servo.tcp.TcpServerListener;
 
-import static com.netflix.servo.monitor.Monitors.*;
-import static io.reactivex.netty.servo.ServoUtils.*;
+import java.util.concurrent.TimeUnit;
+
+import static com.netflix.servo.monitor.Monitors.newCounter;
+import static io.reactivex.netty.servo.ServoUtils.incrementLongGauge;
+import static io.reactivex.netty.servo.ServoUtils.newLongGauge;
 
 /**
  * @author Tomasz Bak

--- a/rx-netty-servo/src/test/java/io/reactivex/netty/servo/http/websocket/WebSocketMetricsTest.java
+++ b/rx-netty-servo/src/test/java/io/reactivex/netty/servo/http/websocket/WebSocketMetricsTest.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.servo.http.websocket;
-
-import java.util.concurrent.TimeUnit;
 
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.reactivex.netty.RxNetty;
@@ -19,7 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 import rx.Observable;
 
-import static org.junit.Assert.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Tomasz Bak

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/Handler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/Handler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.reactivex.netty.channel;
 
 

--- a/rx-netty/src/main/java/io/reactivex/netty/metrics/WebSocketClientMetricEventsListener.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/metrics/WebSocketClientMetricEventsListener.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.metrics;
-
-import java.util.concurrent.TimeUnit;
 
 import io.reactivex.netty.client.ClientMetricsEvent;
 import io.reactivex.netty.protocol.http.websocket.WebSocketClientMetricsEvent;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * A convenience implementation for {@link io.reactivex.netty.metrics.MetricEventsListener} for receiving {@link WebSocketClientMetricsEvent}. This

--- a/rx-netty/src/main/java/io/reactivex/netty/metrics/WebSocketServerMetricEventsListener.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/metrics/WebSocketServerMetricEventsListener.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.metrics;
-
-import java.util.concurrent.TimeUnit;
 
 import io.reactivex.netty.protocol.http.websocket.WebSocketServerMetricsEvent;
 import io.reactivex.netty.server.ServerMetricsEvent;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Tomasz Bak

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/AbstractHttpContentHolder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/AbstractHttpContentHolder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http;
+
+import rx.Observable;
+import rx.subjects.Subject;
+
+/**
+ * An abstract implementation of {@link HttpContentHolder}
+ *
+ * @author Nitesh Kant
+ */
+public abstract class AbstractHttpContentHolder<T> implements HttpContentHolder<T> {
+
+    protected final Observable<T> content;
+
+    /**
+     * @deprecated Use {@link #AbstractHttpContentHolder(UnicastContentSubject)} instead.
+     */
+    @Deprecated
+    protected AbstractHttpContentHolder(Subject<T, T> content) {
+        this.content = content;
+    }
+
+    protected AbstractHttpContentHolder(UnicastContentSubject<T> content) {
+        this.content = content;
+    }
+
+    @Override
+    public Observable<T> getContent() {
+        return content;
+    }
+
+    @Override
+    public void ignoreContent() {
+        if (UnicastContentSubject.class.isAssignableFrom(content.getClass())) {
+            UnicastContentSubject<T> unicastContentSubject = (UnicastContentSubject<T>) content;
+            unicastContentSubject.disposeIfNotSubscribed();
+        }
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/HttpContentHolder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/HttpContentHolder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http;
+
+import rx.Observable;
+
+/**
+ * @author Nitesh Kant
+ */
+public interface HttpContentHolder<T> {
+
+    /**
+     * Returns the content {@link Observable}. The content {@link Observable} can have one and only one subscription. <br>
+     *
+     * In case, multiple subscriptions are required, you must use {@link Observable#publish()}
+     *
+     * <h2>Subscriptions</h2>
+     * It is mandatory to have atleast one subscription to the returned {@link Observable} or else it will increase
+     * memory consumption as the underlying {@link Observable} buffers content untill subscription.
+     *
+     * <h2>Ignoring content</h2>
+     * In case the consumer of this response, is not interested in the content, it should invoke {@link #ignoreContent()}
+     * or else the content will remain in memory till the configured timeout.
+     *
+     * @return The content {@link Observable} which must have one and only one subscription.
+     *
+     * @see UnicastContentSubject
+     */
+    Observable<T> getContent();
+
+    /**
+     * This will ignore the content and any attempt to subscribe to the content {@link Observable} as returned by
+     * {@link #getContent()} will result in invoking {@link rx.Observer#onError(Throwable)} on the subscriber.
+     */
+    void ignoreContent();
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
@@ -68,11 +68,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  */
 public final class UnicastContentSubject<T> extends Subject<T, T> {
 
-    private static final IllegalStateException ALREADY_DISPOSED_EXCEPTION =
-            new IllegalStateException("Content stream is already disposed.");
-    public static final IllegalStateException MULTIPLE_SUBSCRIBERS_EXCEPTIONS =
-            new IllegalStateException("Content can only have one subscription. Use Observable.publish() if you want to multicast.");
-
     private final State<T> state;
     private volatile Observable<Long> timeoutScheduler;
 
@@ -252,9 +247,9 @@ public final class UnicastContentSubject<T> extends Subject<T, T> {
                     }
                 }));
             } else if(State.STATES.SUBSCRIBED.ordinal() == state.state) {
-                subscriber.onError(MULTIPLE_SUBSCRIBERS_EXCEPTIONS);
+                subscriber.onError(new IllegalStateException("Content can only have one subscription. Use Observable.publish() if you want to multicast."));
             } else if(State.STATES.DISPOSED.ordinal() == state.state) {
-                subscriber.onError(ALREADY_DISPOSED_EXCEPTION);
+                subscriber.onError(new IllegalStateException("Content stream is already disposed."));
             }
         }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import rx.Observable;
+import rx.Observer;
+import rx.Scheduler;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.internal.operators.NotificationLite;
+import rx.observers.Subscribers;
+import rx.schedulers.Schedulers;
+import rx.subjects.Subject;
+import rx.subscriptions.Subscriptions;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * A {@link Subject} implementation to be used by {@link HttpClientResponse} and {@link HttpServerRequest}.
+ *
+ * <h2>Unicast</h2>
+ * This implementation allows a single subscription as this buffers the content till subscription to solve the issue
+ * described in <a href="https://github.com/Netflix/RxNetty/issues/206">this github issue</a>.
+ * If we allow multiple subscription and still maintain it as a cold observable i.e. which re-runs the stream on every
+ * subscription, we loose the control on the scope of this {@link Observable} as any code can hold the reference to
+ * this {@link Observable} at any point in time and hence subscribe to it at any time. This will eventually increase
+ * memory consumption as we will hold on to the content buffers for more time than required.
+ *
+ * <h2>Multicast option</h2>
+ * If at all it is required to allow multiple subscriptions to this {@link Subject} one should use a
+ * {@link Observable#publish()} operator.
+ *
+ * <h2>Buffering</h2>
+ * This subject will buffer all content till the first (one and only) subscriber arrives.
+ * In cases, when there are no subscriptions, this buffer may be held till infinity and hence can cause a memory leak in
+ * case of netty's {@link ByteBuf} which needs to be released explicitly.
+ * In order to avoid this leak, this subject provides a "no subscription timeout" which disposes this subject (calling
+ * {@link #disposeIfNotSubscribed()} if it does not get a subscription in the configured timeout duration.
+ *
+ * The buffer is only utilized if there are any items emitted to this subject before a subscription arrives. After a
+ * subscription arrives, this subject becomes a pass through i.e. it does not buffer before sending the notifications.
+ *
+ * This implementation is inspired by
+ * <a href="https://github.com/Netflix/RxJava/blob/master/rxjava-core/src/main/java/rx/internal/operators/BufferUntilSubscriber.java">RxJava's BufferUntilSubscriber</a>
+ * @author Nitesh Kant
+ */
+public final class UnicastContentSubject<T> extends Subject<T, T> {
+
+    private static final IllegalStateException ALREADY_DISPOSED_EXCEPTION =
+            new IllegalStateException("Content stream is already disposed.");
+    public static final IllegalStateException MULTIPLE_SUBSCRIBERS_EXCEPTIONS =
+            new IllegalStateException("Content can only have one subscription. Use Observable.publish() if you want to multicast.");
+
+    private final State<T> state;
+    private volatile Observable<Long> timeoutScheduler;
+
+    private UnicastContentSubject(State<T> state) {
+        super(new OnSubscribeAction<T>(state));
+        this.state = state;
+        timeoutScheduler = Observable.empty(); // No timeout.
+    }
+
+    private UnicastContentSubject(final State<T> state, long noSubscriptionTimeout, TimeUnit timeUnit,
+                                  Scheduler scheduler) {
+        super(new OnSubscribeAction<T>(state));
+        this.state = state;
+        timeoutScheduler = Observable.interval(noSubscriptionTimeout, timeUnit, scheduler).take(1); // Started when content arrives.
+    }
+
+    /**
+     * Creates a new {@link UnicastContentSubject} without a no subscription timeout.
+     * <b>This can cause a memory leak in case no one ever subscribes to this subject.</b> See
+     * {@link UnicastContentSubject} for details.
+     *
+     * @param <T> The type emitted and received by this subject.
+     *
+     * @return The new instance of {@link UnicastContentSubject}
+     */
+    public static <T> UnicastContentSubject<T> createWithoutNoSubscriptionTimeout() {
+        State<T> state = new State<T>();
+        return new UnicastContentSubject<T>(state);
+    }
+
+    public static <T> UnicastContentSubject<T> create(long noSubscriptionTimeout, TimeUnit timeUnit) {
+        return create(noSubscriptionTimeout, timeUnit, Schedulers.computation());
+    }
+
+    public static <T> UnicastContentSubject<T> create(long noSubscriptionTimeout, TimeUnit timeUnit,
+                                                      Scheduler timeoutScheduler) {
+        State<T> state = new State<T>();
+        return new UnicastContentSubject<T>(state, noSubscriptionTimeout, timeUnit, timeoutScheduler);
+    }
+
+    /**
+     * This will eagerly dispose this {@link Subject} without waiting for the no subscription timeout period,
+     * if configured.
+     *
+     * This must be invoked when the caller is sure that no one will subscribe to this subject. Any subscriber after
+     * this call will receive an error that the subject is disposed.
+     *
+     * @return {@code true} if the subject was disposed by this call (if and only if there was no subscription).
+     */
+    public boolean disposeIfNotSubscribed() {
+        if (state.casState(State.STATES.UNSUBSCRIBED, State.STATES.DISPOSED)) {
+            Subscriber<T> noOpSub = new PassThruObserver<T>(Subscribers.empty(), state); // Any buffering post buffer draining must not be lying in the buffer
+
+            state.buffer.sendAllNotifications(noOpSub); // It is important to empty the buffer before setting the observer.
+                                                        // If not done, there can be two threads draining the buffer
+                                                        // (PassThroughObserver on any notification) and this thread.
+
+            state.setObserverRef(noOpSub); // All future notifications are not sent anywhere.
+            return true;
+        }
+        return false;
+    }
+
+    public void updateTimeoutIfNotScheduled(long noSubscriptionTimeout, TimeUnit timeUnit) {
+        if (0 == state.timeoutScheduled) {
+            timeoutScheduler = Observable.interval(noSubscriptionTimeout, timeUnit).take(1);
+        }
+    }
+
+    /** The common state. */
+    private static final class State<T> {
+
+        /**
+         * Following are the only possible state transitions:
+         * UNSUBSCRIBED -> SUBSCRIBED
+         * UNSUBSCRIBED -> DISPOSED
+         */
+        private enum STATES {
+            UNSUBSCRIBED /*Initial*/, SUBSCRIBED /*Terminal state*/, DISPOSED/*Terminal state*/
+        }
+
+        private volatile int state = STATES.UNSUBSCRIBED.ordinal(); /*Values are the ordinals of STATES enum*/
+
+        /** Following Observers are associated with the states:
+         * UNSUBSCRIBED => {@link BufferedObserver}
+         * SUBSCRIBED => {@link PassThruObserver}
+         * DISPOSED => {@link Subscribers#empty()}
+         */
+        private volatile Observer<? super T> observerRef = new BufferedObserver();
+
+        @SuppressWarnings("unused")private volatile int timeoutScheduled; // Boolean
+
+        /**
+         * The only buffer associated with this state. All notifications go to this buffer if no one has subscribed and
+         * the {@link UnicastContentSubject} instance is not disposed.
+         */
+        private final ByteBufAwareBuffer<T> buffer = new ByteBufAwareBuffer<T>();
+
+        /** Field updater for observerRef. */
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<State, Observer> OBSERVER_UPDATER
+                = AtomicReferenceFieldUpdater.newUpdater(State.class, Observer.class, "observerRef");
+
+        /** Field updater for state. */
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<State> STATE_UPDATER
+                = AtomicIntegerFieldUpdater.newUpdater(State.class, "state");
+
+        /** Field updater for timeoutScheduled. */
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<State> TIMEOUT_SCHEDULED_UPDATER
+                = AtomicIntegerFieldUpdater.newUpdater(State.class, "timeoutScheduled");
+
+        public boolean casState(STATES expected, STATES next) {
+            return STATE_UPDATER.compareAndSet(this, expected.ordinal(), next.ordinal());
+        }
+
+        public void setObserverRef(Observer<? super T> o) { // Guarded by casState()
+            observerRef = o;
+        }
+
+        public boolean casObserverRef(Observer<? super T> expected, Observer<? super T> next) {
+            return OBSERVER_UPDATER.compareAndSet(this, expected, next);
+        }
+
+        public boolean casTimeoutScheduled() {
+            return TIMEOUT_SCHEDULED_UPDATER.compareAndSet(this, 0, 1);
+        }
+
+        /**
+         * The default subscriber when the enclosing state is created.
+         */
+        private final class BufferedObserver extends Subscriber<T> {
+
+            private final NotificationLite<Object> nl = NotificationLite.instance();
+
+            @Override
+            public void onCompleted() {
+                buffer.add(nl.completed());
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                buffer.add(nl.error(e));
+            }
+
+            @Override
+            public void onNext(T t) {
+                buffer.add(nl.next(t));
+            }
+        }
+    }
+
+    private static final class OnSubscribeAction<T> implements OnSubscribe<T> {
+
+        private final State<T> state;
+
+        public OnSubscribeAction(State<T> state) {
+            this.state = state;
+        }
+
+        @Override
+        public void call(final Subscriber<? super T> subscriber) {
+            if (state.casState(State.STATES.UNSUBSCRIBED, State.STATES.SUBSCRIBED)) {
+
+                // drain queued notifications before subscription
+                // we do this here before PassThruObserver so the consuming thread can do this before putting itself in
+                // the line of the producer
+                state.buffer.sendAllNotifications(subscriber);
+
+                // register real observer for pass-thru ... and drain any further events received on first notification
+                state.setObserverRef(new PassThruObserver<T>(subscriber, state));
+                subscriber.add(Subscriptions.create(new Action0() {
+                    @Override
+                    public void call() {
+                        state.setObserverRef(Subscribers.empty());
+                    }
+                }));
+            } else if(State.STATES.SUBSCRIBED.ordinal() == state.state) {
+                subscriber.onError(MULTIPLE_SUBSCRIBERS_EXCEPTIONS);
+            } else if(State.STATES.DISPOSED.ordinal() == state.state) {
+                subscriber.onError(ALREADY_DISPOSED_EXCEPTION);
+            }
+        }
+
+    }
+
+    @Override
+    public void onCompleted() {
+        state.observerRef.onCompleted();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        state.observerRef.onError(e);
+    }
+
+    @Override
+    public void onNext(T t) {
+        state.observerRef.onNext(t);
+        if (state.casTimeoutScheduled()) {// Schedule timeout once.
+            timeoutScheduler.subscribe(new Action1<Long>() { // Schedule timeout after the first content arrives.
+                @Override
+                public void call(Long aLong) {
+                    disposeIfNotSubscribed();
+                }
+            });
+        }
+    }
+
+    /**
+     * This is a temporary observer between buffering and the actual that gets into the line of notifications
+     * from the producer and will drain the queue of any items received during the race of the initial drain and
+     * switching this.
+     *
+     * It will then immediately swap itself out for the actual (after a single notification), but since this is
+     * now being done on the same producer thread no further buffering will occur.
+     */
+    private static final class PassThruObserver<T> extends Subscriber<T> {
+
+        private final Observer<? super T> actual;
+        // this assumes single threaded synchronous notifications (the Rx contract for a single Observer)
+        private final ByteBufAwareBuffer<T> buffer; // Same buffer instance from the original BufferedObserver.
+        private final State<T> state;
+
+        PassThruObserver(Observer<? super T> actual, State<T> state) {
+            this.actual = actual;
+            buffer = state.buffer;
+            this.state = state;
+        }
+
+        @Override
+        public void onCompleted() {
+            drainIfNeededAndSwitchToActual();
+            actual.onCompleted();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            drainIfNeededAndSwitchToActual();
+            actual.onError(e);
+        }
+
+        @Override
+        public void onNext(T t) {
+            drainIfNeededAndSwitchToActual();
+            actual.onNext(t);
+        }
+
+        private void drainIfNeededAndSwitchToActual() {
+            buffer.sendAllNotifications(this);
+            // now we can safely change over to the actual and get rid of the pass-thru
+            // but only if not unsubscribed
+            state.casObserverRef(this, actual);
+        }
+    }
+
+    private static final class ByteBufAwareBuffer<T> {
+
+        private final ConcurrentLinkedQueue<Object> actual = new ConcurrentLinkedQueue<Object>();
+        private final NotificationLite<T> nl = NotificationLite.instance();
+
+        private void add(Object toAdd) {
+            ReferenceCountUtil.retain(toAdd); // Released when the notification is sent.
+            actual.add(toAdd);
+        }
+
+        public void sendAllNotifications(Subscriber<? super T> subscriber) {
+            Object notification; // Can be onComplete notification, onError notification or just the actual "T".
+            while ((notification = actual.poll()) != null) {
+                try {
+                    nl.accept(subscriber, notification);
+                } finally {
+                    ReferenceCountUtil.release(notification); // If it is the actual T for onNext and is a ByteBuf, it will be released.
+                }
+            }
+        }
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClient.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClient.java
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.client;
 
 import io.reactivex.netty.client.RxClient;
 import rx.Observable;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -40,6 +43,7 @@ public interface HttpClient<I, O> extends RxClient<HttpClientRequest<I>, HttpCli
 
         private RedirectsHandling followRedirect = RedirectsHandling.Undefined;
         private int maxRedirects = RedirectOperator.DEFAULT_MAX_HOPS;
+        private long responseSubscriptionTimeoutMs = HttpClientResponse.DEFAULT_CONTENT_SUBSCRIPTION_TIMEOUT_MS;
 
         protected HttpClientConfig() {
             // Only the builder can create this instance, so that we can change the constructor signature at will.
@@ -59,6 +63,10 @@ public interface HttpClient<I, O> extends RxClient<HttpClientRequest<I>, HttpCli
 
         public int getMaxRedirects() {
             return maxRedirects;
+        }
+
+        public long getResponseSubscriptionTimeoutMs() {
+            return responseSubscriptionTimeoutMs;
         }
 
         @Override
@@ -89,6 +97,11 @@ public interface HttpClient<I, O> extends RxClient<HttpClientRequest<I>, HttpCli
             public Builder followRedirect(int maxRedirects) {
                 setFollowRedirect(true);
                 config.maxRedirects = maxRedirects;
+                return returnBuilder();
+            }
+
+            public Builder responseSubscriptionTimeout(long timeout, TimeUnit timeUnit) {
+                config.responseSubscriptionTimeoutMs = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
                 return returnBuilder();
             }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -84,7 +84,8 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpClientRequest<I>, Htt
 
         enrichRequest(request, httpClientConfig);
         Observable<HttpClientResponse<O>> toReturn =
-                connectionObservable.lift(new RequestProcessingOperator<I, O>(request, eventsSubject));
+                connectionObservable.lift(new RequestProcessingOperator<I, O>(request, eventsSubject,
+                                                                              httpClientConfig.getResponseSubscriptionTimeoutMs()));
 
         if (followRedirect) {
             toReturn = toReturn.lift(new RedirectOperator<I, O>(request, this, httpClientConfig));

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -90,7 +90,7 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpClientRequest<I>, Htt
         if (followRedirect) {
             toReturn = toReturn.lift(new RedirectOperator<I, O>(request, this, httpClientConfig));
         }
-        return toReturn.finallyDo(new Action0() {
+        return toReturn.take(1).finallyDo(new Action0() {
             @Override
             public void call() {
                 eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_PROCESSING_COMPLETE,

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -23,7 +23,6 @@ import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.metrics.Clock;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 import rx.Observable;
-import rx.Observer;
 import rx.Subscriber;
 
 /**
@@ -76,26 +75,9 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                     public void onNext(HttpServerRequest<I> newRequest) {
                         final long startTimeMillis = Clock.newStartTimeMillis();
                         eventsSubject.onEvent(HttpServerMetricsEvent.NEW_REQUEST_RECEIVED);
-                        newRequest.getContent().subscribe(new Observer<I>() {
-                            // There is no guarantee that the RequestHandler will subscribe to the content, but we want this
-                            // metric anyways, so we subscribe to the content here.
-                            @Override
-                            public void onCompleted() {
-                                eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_RECEIVE_COMPLETE,
-                                                      Clock.onEndMillis(startTimeMillis));
-                            }
 
-                            @Override
-                            public void onError(Throwable e) {
-                            }
-
-                            @Override
-                            public void onNext(I i) {
-                            }
-                        });
-
-                        final HttpServerResponse<O> response = new HttpServerResponse<O>(
-                                newConnection.getChannelHandlerContext(),
+                        final HttpServerResponse<O> response =
+                                new HttpServerResponse<O>(newConnection.getChannelHandlerContext(),
                         /*
                          * Server should send the highest version it is compatible with.
                          * http://tools.ietf.org/html/rfc2145#section-2.3

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequiredConfigurator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequiredConfigurator.java
@@ -33,14 +33,12 @@ class ServerRequiredConfigurator<I, O> implements PipelineConfigurator<HttpServe
 
     public static final String REQUEST_RESPONSE_CONVERTER_HANDLER_NAME = "request-response-converter";
     private final EventExecutorGroup handlersExecutorGroup;
+    private final long requestContentSubscriptionTimeoutMs;
     private MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject;
 
-    ServerRequiredConfigurator() {
-        this(null);
-    }
-
-    ServerRequiredConfigurator(EventExecutorGroup handlersExecutorGroup) {
+    ServerRequiredConfigurator(EventExecutorGroup handlersExecutorGroup, long requestContentSubscriptionTimeoutMs) {
         this.handlersExecutorGroup = handlersExecutorGroup;
+        this.requestContentSubscriptionTimeoutMs = requestContentSubscriptionTimeoutMs;
     }
 
     void useMetricEventsSubject(MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject) {
@@ -50,7 +48,7 @@ class ServerRequiredConfigurator<I, O> implements PipelineConfigurator<HttpServe
     @Override
     public void configureNewPipeline(ChannelPipeline pipeline) {
         pipeline.addLast(getRequestResponseConverterExecutor(), REQUEST_RESPONSE_CONVERTER_HANDLER_NAME,
-                         new ServerRequestResponseConverter(eventsSubject));
+                         new ServerRequestResponseConverter(eventsSubject, requestContentSubscriptionTimeoutMs));
     }
 
     protected EventExecutorGroup getRequestResponseConverterExecutor() {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.bootstrap.Bootstrap;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientBuilder.java
@@ -1,7 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
-
-import java.net.URI;
-import java.net.URISyntaxException;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
@@ -16,6 +28,9 @@ import io.reactivex.netty.client.UnpooledClientConnectionFactory;
 import io.reactivex.netty.metrics.MetricEventsListener;
 import io.reactivex.netty.metrics.MetricEventsListenerFactory;
 import io.reactivex.netty.pipeline.PipelineConfigurator;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * @author Tomasz Bak

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientMetricsEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientMetricsEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.reactivex.netty.client.ClientMetricsEvent;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientMetricsHandlers.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientMetricsHandlers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServer.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
-
-import java.util.List;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
@@ -16,6 +29,8 @@ import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
 import io.reactivex.netty.server.RxServer;
 import rx.Observable;
 import rx.subjects.PublishSubject;
+
+import java.util.List;
 
 /**
  * {@link WebSocketServer} delays passing new connection to the application handler

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.buffer.ByteBuf;
@@ -22,10 +37,12 @@ import io.reactivex.netty.protocol.http.websocket.WebSocketServerMetricsHandlers
 import io.reactivex.netty.protocol.http.websocket.WebSocketServerMetricsHandlers.ServerWriteMetricsHandler;
 import io.reactivex.netty.server.ServerMetricsEvent;
 
-import static io.netty.handler.codec.http.HttpHeaders.*;
-import static io.netty.handler.codec.http.HttpMethod.*;
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
-import static io.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.handler.codec.http.HttpHeaders.isKeepAlive;
+import static io.netty.handler.codec.http.HttpHeaders.setContentLength;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**
  * {@link WebSocketServerHandler} orchestrates WebSocket handshake process and reconfigures

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerMetricsEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerMetricsEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.reactivex.netty.server.ServerMetricsEvent;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerMetricsHandlers.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerMetricsHandlers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerPipelineConfigurator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServerPipelineConfigurator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.channel.ChannelPipeline;

--- a/rx-netty/src/test/java/io/reactivex/netty/RxNettyHttpShorthandsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/RxNettyHttpShorthandsTest.java
@@ -107,7 +107,7 @@ public class RxNettyHttpShorthandsTest {
         HttpClientResponse<ByteBuf> response =
                 RxNetty.createHttpPut("http://localhost:" + mockServer.getServerPort() + '/',
                                       Observable.just(Unpooled.buffer().writeBytes("Hello!".getBytes())))
-                       .toBlocking() .toFuture().get(1, TimeUnit.MINUTES);
+                       .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
         Assert.assertEquals("Unexpected HTTP method sent.", "PUT", response.getHeaders().get(METHOD_HEADER));
         Assert.assertEquals("Content not sent by the client.", "true", response.getHeaders().get(CONTENT_RECEIEVED_HEADER));
     }

--- a/rx-netty/src/test/java/io/reactivex/netty/metrics/EventInvocationsStore.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/metrics/EventInvocationsStore.java
@@ -1,11 +1,26 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.metrics;
+
+import io.reactivex.netty.metrics.MetricsEvent.MetricEventType;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import io.reactivex.netty.metrics.MetricsEvent.MetricEventType;
 
 /**
  * @author Nitesh Kant

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/UnicastContentSubjectTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/UnicastContentSubjectTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Assert;
+import org.junit.Test;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.functions.Actions;
+import rx.observers.Subscribers;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author Nitesh Kant
+ */
+public class UnicastContentSubjectTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void testNoSubscriptions() throws Exception {
+        TestScheduler testScheduler = Schedulers.test();
+        UnicastContentSubject<String> subject = UnicastContentSubject.create(1, TimeUnit.DAYS, testScheduler);
+        subject.onNext("Start the timeout now."); // Since the timeout is scheduled only after content arrival.
+        testScheduler.advanceTimeBy(1, TimeUnit.DAYS);
+        subject.toBlocking().last(); // Should immediately throw an error.
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMultiSubscriber() throws Exception {
+        UnicastContentSubject<Object> subject = UnicastContentSubject.createWithoutNoSubscriptionTimeout();
+        subject.subscribe(Subscribers.empty());
+        subject.toBlocking().last();
+    }
+
+    @Test
+    public void testNoTimeoutPostSubscription() throws Exception {
+        TestScheduler testScheduler = Schedulers.test();
+        UnicastContentSubject<String> subject = UnicastContentSubject.create(1, TimeUnit.DAYS, testScheduler);
+        subject.onNext("Start the timeout now."); // Since the timeout is scheduled only after content arrival.
+        final AtomicReference<Throwable> errorOnSubscribe = new AtomicReference<Throwable>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        subject.subscribe(Actions.empty(), new Action1<Throwable>() {
+            @Override
+            public void call(Throwable throwable) {
+                errorOnSubscribe.set(throwable);
+                latch.countDown();
+            }
+        }, new Action0() {
+            @Override
+            public void call() {
+                latch.countDown();
+            }
+        });
+
+        testScheduler.advanceTimeBy(1, TimeUnit.DAYS);
+        subject.onCompleted();
+
+        latch.await(1, TimeUnit.MINUTES);
+
+        Assert.assertNull("Subscription got an error.", errorOnSubscribe.get());
+    }
+
+    @Test
+    public void testBuffer() throws Exception {
+        UnicastContentSubject<String> subject = UnicastContentSubject.createWithoutNoSubscriptionTimeout();
+
+        final List<String> data = new ArrayList<String>();
+        data.add("Item1");
+        data.add("Item2");
+
+        //buffer these
+        for (String item : data) {
+            subject.onNext(item);
+        }
+        subject.onCompleted();
+
+        final List<String> items = new ArrayList<String>();
+        subject.toBlocking().forEach(new Action1<String>() {
+            @Override
+            public void call(String item) {
+                items.add(item);
+            }
+        });
+
+        Assert.assertEquals("Unexpected onNext calls", data, items);
+    }
+
+    @Test
+    public void testByteBufRelease() throws Exception {
+        UnicastContentSubject<ByteBuf> subject = UnicastContentSubject.createWithoutNoSubscriptionTimeout();
+        ByteBuf buffer = Unpooled.buffer();
+        Assert.assertEquals("Created byte buffer not retained.", 1, buffer.refCnt());
+        subject.onNext(buffer);
+        subject.onCompleted();
+        final AtomicInteger byteBufRefCnt = new AtomicInteger(-1);
+
+        ByteBuf last = subject.doOnNext(new Action1<ByteBuf>() {
+            @Override
+            public void call(ByteBuf byteBuf) {
+                byteBufRefCnt.set(byteBuf.refCnt());
+                byteBuf.release();// Simulate consumption as ByteBuf refcount is 1 when created.
+            }
+        }).toBlocking().last();
+
+        Assert.assertEquals("Unexpected ByteBuf ref count when received.", 2, byteBufRefCnt.get());
+        Assert.assertSame("Unexpected byte buffer received.", buffer, last);
+        Assert.assertEquals("Byte buffer not released.", 0, last.refCnt());
+    }
+}

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/CookieTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/CookieTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.client;
 
 import io.netty.buffer.ByteBuf;
@@ -25,9 +26,9 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.netty.protocol.http.UnicastContentSubject;
 import org.junit.Assert;
 import org.junit.Test;
-import rx.subjects.PublishSubject;
 
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +48,7 @@ public class CookieTest {
         String cookie1Header = cookie1Name + '=' + cookie1Value
                                + "; expires=Thu, 18-Feb-2016 07:47:08 GMT; path=" + cookie1Path + "; domain=" + cookie1Domain;
         nettyResponse.headers().add(HttpHeaders.Names.SET_COOKIE, cookie1Header);
-        HttpClientResponse<ByteBuf> response = new HttpClientResponse<ByteBuf>(nettyResponse, PublishSubject.<ByteBuf>create());
+        HttpClientResponse<ByteBuf> response = new HttpClientResponse<ByteBuf>(nettyResponse, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
         Map<String,Set<Cookie>> cookies = response.getCookies();
         Assert.assertNotNull("Cookies are null.", cookies);
         Assert.assertEquals("Cookies are empty.", 1, cookies.size());

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RedirectOperatorTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/RedirectOperatorTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.client;
 
 import io.netty.buffer.ByteBuf;
@@ -21,11 +22,11 @@ import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.netty.protocol.http.UnicastContentSubject;
 import org.junit.Assert;
 import org.junit.Test;
 import rx.Observable;
 import rx.Subscriber;
-import rx.subjects.PublishSubject;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -67,7 +68,7 @@ public class RedirectOperatorTest {
         public TestableRedirectHandler(int maxHops, HttpResponseStatus redirectResponseStatus) {
             this.maxHops = maxHops;
             DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, redirectResponseStatus);
-            response = new HttpClientResponse<O>(nettyResponse, PublishSubject.<O>create());
+            response = new HttpClientResponse<O>(nettyResponse, UnicastContentSubject.<O>createWithoutNoSubscriptionTimeout());
         }
 
         public TestableRedirectHandler(int maxHops) {
@@ -164,9 +165,9 @@ public class RedirectOperatorTest {
             HttpClientRequest<ByteBuf> request = new HttpClientRequest<ByteBuf>(nettyRequest);
             DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
                                                                         HttpResponseStatus.TEMPORARY_REDIRECT);
-            final HttpClientResponse<ByteBuf> response = new HttpClientResponse<ByteBuf>(nettyResponse,
-                                                                                         PublishSubject
-                                                                                                 .<ByteBuf>create());
+            final HttpClientResponse<ByteBuf> response =
+                    new HttpClientResponse<ByteBuf>(nettyResponse,
+                                              UnicastContentSubject .<ByteBuf>createWithoutNoSubscriptionTimeout());
             handler = new TestableRedirectHandler<ByteBuf, ByteBuf>(2, redirectStatus);
 
             subscriber = new UnsafeRedirectSubscriber();

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
@@ -27,9 +28,9 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.reactivex.netty.NoOpChannelHandlerContext;
 import io.reactivex.netty.metrics.MetricEventsSubject;
+import io.reactivex.netty.protocol.http.UnicastContentSubject;
 import org.junit.Assert;
 import org.junit.Test;
-import rx.subjects.PublishSubject;
 
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +50,7 @@ public class CookieTest {
         String cookie1Header = cookie1Name + '=' + cookie1Value
                                + "; expires=Thu, 18-Feb-2016 07:47:08 GMT; path=" + cookie1Path + "; domain=" + cookie1Domain;
         nettyRequest.headers().add(HttpHeaders.Names.COOKIE, cookie1Header);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, PublishSubject.<ByteBuf>create());
+        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
         Map<String,Set<Cookie>> cookies = request.getCookies();
         Assert.assertEquals("Unexpected number of cookies.", 1, cookies.size());
         Set<Cookie> cookies1 = cookies.get(cookie1Name);

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UriTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/UriTest.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.netty.protocol.http.UnicastContentSubject;
 import org.junit.Assert;
 import org.junit.Test;
-import rx.subjects.PublishSubject;
 
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class UriTest {
         String queryString = qp1Name + '=' + qp1Val + '&' + qp2Name + '=' + qp2Val + '&' + qp2Name + '=' + qp2Val2 ;
         String uri = path + '?' + queryString;
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, PublishSubject.<ByteBuf>create());
+        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
         Assert.assertEquals("Unexpected uri string", uri, request.getUri());
         Assert.assertEquals("Unexpected query string", queryString,request.getQueryString());
         Assert.assertEquals("Unexpected path string", path, request.getPath());
@@ -66,7 +67,7 @@ public class UriTest {
         String path = "a/b/c";
         String uri = path + '?';
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, PublishSubject.<ByteBuf>create());
+        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
         Assert.assertEquals("Unexpected uri string", uri, request.getUri());
         Assert.assertEquals("Unexpected query string", "", request.getQueryString());
     }
@@ -76,7 +77,7 @@ public class UriTest {
         String path = "a/b/c";
         String uri = path;
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, PublishSubject.<ByteBuf>create());
+        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
         Assert.assertEquals("Unexpected uri string", uri, request.getUri());
         Assert.assertEquals("Unexpected query string", "", request.getQueryString());
     }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/TestableClientMetricsEventListener.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/TestableClientMetricsEventListener.java
@@ -1,13 +1,28 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
-
-import java.util.EnumMap;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import io.reactivex.netty.client.ClientMetricsEvent;
 import io.reactivex.netty.metrics.EventInvocationsStore;
 import io.reactivex.netty.metrics.MetricsEvent;
 import io.reactivex.netty.metrics.WebSocketClientMetricEventsListener;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Tomasz Bak
@@ -29,6 +44,7 @@ public class TestableClientMetricsEventListener extends WebSocketClientMetricEve
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onEvent(ClientMetricsEvent<?> event, long duration, TimeUnit timeUnit,
                         Throwable throwable, Object value) {
         if (WebSocketClientMetricsEvent.EventType.class == event.getType().getClass()) {

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/TestableServerMetricsEventListener.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/TestableServerMetricsEventListener.java
@@ -1,13 +1,28 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
-
-import java.util.EnumMap;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import io.reactivex.netty.metrics.EventInvocationsStore;
 import io.reactivex.netty.metrics.MetricsEvent;
 import io.reactivex.netty.metrics.WebSocketServerMetricEventsListener;
 import io.reactivex.netty.server.ServerMetricsEvent;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Tomasz Bak
@@ -29,6 +44,7 @@ public class TestableServerMetricsEventListener extends WebSocketServerMetricEve
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onEvent(ServerMetricsEvent<?> event, long duration, TimeUnit timeUnit,
                         Throwable throwable, Object value) {
         if (WebSocketServerMetricsEvent.EventType.class == event.getType().getClass()) {

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientServerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientServerTest.java
@@ -1,12 +1,19 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
-
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -28,7 +35,16 @@ import rx.Observable;
 import rx.functions.Action1;
 import rx.functions.Func1;
 
-import static org.junit.Assert.*;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Tomasz Bak
@@ -236,7 +252,8 @@ public class WebSocketClientServerTest {
             return this;
         }
 
-        private Observable<Void> sendBatchOfFrames(ObservableConnection<WebSocketFrame, WebSocketFrame> connection, WebSocketFrame[] frames) {
+        private static Observable<Void> sendBatchOfFrames(ObservableConnection<WebSocketFrame, WebSocketFrame> connection,
+                                                          WebSocketFrame[] frames) {
             if (frames != null) {
                 for (WebSocketFrame frame : frames) {
                     connection.write(frame);

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/WebSocketMetricsTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/websocket/WebSocketMetricsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.buffer.ByteBuf;


### PR DESCRIPTION
Making HttpServerRequest.getContent() and HttpClientResponse.getContent() lazily subscribable.
