### PR TITLE
Updated so that the SSLEngines are lazy loaded.

### DIFF
--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/README.md
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/README.md
@@ -30,7 +30,7 @@ Here is the snippet from [SslHelloWordClient](SslHelloWorldClient.java):
 ```java
 public HttpResponseStatus sendHelloRequest() throws Exception {
     HttpClient<ByteBuf, ByteBuf> rxClient = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder("localhost", port)
-            .withSslEngineFactory(DefaultFactories.TRUST_ALL)
+            .withSslEngineFactory(DefaultFactories.trustAll())
             .build();
 
     HttpResponseStatus statusCode = rxClient.submit(HttpClientRequest.createGet("/hello"))
@@ -40,7 +40,7 @@ public HttpResponseStatus sendHelloRequest() throws Exception {
 ```
 
 The client code is identical to its non-encrypted counterpart ([HelloWorldClient](../helloworld/README.md)), except
-the HTTPClient creation step. The predefined DefaultFactories.TRUST_ALL SSLEngineFactory used in the example
+the HTTPClient creation step. The predefined DefaultFactories.trustAll() SSLEngineFactory used in the example
 will accept all certificates without validation. It is good only for testing purposes.
 
 HTTP server
@@ -56,7 +56,7 @@ public HttpServer<ByteBuf, ByteBuf> createServer() throws CertificateException, 
             response.writeStringAndFlush("Welcome!!");
             return response.close();
         }
-    }).withSslEngineFactory(DefaultFactories.SELF_SIGNED).build();
+    }).withSslEngineFactory(DefaultFactories.selfSigned()).build();
     ...
 }
 ```

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/SslHelloWorldClient.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/SslHelloWorldClient.java
@@ -44,7 +44,7 @@ public class SslHelloWorldClient {
 
     public HttpResponseStatus sendHelloRequest() throws Exception {
         HttpClient<ByteBuf, ByteBuf> rxClient = RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder("localhost", port)
-                .withSslEngineFactory(DefaultFactories.TRUST_ALL)
+                .withSslEngineFactory(DefaultFactories.trustAll())
                 .build();
 
         HttpResponseStatus statusCode = rxClient.submit(HttpClientRequest.createGet("/hello"))

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/SslHelloWorldServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/ssl/SslHelloWorldServer.java
@@ -45,7 +45,7 @@ public final class SslHelloWorldServer {
                 response.writeStringAndFlush("Welcome!!");
                 return response.close(false);
             }
-        }).withSslEngineFactory(DefaultFactories.SELF_SIGNED).build();
+        }).withSslEngineFactory(DefaultFactories.selfSigned()).build();
 
         System.out.println("HTTP hello world server started...");
         return server;

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/ssl/SslTcpEchoClient.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/ssl/SslTcpEchoClient.java
@@ -44,7 +44,7 @@ public class SslTcpEchoClient {
 
     public List<String> sendEchos() {
         RxClient<String, String> rxClient = RxNetty.<String, String>newTcpClientBuilder("localhost", port)
-                .withSslEngineFactory(DefaultFactories.TRUST_ALL)
+                .withSslEngineFactory(DefaultFactories.trustAll())
                 .pipelineConfigurator(PipelineConfigurators.textOnlyConfigurator())
                 .build();
 

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/ssl/SslTcpEchoServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/tcp/ssl/SslTcpEchoServer.java
@@ -58,7 +58,7 @@ public final class SslTcpEchoServer {
                     }
                 });
             }
-        }).withSslEngineFactory(DefaultFactories.SELF_SIGNED)
+        }).withSslEngineFactory(DefaultFactories.selfSigned())
                 .appendPipelineConfigurator(PipelineConfigurators.textOnlyConfigurator())
                 .build();
 

--- a/rx-netty/src/main/java/io/reactivex/netty/pipeline/ssl/DefaultFactories.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/pipeline/ssl/DefaultFactories.java
@@ -42,6 +42,9 @@ public final class DefaultFactories {
         return new SSLContextBasedFactory(sslContext);
     }
 
+    /**
+     * Get a SSLEngineFactory configured with a temporary self-signed certificate for testing purposes.
+     */
     public static SSLEngineFactory selfSigned() {
         if (SELF_SIGNED == null) {
             synchronized (SelfSignedSSLEngineFactory.class) {
@@ -51,6 +54,9 @@ public final class DefaultFactories {
         return SELF_SIGNED;
     }
 
+    /**
+     * Get a SSLEngineFactory configured to trust all X.509 certificates without any verification.
+     */
     public static SSLEngineFactory trustAll() {
         if (TRUST_ALL == null) {
             synchronized (TrustAllSSLEngineFactory.class) {

--- a/rx-netty/src/main/java/io/reactivex/netty/pipeline/ssl/DefaultFactories.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/pipeline/ssl/DefaultFactories.java
@@ -27,18 +27,37 @@ import java.security.cert.CertificateException;
 
 /**
  * @author Tomasz Bak
+ * @author Andrew Reitz
  */
 public final class DefaultFactories {
 
-    public static SSLEngineFactory SELF_SIGNED = new SelfSignedSSLEngineFactory();
+    private static SSLEngineFactory SELF_SIGNED;
 
-    public static SSLEngineFactory TRUST_ALL = new TrustAllSSLEngineFactory();
+    private static SSLEngineFactory TRUST_ALL;
 
     private DefaultFactories() {
     }
 
     public static SSLEngineFactory fromSSLContext(SSLContext sslContext) {
         return new SSLContextBasedFactory(sslContext);
+    }
+
+    public static SSLEngineFactory selfSigned() {
+        if (SELF_SIGNED == null) {
+            synchronized (SelfSignedSSLEngineFactory.class) {
+                SELF_SIGNED = new SelfSignedSSLEngineFactory();
+            }
+        }
+        return SELF_SIGNED;
+    }
+
+    public static SSLEngineFactory trustAll() {
+        if (TRUST_ALL == null) {
+            synchronized (TrustAllSSLEngineFactory.class) {
+                TRUST_ALL = new TrustAllSSLEngineFactory();
+            }
+        }
+        return TRUST_ALL;
     }
 
     public static class SSLContextBasedFactory implements SSLEngineFactory {


### PR DESCRIPTION
TRUST_ALL and SELF_SIGNED where both loaded at the same time. In environments where only TRUST_ALL was needed and OpenJdkSelfSignedCertGenerator or BouncyCastleSelfSignedCertGenerator where not available. SELF_SIGNED would throw an exception forcing the user to create their own SSLEngineFactory for this type.

This is a breaking change for users that were using SELF_SIGNED or TRUST_ALL.

Fixes #233
