### PR TITLE
Fixes #223 #225 #226 #214 #228 #230

### DIFF
--- a/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/http/HttpContextClientChannelFactory.java
+++ b/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/http/HttpContextClientChannelFactory.java
@@ -100,7 +100,7 @@ public class HttpContextClientChannelFactory<I, O> extends
         @Override
         public void onNext(ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>> connection) {
             if (null != requestId && null != container) {
-                connection.getChannelHandlerContext().pipeline()
+                connection.getChannel().pipeline()
                           .fireUserEventTriggered(new NewContextEvent(requestId, container));
             }
             original.onNext(connection);

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/CPUIntensiveServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/CPUIntensiveServer.java
@@ -49,7 +49,7 @@ public final class CPUIntensiveServer {
                                                    final HttpServerResponse<ByteBuf> response) {
                         printRequestHeader(request);
                         response.getHeaders().set(IN_EVENT_LOOP_HEADER_NAME,
-                                                  response.getChannelHandlerContext().channel().eventLoop()
+                                                  response.getChannel().eventLoop()
                                                           .inEventLoop());
                         response.writeString("Welcome!!");
                         return response.close(false);

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/udp/HelloUdpClient.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/udp/HelloUdpClient.java
@@ -17,6 +17,7 @@
 package io.reactivex.netty.examples.udp;
 
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.logging.LogLevel;
 import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import rx.Observable;
@@ -38,7 +39,8 @@ public final class HelloUdpClient {
     }
 
     public String sendHello() {
-        String content = RxNetty.createUdpClient("localhost", port).connect()
+        String content = RxNetty.<DatagramPacket, DatagramPacket>newUdpClientBuilder("localhost", port)
+                                .enableWireLogging(LogLevel.ERROR).build().connect()
                 .flatMap(new Func1<ObservableConnection<DatagramPacket, DatagramPacket>,
                         Observable<DatagramPacket>>() {
                     @Override
@@ -46,7 +48,8 @@ public final class HelloUdpClient {
                         connection.writeStringAndFlush("Is there anybody out there?");
                         return connection.getInput();
                     }
-                }).take(1)
+                })
+                .take(1)
                 .map(new Func1<DatagramPacket, String>() {
                     @Override
                     public String call(DatagramPacket datagramPacket) {

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/udp/HelloUdpServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/udp/HelloUdpServer.java
@@ -52,7 +52,7 @@ public final class HelloUdpServer {
                         InetSocketAddress sender = received.sender();
                         System.out.println("Received datagram. Sender: " + sender + ", data: "
                                 + received.content().toString(Charset.defaultCharset()));
-                        ByteBuf data = newConnection.getChannelHandlerContext().alloc().buffer(WELCOME_MSG_BYTES.length);
+                        ByteBuf data = newConnection.getChannel().alloc().buffer(WELCOME_MSG_BYTES.length);
                         data.writeBytes(WELCOME_MSG_BYTES);
                         return newConnection.writeAndFlush(new DatagramPacket(data, sender));
                     }

--- a/rx-netty-remote-observable/src/main/java/io/reactivex/netty/ingress/InetAddressWhiteListIngressPolicy.java
+++ b/rx-netty-remote-observable/src/main/java/io/reactivex/netty/ingress/InetAddressWhiteListIngressPolicy.java
@@ -17,13 +17,12 @@ package io.reactivex.netty.ingress;
 
 import io.reactivex.netty.RemoteRxEvent;
 import io.reactivex.netty.channel.ObservableConnection;
+import rx.Observable;
+import rx.functions.Action1;
 
 import java.net.InetSocketAddress;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import rx.Observable;
-import rx.functions.Action1;
 
 public class InetAddressWhiteListIngressPolicy implements IngressPolicy{
 
@@ -42,7 +41,7 @@ public class InetAddressWhiteListIngressPolicy implements IngressPolicy{
 	public boolean allowed(
 			ObservableConnection<RemoteRxEvent, RemoteRxEvent> connection) {
 		InetSocketAddress inetSocketAddress 
-			= (InetSocketAddress) connection.getChannelHandlerContext().channel().remoteAddress();
+			= (InetSocketAddress) connection.getChannel().remoteAddress();
 		return whiteList.get().contains(inetSocketAddress.getAddress().getHostAddress());
 	}
 		

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/AbstractConnectionEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/AbstractConnectionEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.channel;
+
+import rx.Observer;
+
+/**
+ * @author Nitesh Kant
+ */
+@SuppressWarnings("rawtypes")
+public abstract class AbstractConnectionEvent<T extends ObservableConnection> {
+
+    @SuppressWarnings("rawtypes") protected final T observableConnection;
+    @SuppressWarnings("rawtypes") protected final Observer connectedObserver;
+
+    protected AbstractConnectionEvent(@SuppressWarnings("rawtypes") Observer connectedObserver,
+                                      final T observableConnection) {
+        this.connectedObserver = connectedObserver;
+        this.observableConnection = observableConnection;
+    }
+
+    public @SuppressWarnings("rawtypes")
+    Observer getConnectedObserver() {
+        return connectedObserver;
+    }
+
+    public @SuppressWarnings("rawtypes") T getConnection() {
+        return observableConnection;
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/NewRxConnectionEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/NewRxConnectionEvent.java
@@ -22,15 +22,12 @@ import rx.Observer;
  *
  * @author Nitesh Kant
  */
-public class NewRxConnectionEvent {
+@SuppressWarnings("rawtypes")
+public class NewRxConnectionEvent extends AbstractConnectionEvent<ObservableConnection> {
 
-    @SuppressWarnings("rawtypes") private final Observer connectedObserver;
-
-    public NewRxConnectionEvent(@SuppressWarnings("rawtypes") Observer connectedObserver) {
-        this.connectedObserver = connectedObserver;
+    public NewRxConnectionEvent(final ObservableConnection<?, ?> observableConnection,
+                                final Observer connectedObserver) {
+        super(connectedObserver, observableConnection);
     }
 
-    public @SuppressWarnings("rawtypes") Observer getConnectedObserver() {
-        return connectedObserver;
-    }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
@@ -84,7 +84,7 @@ public class ObservableConnection<I, O> extends DefaultChannelWriter<O> {
      * instance which when sending from the constructor will escape "this"
      */
     protected void fireNewRxConnectionEvent() {
-        ChannelHandlerContext firstContext = getChannelHandlerContext().pipeline().firstContext();
+        ChannelHandlerContext firstContext = getChannel().pipeline().firstContext();
         firstContext.fireUserEventTriggered(new NewRxConnectionEvent(this, inputSubject));
     }
 
@@ -105,7 +105,7 @@ public class ObservableConnection<I, O> extends DefaultChannelWriter<O> {
     protected Observable<Void> _close(boolean flush) {
         final PublishSubject<I> thisSubject = inputSubject;
         cancelPendingWrites(true);
-        ReadTimeoutPipelineConfigurator.disableReadTimeout(getChannelHandlerContext().pipeline());
+        ReadTimeoutPipelineConfigurator.disableReadTimeout(getChannel().pipeline());
         if (flush) {
             Observable<Void> toReturn = flush().lift(new Observable.Operator<Void, Void>() {
                 @Override
@@ -151,7 +151,7 @@ public class ObservableConnection<I, O> extends DefaultChannelWriter<O> {
         closeStartTimeMillis = Clock.newStartTimeMillis();
         eventsSubject.onEvent(metricEventProvider.getChannelCloseStartEvent());
 
-        final ChannelFuture closeFuture = getChannelHandlerContext().close();
+        final ChannelFuture closeFuture = getChannel().close();
 
         /**
          * This listener if added inside the returned Observable onSubscribe() function, would mean that the

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/UnpooledConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/UnpooledConnectionFactory.java
@@ -34,7 +34,7 @@ public class UnpooledConnectionFactory<I, O> implements ObservableConnectionFact
 
     @Override
     public ObservableConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return new ObservableConnection<I, O>(ctx, eventsSubject, metricEventProvider);
+        return ObservableConnection.create(ctx, eventsSubject, metricEventProvider);
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ConnectionLifecycleHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ConnectionLifecycleHandler.java
@@ -32,7 +32,7 @@ public class ConnectionLifecycleHandler<I, O> extends ChannelInboundHandlerAdapt
     }
 
     /*package private to set the connection*/ void setConnection(ObservableConnection<I, O> newConnection) {
-        if (!newConnection.getChannelHandlerContext().channel().isRegistered()) {
+        if (!newConnection.getChannel().isRegistered()) {
             connection.close();
         } else {
             connection = newConnection;

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ConnectionReuseEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ConnectionReuseEvent.java
@@ -15,20 +15,17 @@
  */
 package io.reactivex.netty.client;
 
+import io.reactivex.netty.channel.AbstractConnectionEvent;
 import rx.Observer;
 
 /**
  * @author Nitesh Kant
  */
-public class ConnectionReuseEvent {
+@SuppressWarnings("rawtypes")
+public class ConnectionReuseEvent extends AbstractConnectionEvent<PooledConnection>{
 
-    @SuppressWarnings("rawtypes") private final Observer connectedObserver;
-
-    public ConnectionReuseEvent(@SuppressWarnings("rawtypes") Observer connectedObserver) {
-        this.connectedObserver = connectedObserver;
-    }
-
-    public @SuppressWarnings("rawtypes") Observer getConnectedObserver() {
-        return connectedObserver;
+    public ConnectionReuseEvent(PooledConnection<?, ?> connection,
+                                @SuppressWarnings("rawtypes") final Observer connectedObserver) {
+        super(connectedObserver, connection);
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
@@ -115,8 +115,7 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
 
     @Override
     protected Observable<Void> _closeChannel() {
-        Long keepAliveTimeout = getChannelHandlerContext().channel()
-                                .attr(ClientRequestResponseConverter.KEEP_ALIVE_TIMEOUT_MILLIS_ATTR).get();
+        Long keepAliveTimeout = getChannel().attr(ClientRequestResponseConverter.KEEP_ALIVE_TIMEOUT_MILLIS_ATTR).get();
         if (null != keepAliveTimeout) {
             maxIdleTimeMillis = keepAliveTimeout;
         }
@@ -149,10 +148,9 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
      * @return {@code true} if the connection is usable.
      */
     public boolean isUsable() {
-        Boolean discardConn = getChannelHandlerContext().channel()
-                              .attr(ClientRequestResponseConverter.DISCARD_CONNECTION).get();
+        Boolean discardConn = getChannel().attr(ClientRequestResponseConverter.DISCARD_CONNECTION).get();
 
-        if (!getChannelHandlerContext().channel().isActive() || Boolean.TRUE == discardConn) {
+        if (!getChannel().isActive() || Boolean.TRUE == discardConn) {
             return false;
         }
 
@@ -166,7 +164,7 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
         PublishSubject<I> newInputSubject = PublishSubject.create();
         updateInputSubject(newInputSubject);
         ConnectionReuseEvent reuseEvent = new ConnectionReuseEvent(this, newInputSubject);
-        getChannelHandlerContext().pipeline().fireUserEventTriggered(reuseEvent);
+        getChannel().pipeline().fireUserEventTriggered(reuseEvent);
     }
 
     public void updateMaxIdleTimeMillis(long maxIdleTimeMillis) {

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnectionFactory.java
@@ -33,8 +33,8 @@ public class PooledConnectionFactory<I, O> implements ClientConnectionFactory<I,
 
     @Override
     public PooledConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return new PooledConnection<I, O>(ctx, poolConfig.getMaxIdleTimeMillis(), eventsSubject,
-                                          ClientChannelMetricEventProvider.INSTANCE);
+        return PooledConnection.create(ctx, poolConfig.getMaxIdleTimeMillis(),
+                                       ClientChannelMetricEventProvider.INSTANCE, eventsSubject);
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
@@ -150,6 +150,9 @@ public final class UnicastContentSubject<T> extends Subject<T, T> {
                                                         // (PassThroughObserver on any notification) and this thread.
 
             state.setObserverRef(noOpSub); // All future notifications are not sent anywhere.
+            if (null != state.onUnsubscribe) {
+                state.onUnsubscribe.call(); // Since this is an inline/sync call, if this throws an error, it gets thrown to the caller.
+            }
             return true;
         }
         return false;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -23,10 +23,8 @@ import io.reactivex.netty.metrics.MetricEventsSubject;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
-import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.subscriptions.CompositeSubscription;
-import rx.subscriptions.Subscriptions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -70,13 +68,6 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
 
                     @Override
                     public void onNext(final ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>> connection) {
-
-                        cs.add(Subscriptions.create(new Action0() {
-                            @Override
-                            public void call() {
-                                connection.close();
-                            }
-                        }));
 
                         cs.add(connection.getInput()
                                          .doOnNext(new Action1<HttpClientResponse<O>>() {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ResponseHolder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ResponseHolder.java
@@ -29,11 +29,26 @@ public class ResponseHolder<T> {
         this.content = content;
     }
 
+    public ResponseHolder(HttpClientResponse<T> response) {
+        this.response = response;
+        content = null;
+    }
+
     public HttpClientResponse<T> getResponse() {
         return response;
     }
 
+    /**
+     * Returns the content, if any. Use {@link #hasContent()} to check if there is a content in this holder.
+     *
+     * @return The content, if any, {@code null} otherwise.
+     * Use {@link #hasContent()} to check if there is a content in this holder.
+     */
     public T getContent() {
         return content;
+    }
+
+    public boolean hasContent() {
+        return null != content;
     }
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/DefaultErrorResponseGenerator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/DefaultErrorResponseGenerator.java
@@ -52,7 +52,7 @@ class DefaultErrorResponseGenerator<O> implements ErrorResponseGenerator<O> {
     public void updateResponse(HttpServerResponse<O> response, Throwable error) {
         response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
         response.getHeaders().set(HttpHeaders.Names.CONTENT_TYPE, "text/html");
-        ByteBuf buffer = response.getChannelHandlerContext().alloc().buffer(1024);// 1KB initial length.
+        ByteBuf buffer = response.getChannel().alloc().buffer(1024);// 1KB initial length.
         PrintStream printStream = null;
         try {
             printStream = new PrintStream(new ByteBufOutputStream(buffer));

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -125,7 +125,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                                 if (!response.isHeaderWritten()) {
                                     responseGenerator.updateResponse(response, throwable);
                                 }
-                                response.close(false);
+                                response.close(true); // Response should be flushed for errors: https://github.com/ReactiveX/RxNetty/issues/226
                             }
 
                             @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -76,6 +76,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                         final long startTimeMillis = Clock.newStartTimeMillis();
                         eventsSubject.onEvent(HttpServerMetricsEvent.NEW_REQUEST_RECEIVED);
 
+                        @SuppressWarnings("deprecation") //TODO: Remove when we stop returning ctx. (Issue https://github.com/ReactiveX/RxNetty/issues/229)
                         final HttpServerResponse<O> response =
                                 new HttpServerResponse<O>(newConnection.getChannelHandlerContext(),
                         /*

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
@@ -82,7 +82,7 @@ public class ServerRequestResponseConverter extends ChannelDuplexHandler {
             eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HEADERS_RECEIVED);
 
             @SuppressWarnings({"rawtypes", "unchecked"})
-            HttpServerRequest rxRequest = new HttpServerRequest((HttpRequest) msg, contentSubject);
+            HttpServerRequest rxRequest = new HttpServerRequest(ctx.channel(), (HttpRequest) msg, contentSubject);
             this.rxRequest = rxRequest;
 
             super.channelRead(ctx, rxRequest);

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
@@ -73,8 +73,7 @@ public class WebSocketClient<I extends WebSocketFrame, O extends WebSocketFrame>
 
                 @Override
                 public void onNext(final ObservableConnection<T, T> connection) {
-                    ChannelHandlerContext ctx = connection.getChannelHandlerContext();
-                    final ChannelPipeline p = ctx.channel().pipeline();
+                    final ChannelPipeline p = connection.getChannel().pipeline();
                     ChannelHandlerContext hctx = p.context(WebSocketClientHandler.class);
                     if (hctx != null) {
                         WebSocketClientHandler handler = p.get(WebSocketClientHandler.class);

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServer.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketServer.java
@@ -82,8 +82,7 @@ public class WebSocketServer<I extends WebSocketFrame, O extends WebSocketFrame>
 
         @Override
         public Observable<Void> handle(final ObservableConnection<I, O> connection) {
-            ChannelHandlerContext ctx = connection.getChannelHandlerContext();
-            final ChannelPipeline p = ctx.channel().pipeline();
+            final ChannelPipeline p = connection.getChannel().pipeline();
             ChannelHandlerContext hctx = p.context(WebSocketServerHandler.class);
             if (hctx != null) {
                 WebSocketServerHandler handler = p.get(WebSocketServerHandler.class);

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnection.java
@@ -37,15 +37,43 @@ public class UdpClientConnection<I, O> extends ObservableConnection<I, O> {
 
     private final InetSocketAddress receiverAddress;
 
+    protected UdpClientConnection(ChannelHandlerContext ctx, InetSocketAddress receiverAddress,
+                                  ChannelMetricEventProvider metricEventProvider,
+                                  MetricEventsSubject<?> eventsSubject) {
+        super(ctx, metricEventProvider, eventsSubject);
+        this.receiverAddress = receiverAddress;
+    }
+
+
+    /**
+     * @deprecated Use {@link #create(ChannelHandlerContext, InetSocketAddress, MetricEventsSubject,
+     * ChannelMetricEventProvider)} instead.
+     */
+    @Deprecated
     public UdpClientConnection(ChannelHandlerContext ctx, InetSocketAddress receiverAddress) {
         this(ctx, receiverAddress, NoOpChannelMetricEventProvider.NoOpMetricEventsSubject.INSTANCE,
              NoOpChannelMetricEventProvider.INSTANCE);
     }
 
+    /**
+     * @deprecated Use {@link #create(ChannelHandlerContext, InetSocketAddress, MetricEventsSubject,
+     * ChannelMetricEventProvider)} instead.
+     */
+    @Deprecated
     public UdpClientConnection(ChannelHandlerContext ctx, InetSocketAddress receiverAddress,
                                MetricEventsSubject<?> eventsSubject, ChannelMetricEventProvider metricEventProvider) {
-        super(ctx, eventsSubject, metricEventProvider);
+        super(ctx, metricEventProvider, eventsSubject);
         this.receiverAddress = receiverAddress;
+    }
+
+    public static <I, O> UdpClientConnection<I, O> create(final ChannelHandlerContext ctx,
+                                                          InetSocketAddress receiverAddress,
+                                                          final MetricEventsSubject<?> eventsSubject,
+                                                          final ChannelMetricEventProvider metricEventProvider) {
+        UdpClientConnection<I, O> toReturn = new UdpClientConnection<I, O>(ctx, receiverAddress, metricEventProvider,
+                                                                           eventsSubject);
+        toReturn.fireNewRxConnectionEvent();
+        return toReturn;
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnection.java
@@ -78,7 +78,7 @@ public class UdpClientConnection<I, O> extends ObservableConnection<I, O> {
 
     @Override
     public void writeBytes(byte[] msg) {
-        ByteBuf data = getChannelHandlerContext().alloc().buffer(msg.length);
+        ByteBuf data = getChannel().alloc().buffer(msg.length);
         data.writeBytes(msg);
         writeOnChannel(new DatagramPacket(data, receiverAddress));
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnectionFactory.java
@@ -44,8 +44,8 @@ class UdpClientConnectionFactory<I, O> implements ClientConnectionFactory<I, O, 
 
     @Override
     public UdpClientConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return new UdpClientConnection<I, O>(ctx, receiverAddress, eventsSubject,
-                                             ClientChannelMetricEventProvider.INSTANCE);
+        return UdpClientConnection.create(ctx, receiverAddress, eventsSubject,
+                                          ClientChannelMetricEventProvider.INSTANCE);
     }
 
     @Override

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/FlatResponseOperatorTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/client/FlatResponseOperatorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.protocol.http.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.netty.protocol.http.UnicastContentSubject;
+import org.junit.Assert;
+import org.junit.Test;
+import rx.Observable;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Nitesh Kant
+ */
+public class FlatResponseOperatorTest {
+
+    @Test
+    public void testContent() throws Exception {
+        DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                                                                    HttpResponseStatus.NO_CONTENT);
+        UnicastContentSubject<ByteBuf> contentSubject = UnicastContentSubject.createWithoutNoSubscriptionTimeout();
+        contentSubject.onNext(Unpooled.buffer());
+        contentSubject.onCompleted();
+
+        ResponseHolder<ByteBuf> holder = Observable.just(new HttpClientResponse<ByteBuf>(nettyResponse, contentSubject))
+                                                   .lift(FlatResponseOperator.<ByteBuf>flatResponse())
+                                                   .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
+
+        Assert.assertEquals("Unexpected http response status", HttpResponseStatus.NO_CONTENT,
+                            holder.getResponse().getStatus());
+        Assert.assertTrue("Response holder does not have content.", holder.hasContent());
+
+    }
+
+    @Test
+    public void testNoContent() throws Exception {
+        DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                                                                    HttpResponseStatus.NO_CONTENT);
+        UnicastContentSubject<ByteBuf> contentSubject = UnicastContentSubject.createWithoutNoSubscriptionTimeout();
+        contentSubject.onCompleted();
+
+        ResponseHolder<ByteBuf> holder = Observable.just(new HttpClientResponse<ByteBuf>(nettyResponse, contentSubject))
+                                                   .lift(FlatResponseOperator.<ByteBuf>flatResponse())
+                                                   .toBlocking().toFuture().get(1, TimeUnit.MINUTES);
+        Assert.assertEquals("Unexpected http response status", HttpResponseStatus.NO_CONTENT,
+                            holder.getResponse().getStatus());
+        Assert.assertFalse("Response holder has content.", holder.hasContent());
+
+    }
+}

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
@@ -17,6 +17,7 @@
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.DefaultCookie;
@@ -50,7 +51,10 @@ public class CookieTest {
         String cookie1Header = cookie1Name + '=' + cookie1Value
                                + "; expires=Thu, 18-Feb-2016 07:47:08 GMT; path=" + cookie1Path + "; domain=" + cookie1Domain;
         nettyRequest.headers().add(HttpHeaders.Names.COOKIE, cookie1Header);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
+        Channel noOpChannel = new NoOpChannelHandlerContext().channel();
+        HttpServerRequest<ByteBuf> request =
+                new HttpServerRequest<ByteBuf>(noOpChannel, nettyRequest,
+                                               UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
         Map<String,Set<Cookie>> cookies = request.getCookies();
         Assert.assertEquals("Unexpected number of cookies.", 1, cookies.size());
         Set<Cookie> cookies1 = cookies.get(cookie1Name);

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerRequestUriTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerRequestUriTest.java
@@ -17,9 +17,11 @@
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import io.reactivex.netty.NoOpChannelHandlerContext;
 import io.reactivex.netty.protocol.http.UnicastContentSubject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +32,7 @@ import java.util.Map;
 /**
  * @author Nitesh Kant
  */
-public class UriTest {
+public class HttpServerRequestUriTest {
 
     @Test
     public void testRequestUri() throws Exception {
@@ -43,7 +45,7 @@ public class UriTest {
         String queryString = qp1Name + '=' + qp1Val + '&' + qp2Name + '=' + qp2Val + '&' + qp2Name + '=' + qp2Val2 ;
         String uri = path + '?' + queryString;
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
+        HttpServerRequest<ByteBuf> request = newServerRequest(nettyRequest);
         Assert.assertEquals("Unexpected uri string", uri, request.getUri());
         Assert.assertEquals("Unexpected query string", queryString,request.getQueryString());
         Assert.assertEquals("Unexpected path string", path, request.getPath());
@@ -67,7 +69,7 @@ public class UriTest {
         String path = "a/b/c";
         String uri = path + '?';
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
+        HttpServerRequest<ByteBuf> request = newServerRequest(nettyRequest);
         Assert.assertEquals("Unexpected uri string", uri, request.getUri());
         Assert.assertEquals("Unexpected query string", "", request.getQueryString());
     }
@@ -77,8 +79,14 @@ public class UriTest {
         String path = "a/b/c";
         String uri = path;
         DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-        HttpServerRequest<ByteBuf> request = new HttpServerRequest<ByteBuf>(nettyRequest, UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
+        HttpServerRequest<ByteBuf> request = newServerRequest(nettyRequest);
         Assert.assertEquals("Unexpected uri string", uri, request.getUri());
         Assert.assertEquals("Unexpected query string", "", request.getQueryString());
+    }
+
+    protected HttpServerRequest<ByteBuf> newServerRequest(DefaultHttpRequest nettyRequest) {
+        Channel noOpChannel = new NoOpChannelHandlerContext().channel();
+        return new HttpServerRequest<ByteBuf>(noOpChannel, nettyRequest,
+                                              UnicastContentSubject.<ByteBuf>createWithoutNoSubscriptionTimeout());
     }
 }


### PR DESCRIPTION
Issue #223 Force closing underlying physical connection whenever an SSE response is received on it.
Issue #225 Now the connection close is triggered after the content completes or the sole subscriber of the content unsubscribes.
Issue #226 Flushing response when `RequestHandler` emits an error or throws an unexpected error.
Issue #214 `HttpServerRequest` should provide access to the underlying `Channel`.
Issue #228 Provided `getChannel()` in `DefaultChannelWriter` instead of `getChannelHandlerContext()`.
Issue #230 FlatResponseOperator does not emit any item if there is no content.
