### PR TITLE
Fixes issues for milestone 0.3.15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@
 version=0.3.15
 netty_version=4.0.21.Final
 slf4j_version=1.7.6
-rxjava_version=0.19.1
+rxjava_version=1.0.0-rc.7

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/file/HttpFileServer.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/file/HttpFileServer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.examples.http.file;
 
 import io.netty.buffer.ByteBuf;

--- a/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/logtail/LogAggregator.java
+++ b/rx-netty-examples/src/main/java/io/reactivex/netty/examples/http/logtail/LogAggregator.java
@@ -29,7 +29,6 @@ import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
 import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
 import rx.Observable;
-import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func1;
 
 import java.util.ArrayList;
@@ -66,9 +65,9 @@ public class LogAggregator {
                                 ServerSentEvent data = new ServerSentEvent(sse.getEventId(), "data", sse.getEventData());
                                 return response.writeAndFlush(data);
                             }
-                        }).onErrorFlatMap(new Func1<OnErrorThrowable, Observable<Void>>() {
+                        }).onErrorResumeNext(new Func1<Throwable, Observable<Void>>() {
                             @Override
-                            public Observable<Void> call(OnErrorThrowable onErrorThrowable) {
+                            public Observable<Void> call(Throwable throwable) {
                                 response.setStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
                                 return response.close();
                             }

--- a/rx-netty-examples/src/main/resources/WEB-INF/index.html
+++ b/rx-netty-examples/src/main/resources/WEB-INF/index.html
@@ -1,1 +1,16 @@
+<!--
+  ~ Copyright 2014 Netflix, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <h1>Hello RxNetty!!!</h1>

--- a/rx-netty-remote-observable/build.gradle
+++ b/rx-netty-remote-observable/build.gradle
@@ -23,7 +23,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
 	compile project(':rx-netty')
 	compile 'com.netflix.numerus:numerus:1.1'
-    compile "com.netflix.rxjava:rxjava-math:${rxjava_version}"
+    compile "io.reactivex:rxjava-math:0.21.0"
 	compile "org.slf4j:slf4j-log4j12:${slf4j_version}"
     testCompile 'junit:junit:4.10'
 }

--- a/rx-netty/build.gradle
+++ b/rx-netty/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(Javadoc).each {
 
 dependencies {
     compile "io.netty:netty-codec-http:${netty_version}"
-    compile "com.netflix.rxjava:rxjava-core:${rxjava_version}"
+    compile "io.reactivex:rxjava:${rxjava_version}"
 
     testCompile 'junit:junit:4.10'
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
@@ -104,7 +104,6 @@ public class ObservableConnection<I, O> extends DefaultChannelWriter<O> {
     @Override
     protected Observable<Void> _close(boolean flush) {
         final PublishSubject<I> thisSubject = inputSubject;
-        cancelPendingWrites(true);
         ReadTimeoutPipelineConfigurator.disableReadTimeout(getChannel().pipeline());
         if (flush) {
             Observable<Void> toReturn = flush().lift(new Observable.Operator<Void, Void>() {

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnection.java
@@ -16,6 +16,7 @@
 
 package io.reactivex.netty.channel;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -40,33 +41,23 @@ public class ObservableConnection<I, O> extends DefaultChannelWriter<O> {
     private final ChannelMetricEventProvider metricEventProvider;
     /* Guarded by closeIssued so that its only updated once*/ protected volatile long closeStartTimeMillis = -1;
 
-    protected ObservableConnection(final ChannelHandlerContext ctx, ChannelMetricEventProvider metricEventProvider,
+    protected ObservableConnection(final Channel channel, ChannelMetricEventProvider metricEventProvider,
                                    MetricEventsSubject<?> eventsSubject) {
-        super(ctx, eventsSubject, metricEventProvider);
+        super(channel, eventsSubject, metricEventProvider);
         this.eventsSubject = eventsSubject;
         this.metricEventProvider = metricEventProvider;
         inputSubject = PublishSubject.create();
-    }
-
-    /**
-     * @deprecated Use {@link ObservableConnection#create(ChannelHandlerContext, MetricEventsSubject,
-     * ChannelMetricEventProvider)} instead.
-     */
-    @Deprecated
-    public ObservableConnection(final ChannelHandlerContext ctx, MetricEventsSubject<?> eventsSubject,
-                                ChannelMetricEventProvider metricEventProvider) {
-        this(ctx, metricEventProvider, eventsSubject);
     }
 
     public Observable<I> getInput() {
         return inputSubject;
     }
 
-    public static <I, O>  ObservableConnection<I, O> create(final ChannelHandlerContext ctx,
+    public static <I, O>  ObservableConnection<I, O> create(final Channel channel,
                                                             final MetricEventsSubject<?> eventsSubject,
                                                             final ChannelMetricEventProvider metricEventProvider) {
-        final ObservableConnection<I, O> toReturn = new ObservableConnection<I, O>(ctx, metricEventProvider,
-                                                                                   eventsSubject);
+        final ObservableConnection<I, O> toReturn = new ObservableConnection<I, O>(channel, metricEventProvider,
+                                                                                eventsSubject);
         /**
          * Sending the event here does not leak "this" via the NewRxConnectionEvent as opposed to doing it inside the
          * constructor.

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/ObservableConnectionFactory.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.channel;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 
 /**
@@ -23,7 +23,7 @@ import io.reactivex.netty.metrics.MetricEventsSubject;
  */
 public interface ObservableConnectionFactory<I, O> {
 
-    ObservableConnection<I, O> newConnection(ChannelHandlerContext ctx);
+    ObservableConnection<I, O> newConnection(Channel channel);
 
     void useMetricEventsSubject(MetricEventsSubject<?> eventsSubject);
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/UnpooledConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/UnpooledConnectionFactory.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.channel;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 
 /**
@@ -33,8 +33,8 @@ public class UnpooledConnectionFactory<I, O> implements ObservableConnectionFact
     }
 
     @Override
-    public ObservableConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return ObservableConnection.create(ctx, eventsSubject, metricEventProvider);
+    public ObservableConnection<I, O> newConnection(Channel channel) {
+        return ObservableConnection.create(channel, eventsSubject, metricEventProvider);
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ClientChannelFactoryImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ClientChannelFactoryImpl.java
@@ -21,7 +21,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.Future;
@@ -83,8 +82,7 @@ public class ClientChannelFactoryImpl<I, O> implements ClientChannelFactory<I, O
                     } else {
                         eventsSubject.onEvent(ClientMetricsEvent.CONNECT_SUCCESS, Clock.onEndMillis(startTimeMillis));
                         ChannelPipeline pipeline = future.channel().pipeline();
-                        ChannelHandlerContext ctx = pipeline.lastContext(); // The connection uses the context for write which should always start from the tail.
-                        final ObservableConnection<I, O> newConnection = connectionFactory.newConnection(ctx);
+                        final ObservableConnection<I, O> newConnection = connectionFactory.newConnection(future.channel());
                         ChannelHandler lifecycleHandler = pipeline.get(RxRequiredConfigurator.CONN_LIFECYCLE_HANDLER_NAME);
                         if (null == lifecycleHandler) {
                             onNewConnection(newConnection, subscriber);

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ClientConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ClientConnectionFactory.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.client;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.channel.ObservableConnectionFactory;
 
@@ -26,5 +26,5 @@ public interface ClientConnectionFactory<I, O, C extends ObservableConnection<I,
         extends ObservableConnectionFactory<I, O> {
 
     @Override
-    C newConnection(ChannelHandlerContext ctx);
+    C newConnection(Channel channel);
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ClientMetricsEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ClientMetricsEvent.java
@@ -44,8 +44,8 @@ public class ClientMetricsEvent<T extends Enum> extends AbstractMetricsEvent<T> 
         PoolReleaseFailed(true, true, Void.class),
 
         /* Write events on underlying connection, this has no associated protocol, so it is raw bytes written. */
-        WriteStart(false, false, Integer.class),
-        WriteSuccess(true, false, Integer.class),
+        WriteStart(false, false, Long.class),
+        WriteSuccess(true, false, Long.class),
         WriteFailed(true, true, Integer.class),
         FlushStart(false, false, Void.class),
         FlushSuccess(true, false, Void.class),

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ConnectionPoolImpl.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ConnectionPoolImpl.java
@@ -168,14 +168,17 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
         long startTimeMillis = Clock.newStartTimeMillis();
 
         try {
+            connection.getChannel().pipeline().fireUserEventTriggered(new PooledConnectionReleasedEvent(connection));
             metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_START);
             if (isShutdown.get() || !connection.isUsable()) {
                 discardConnection(connection);
-                metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, Clock.onEndMillis(startTimeMillis));
+                metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, Clock.onEndMillis(
+                        startTimeMillis));
                 return Observable.empty();
             } else {
                 idleConnections.add(connection);
-                metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, Clock.onEndMillis(startTimeMillis));
+                metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, Clock.onEndMillis(
+                        startTimeMillis));
                 return Observable.empty();
             }
         } catch (Throwable throwable) {

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
@@ -17,9 +17,7 @@
 package io.reactivex.netty.client;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
 import io.reactivex.netty.channel.ChannelMetricEventProvider;
-import io.reactivex.netty.channel.NoOpChannelMetricEventProvider;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 import io.reactivex.netty.protocol.http.client.ClientRequestResponseConverter;
@@ -50,48 +48,9 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
     private volatile long lastReturnToPoolTimeMillis;
     private volatile long maxIdleTimeMillis;
 
-    /**
-     * @deprecated Use {@link PooledConnection#create(ChannelHandlerContext, ChannelMetricEventProvider,
-     * MetricEventsSubject)} instead.
-     */
-    @Deprecated
-    public PooledConnection(ChannelHandlerContext ctx) {
-        this(ctx, PoolConfig.DEFAULT_CONFIG.getMaxIdleTimeMillis());
-    }
-
-    /**
-     * @deprecated Use {@link PooledConnection#create(ChannelHandlerContext, long, ChannelMetricEventProvider,
-     * MetricEventsSubject)} instead.
-     */
-    @Deprecated
-    public PooledConnection(ChannelHandlerContext ctx, long maxIdleTimeMillis) {
-        this(ctx, maxIdleTimeMillis, NoOpChannelMetricEventProvider.NoOpMetricEventsSubject.INSTANCE,
-             NoOpChannelMetricEventProvider.INSTANCE);
-    }
-
-    /**
-     * @deprecated Use {@link PooledConnection#create(ChannelHandlerContext, ChannelMetricEventProvider,
-     * MetricEventsSubject)} instead.
-     */
-    @Deprecated
-    public PooledConnection(ChannelHandlerContext ctx, MetricEventsSubject<?> eventsSubject,
-                            ChannelMetricEventProvider metricEventProvider) {
-        this(ctx, PoolConfig.DEFAULT_CONFIG.getMaxIdleTimeMillis(), eventsSubject, metricEventProvider);
-    }
-
-    /**
-     * @deprecated Use {@link PooledConnection#create(ChannelHandlerContext, long, ChannelMetricEventProvider,
-     * MetricEventsSubject)} instead.
-     */
-    @Deprecated
-    public PooledConnection(ChannelHandlerContext ctx, long maxIdleTimeMillis, MetricEventsSubject<?> eventsSubject,
-                            ChannelMetricEventProvider metricEventProvider) {
-        this(ctx, maxIdleTimeMillis, metricEventProvider, eventsSubject);
-    }
-
-    protected PooledConnection(ChannelHandlerContext ctx, long maxIdleTimeMillis,
+    protected PooledConnection(Channel channel, long maxIdleTimeMillis,
                                ChannelMetricEventProvider metricEventProvider, MetricEventsSubject<?> eventsSubject) {
-        super(ctx, metricEventProvider, eventsSubject);
+        super(channel, metricEventProvider, eventsSubject);
         lastReturnToPoolTimeMillis = System.currentTimeMillis();
         this.maxIdleTimeMillis = maxIdleTimeMillis;
     }
@@ -174,19 +133,19 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
         this.maxIdleTimeMillis = maxIdleTimeMillis;
     }
 
-    public static <I, O> PooledConnection<I, O> create(ChannelHandlerContext ctx, long maxIdleTimeMillis,
+    public static <I, O> PooledConnection<I, O> create(Channel channel, long maxIdleTimeMillis,
                                                        ChannelMetricEventProvider metricEventProvider,
                                                        MetricEventsSubject<?> eventsSubject) {
-        final PooledConnection<I, O> toReturn = new PooledConnection<I, O>(ctx, maxIdleTimeMillis, metricEventProvider,
+        final PooledConnection<I, O> toReturn = new PooledConnection<I, O>(channel, maxIdleTimeMillis, metricEventProvider,
                                                                            eventsSubject);
         toReturn.fireNewRxConnectionEvent();
         return toReturn;
     }
 
-    public static <I, O> PooledConnection<I, O> create(ChannelHandlerContext ctx,
+    public static <I, O> PooledConnection<I, O> create(Channel channel,
                                                        ChannelMetricEventProvider metricEventProvider,
                                                        MetricEventsSubject<?> eventsSubject) {
-        return create(ctx, PoolConfig.DEFAULT_CONFIG.getMaxIdleTimeMillis(), metricEventProvider, eventsSubject);
+        return create(channel, PoolConfig.DEFAULT_CONFIG.getMaxIdleTimeMillis(), metricEventProvider, eventsSubject);
     }
 
     /*Visible for testing*/ void setLastReturnToPoolTimeMillis(long lastReturnToPoolTimeMillis) {

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
@@ -108,8 +108,6 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
             discard(); // This is the case where multiple close are invoked on the same connection.
             // One results in release and then the other result in discard if the call was
             // because of an underlying channel close.
-        } else {
-            cancelPendingWrites(true);
         }
 
         return super.close();
@@ -124,6 +122,9 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
 
         final Observable<Void> release;
         if (null != pool) {
+
+            cancelPendingWrites(true); // Cancel pending writes before releasing to the pool.
+
             release = pool.release(this);
             /**
              * Other way of doing this is release.finallyDo() but that would depend on whether someone subscribes to the

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnection.java
@@ -108,6 +108,8 @@ public class PooledConnection<I, O> extends ObservableConnection<I, O> {
             discard(); // This is the case where multiple close are invoked on the same connection.
             // One results in release and then the other result in discard if the call was
             // because of an underlying channel close.
+        } else {
+            cancelPendingWrites(true);
         }
 
         return super.close();

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnectionFactory.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.client;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 
 /**
@@ -32,8 +32,8 @@ public class PooledConnectionFactory<I, O> implements ClientConnectionFactory<I,
     }
 
     @Override
-    public PooledConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return PooledConnection.create(ctx, poolConfig.getMaxIdleTimeMillis(),
+    public PooledConnection<I, O> newConnection(Channel channel) {
+        return PooledConnection.create(channel, poolConfig.getMaxIdleTimeMillis(),
                                        ClientChannelMetricEventProvider.INSTANCE, eventsSubject);
     }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnectionReleasedEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/PooledConnectionReleasedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.client;
+
+/**
+ * @author Nitesh Kant
+ */
+@SuppressWarnings("rawtypes")
+public class PooledConnectionReleasedEvent {
+
+    private final PooledConnection<?, ?> connection;
+
+    public PooledConnectionReleasedEvent(final PooledConnection<?, ?> connection) {
+        this.connection = connection;
+    }
+
+    public PooledConnection<?, ?> getConnection() {
+        return connection;
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/client/UnpooledClientConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/UnpooledClientConnectionFactory.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.client;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.channel.UnpooledConnectionFactory;
 import io.reactivex.netty.metrics.MetricEventsSubject;
@@ -32,8 +32,8 @@ public class UnpooledClientConnectionFactory<I, O> implements ClientConnectionFa
     }
 
     @Override
-    public ObservableConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return delegate.newConnection(ctx);
+    public ObservableConnection<I, O> newConnection(Channel channel) {
+        return delegate.newConnection(channel);
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/metrics/HttpClientMetricEventsListener.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/metrics/HttpClientMetricEventsListener.java
@@ -40,6 +40,9 @@ public abstract class HttpClientMetricEventsListener extends ClientMetricEventsL
                 case RequestSubmitted:
                     onRequestSubmitted();
                     break;
+                case RequestContentSourceError:
+                    onRequestContentSourceError(throwable);
+                    break;
                 case RequestHeadersWriteStart:
                     onRequestHeadersWriteStart();
                     break;
@@ -61,6 +64,9 @@ public abstract class HttpClientMetricEventsListener extends ClientMetricEventsL
                 case RequestWriteComplete:
                     onRequestWriteComplete(duration, timeUnit);
                     break;
+                case RequestWriteFailed:
+                    onRequestWriteFailed(duration, timeUnit, throwable);
+                    break;
                 case ResponseHeadersReceived:
                     onResponseHeadersReceived(duration, timeUnit);
                     break;
@@ -79,6 +85,10 @@ public abstract class HttpClientMetricEventsListener extends ClientMetricEventsL
             }
         }
     }
+
+    @SuppressWarnings("unused") protected void onRequestContentSourceError(Throwable throwable) {}
+
+    @SuppressWarnings("unused") protected void onRequestWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {}
 
     @SuppressWarnings("unused") protected void onResponseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {}
 

--- a/rx-netty/src/main/java/io/reactivex/netty/metrics/MetricEventsSubject.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/metrics/MetricEventsSubject.java
@@ -65,6 +65,10 @@ public class MetricEventsSubject<E extends MetricsEvent<?>> implements MetricEve
         onEvent(event, NO_DURATION, NO_TIME_UNIT, NO_ERROR, NO_VALUE);
     }
 
+    public void onEvent(E event, Throwable throwable) {
+        onEvent(event, NO_DURATION, NO_TIME_UNIT, throwable, NO_VALUE);
+    }
+
     public void onEvent(E event, long duration, TimeUnit timeUnit) {
         onEvent(event, duration, timeUnit, NO_ERROR, NO_VALUE);
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientMetricsEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientMetricsEvent.java
@@ -28,6 +28,7 @@ public class HttpClientMetricsEvent<T extends Enum> extends ClientMetricsEvent<T
 
         RequestSubmitted(false, false, Void.class),
 
+        RequestContentSourceError(false, true, Void.class),
         RequestHeadersWriteStart(false, false, Void.class),
         RequestHeadersWriteSuccess(true, false, Void.class),
         RequestHeadersWriteFailed(true, true, Void.class),
@@ -36,6 +37,7 @@ public class HttpClientMetricsEvent<T extends Enum> extends ClientMetricsEvent<T
         RequestContentWriteFailed(true, true, Void.class),
 
         RequestWriteComplete(true, false, Void.class),
+        RequestWriteFailed(true, true, Void.class),
 
         ResponseHeadersReceived(false, false, Void.class),
         ResponseContentReceived(false, false, Void.class),
@@ -71,6 +73,7 @@ public class HttpClientMetricsEvent<T extends Enum> extends ClientMetricsEvent<T
     }
 
     public static final HttpClientMetricsEvent<EventType> REQUEST_SUBMITTED = from(EventType.RequestSubmitted);
+    public static final HttpClientMetricsEvent<EventType> REQUEST_CONTENT_SOURCE_ERROR = from(EventType.RequestContentSourceError);
     public static final HttpClientMetricsEvent<EventType> REQUEST_HEADERS_WRITE_START = from(EventType.RequestHeadersWriteStart);
     public static final HttpClientMetricsEvent<EventType> REQUEST_HEADERS_WRITE_SUCCESS = from(EventType.RequestHeadersWriteSuccess);
     public static final HttpClientMetricsEvent<EventType> REQUEST_HEADERS_WRITE_FAILED = from(EventType.RequestHeadersWriteFailed);
@@ -78,6 +81,7 @@ public class HttpClientMetricsEvent<T extends Enum> extends ClientMetricsEvent<T
     public static final HttpClientMetricsEvent<EventType> REQUEST_CONTENT_WRITE_SUCCESS = from(EventType.RequestContentWriteSuccess);
     public static final HttpClientMetricsEvent<EventType> REQUEST_CONTENT_WRITE_FAILED = from(EventType.RequestContentWriteFailed);
     public static final HttpClientMetricsEvent<EventType> REQUEST_WRITE_COMPLETE = from(EventType.RequestWriteComplete);
+    public static final HttpClientMetricsEvent<EventType> REQUEST_WRITE_FAILED = from(EventType.RequestWriteFailed);
 
     public static final HttpClientMetricsEvent<EventType> RESPONSE_HEADER_RECEIVED = from(EventType.ResponseHeadersReceived);
     public static final HttpClientMetricsEvent<EventType> RESPONSE_CONTENT_RECEIVED = from(EventType.ResponseContentReceived);

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientRequest.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientRequest.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.reactivex.netty.channel.ByteTransformer;
 import io.reactivex.netty.channel.ContentTransformer;
 import rx.Observable;
+import rx.functions.Action0;
 import rx.functions.Func1;
 
 import java.nio.charset.Charset;
@@ -42,6 +43,7 @@ public class HttpClientRequest<T> {
     private Observable<T> contentSource;
     private Observable<ByteBuf> rawContentSource;
     private String absoluteUri;
+    private Action0 onWriteCompleteAction;
 
     HttpClientRequest(HttpRequest nettyRequest) {
         this.nettyRequest = nettyRequest;
@@ -125,7 +127,7 @@ public class HttpClientRequest<T> {
         });
         return this;
     }
-    
+
     public <S> HttpClientRequest<T> withRawContent(S content, final ContentTransformer<S> transformer) {
         return withRawContentSource(Observable.just(content), transformer);
     }
@@ -188,6 +190,16 @@ public class HttpClientRequest<T> {
     void removeContent() {
         contentSource = null;
         rawContentSource = null;
+    }
+
+    void doOnWriteComplete(Action0 onWriteCompleteAction) {
+        this.onWriteCompleteAction = onWriteCompleteAction;
+    }
+
+    void onWriteComplete() {
+        if (null != onWriteCompleteAction) {
+            onWriteCompleteAction.call();
+        }
     }
 
     /*Set by HttpClient*/void setDynamicUriParts(String host, int port, boolean secure) {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -70,6 +70,8 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
                     @Override
                     public void onNext(final ObservableConnection<HttpClientResponse<O>, HttpClientRequest<I>> connection) {
 
+                        // Why don't we close the connection on unsubscribe?
+                        // See issue: https://github.com/ReactiveX/RxNetty/issues/225
                         cs.add(connection.getInput()
                                          .doOnNext(new Action1<HttpClientResponse<O>>() {
                                              @Override
@@ -101,6 +103,8 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
 
                                     @Override
                                     public void onError(Throwable e) {
+                                        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_WRITE_FAILED,
+                                                              Clock.onEndMillis(startTimeMillis), e);
                                         child.onError(e);
                                     }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -23,6 +23,7 @@ import io.reactivex.netty.metrics.MetricEventsSubject;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscriber;
+import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.subscriptions.CompositeSubscription;
 
@@ -86,26 +87,31 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
                                              }
                                          })
                                          .subscribe(child)); //subscribe the child for response.
-
-                        connection.writeAndFlush(request).subscribe(new Observer<Void>() {
+                        request.doOnWriteComplete(new Action0() {
                             @Override
-                            public void onCompleted() {
-                                // Failure in writes gets reported during write, this is for the entire request write
-                                // over event.
-                                eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_WRITE_COMPLETE,
-                                                      Clock.onEndMillis(startTimeMillis));
-                            }
+                            public void call() {
+                                connection.flush().subscribe(new Observer<Void>() {
+                                    @Override
+                                    public void onCompleted() {
+                                        // Failure in writes gets reported during write, this is for the entire request write
+                                        // over event.
+                                        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_WRITE_COMPLETE,
+                                                              Clock.onEndMillis(startTimeMillis));
+                                    }
 
-                            @Override
-                            public void onError(Throwable e) {
-                                child.onError(e);
-                            }
+                                    @Override
+                                    public void onError(Throwable e) {
+                                        child.onError(e);
+                                    }
 
-                            @Override
-                            public void onNext(Void aVoid) {
-                                // No op as nothing to do for a write onNext().
+                                    @Override
+                                    public void onNext(Void aVoid) {
+                                        // No op as nothing to do for a write onNext().
+                                    }
+                                });
                             }
                         });
+                        connection.write(request);
                     }
                 };
         return toReturn;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -76,9 +76,7 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                         final long startTimeMillis = Clock.newStartTimeMillis();
                         eventsSubject.onEvent(HttpServerMetricsEvent.NEW_REQUEST_RECEIVED);
 
-                        @SuppressWarnings("deprecation") //TODO: Remove when we stop returning ctx. (Issue https://github.com/ReactiveX/RxNetty/issues/229)
-                        final HttpServerResponse<O> response =
-                                new HttpServerResponse<O>(newConnection.getChannelHandlerContext(),
+                        final HttpServerResponse<O> response = new HttpServerResponse<O>(newConnection.getChannel(),
                         /*
                          * Server should send the highest version it is compatible with.
                          * http://tools.ietf.org/html/rfc2145#section-2.3

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpError.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpError.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server;
 
 import io.netty.handler.codec.http.HttpResponseStatus;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
@@ -18,8 +18,8 @@ package io.reactivex.netty.protocol.http.server;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -53,19 +53,19 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
     private volatile boolean fullResponseWritten;
     private ChannelFuture headerWriteFuture;
 
-    protected HttpServerResponse(ChannelHandlerContext ctx,
+    protected HttpServerResponse(Channel nettyChannel,
                                  MetricEventsSubject<? extends ServerMetricsEvent<?>> eventsSubject) {
-        this(ctx, HttpVersion.HTTP_1_1, eventsSubject);
+        this(nettyChannel, HttpVersion.HTTP_1_1, eventsSubject);
     }
 
-    protected HttpServerResponse(ChannelHandlerContext ctx, HttpVersion httpVersion,
+    protected HttpServerResponse(Channel nettyChannel, HttpVersion httpVersion,
                                  MetricEventsSubject<? extends ServerMetricsEvent<?>> eventsSubject) {
-        this(ctx, new DefaultHttpResponse(httpVersion, HttpResponseStatus.OK), eventsSubject);
+        this(nettyChannel, new DefaultHttpResponse(httpVersion, HttpResponseStatus.OK), eventsSubject);
     }
 
-    /*Visible for testing */ HttpServerResponse(ChannelHandlerContext ctx, HttpResponse nettyResponse,
+    /*Visible for testing */ HttpServerResponse(Channel nettyChannel, HttpResponse nettyResponse,
                                                 MetricEventsSubject<? extends ServerMetricsEvent<?>> eventsSubject) {
-        super(ctx, eventsSubject, ServerChannelMetricEventProvider.INSTANCE);
+        super(nettyChannel, eventsSubject, ServerChannelMetricEventProvider.INSTANCE);
         this.nettyResponse = nettyResponse;
         headers = new HttpResponseHeaders(nettyResponse);
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandlerWithErrorMapper.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandlerWithErrorMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server;
 
 import rx.Observable;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
@@ -82,6 +82,7 @@ public class ServerRequestResponseConverter extends ChannelDuplexHandler {
         if (HttpRequest.class.isAssignableFrom(recievedMsgClass)) {
             eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HEADERS_RECEIVED);
             stateToUse.createRxRequest(ctx, (HttpRequest) msg); // Update the state to use.
+            stateToUse.rxRequest.onProcessingStart(Clock.newStartTimeMillis());
             super.channelRead(ctx, stateToUse.rxRequest);
             isHttpRequest = true;
         }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/AbstractFileRequestHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/AbstractFileRequestHandler.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server.file;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import io.reactivex.netty.protocol.http.server.RequestHandler;
-import io.netty.handler.codec.http.HttpHeaders;
 
+import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -15,8 +31,6 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
-
-import javax.activation.MimetypesFileTypeMap;
 
 public abstract class AbstractFileRequestHandler implements RequestHandler<ByteBuf, ByteBuf> {
     public static final Pattern INSECURE_URI = Pattern.compile(".*[<>&\"].*");

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/ClassPathFileRequestHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/ClassPathFileRequestHandler.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server.file;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * FileRequestHandler that reads files from the class path

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/FileErrorResponseMapper.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/FileErrorResponseMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server.file;
 
 import io.netty.buffer.ByteBuf;

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/LocalDirectoryRequestHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/LocalDirectoryRequestHandler.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server.file;
 
 import io.netty.util.internal.SystemPropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * FileRequestHandler that reads files from the file system

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/WebappFileRequestHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/file/WebappFileRequestHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server.file;
 
 public class WebappFileRequestHandler extends ClassPathFileRequestHandler {

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnection.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnection.java
@@ -16,10 +16,9 @@
 package io.reactivex.netty.protocol.udp.client;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.netty.channel.socket.DatagramPacket;
 import io.reactivex.netty.channel.ChannelMetricEventProvider;
-import io.reactivex.netty.channel.NoOpChannelMetricEventProvider;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 import rx.Observable;
@@ -37,41 +36,19 @@ public class UdpClientConnection<I, O> extends ObservableConnection<I, O> {
 
     private final InetSocketAddress receiverAddress;
 
-    protected UdpClientConnection(ChannelHandlerContext ctx, InetSocketAddress receiverAddress,
+    protected UdpClientConnection(Channel channel, InetSocketAddress receiverAddress,
                                   ChannelMetricEventProvider metricEventProvider,
                                   MetricEventsSubject<?> eventsSubject) {
-        super(ctx, metricEventProvider, eventsSubject);
+        super(channel, metricEventProvider, eventsSubject);
         this.receiverAddress = receiverAddress;
     }
 
-
-    /**
-     * @deprecated Use {@link #create(ChannelHandlerContext, InetSocketAddress, MetricEventsSubject,
-     * ChannelMetricEventProvider)} instead.
-     */
-    @Deprecated
-    public UdpClientConnection(ChannelHandlerContext ctx, InetSocketAddress receiverAddress) {
-        this(ctx, receiverAddress, NoOpChannelMetricEventProvider.NoOpMetricEventsSubject.INSTANCE,
-             NoOpChannelMetricEventProvider.INSTANCE);
-    }
-
-    /**
-     * @deprecated Use {@link #create(ChannelHandlerContext, InetSocketAddress, MetricEventsSubject,
-     * ChannelMetricEventProvider)} instead.
-     */
-    @Deprecated
-    public UdpClientConnection(ChannelHandlerContext ctx, InetSocketAddress receiverAddress,
-                               MetricEventsSubject<?> eventsSubject, ChannelMetricEventProvider metricEventProvider) {
-        super(ctx, metricEventProvider, eventsSubject);
-        this.receiverAddress = receiverAddress;
-    }
-
-    public static <I, O> UdpClientConnection<I, O> create(final ChannelHandlerContext ctx,
+    public static <I, O> UdpClientConnection<I, O> create(final Channel channel,
                                                           InetSocketAddress receiverAddress,
                                                           final MetricEventsSubject<?> eventsSubject,
                                                           final ChannelMetricEventProvider metricEventProvider) {
-        UdpClientConnection<I, O> toReturn = new UdpClientConnection<I, O>(ctx, receiverAddress, metricEventProvider,
-                                                                           eventsSubject);
+        UdpClientConnection<I, O> toReturn = new UdpClientConnection<I, O>(channel, receiverAddress, metricEventProvider,
+                                                                        eventsSubject);
         toReturn.fireNewRxConnectionEvent();
         return toReturn;
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnectionFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/udp/client/UdpClientConnectionFactory.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.protocol.udp.client;
 
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.netty.channel.socket.DatagramPacket;
 import io.reactivex.netty.client.ClientChannelMetricEventProvider;
 import io.reactivex.netty.client.ClientConnectionFactory;
@@ -43,8 +43,8 @@ class UdpClientConnectionFactory<I, O> implements ClientConnectionFactory<I, O, 
     }
 
     @Override
-    public UdpClientConnection<I, O> newConnection(ChannelHandlerContext ctx) {
-        return UdpClientConnection.create(ctx, receiverAddress, eventsSubject,
+    public UdpClientConnection<I, O> newConnection(Channel channel) {
+        return UdpClientConnection.create(channel, receiverAddress, eventsSubject,
                                           ClientChannelMetricEventProvider.INSTANCE);
     }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/server/ConnectionLifecycleHandler.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/ConnectionLifecycleHandler.java
@@ -57,7 +57,7 @@ public class ConnectionLifecycleHandler<I, O> extends ChannelInboundHandlerAdapt
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         if(null == ctx.channel().pipeline().get(SslHandler.class)) {
             final long startTimeMillis = Clock.newStartTimeMillis();
-            connection = connectionFactory.newConnection(ctx);
+            connection = connectionFactory.newConnection(ctx.channel());
             eventsSubject.onEvent(ServerMetricsEvent.NEW_CLIENT_CONNECTED);
 
             super.channelActive(ctx); // Called before connection handler call to finish the pipeline before the connection
@@ -74,7 +74,7 @@ public class ConnectionLifecycleHandler<I, O> extends ChannelInboundHandlerAdapt
         super.userEventTriggered(ctx, evt);
         if (evt instanceof SslHandshakeCompletionEvent) {
             final long startTimeMillis = Clock.newStartTimeMillis();
-            connection = connectionFactory.newConnection(ctx.pipeline().lastContext());
+            connection = connectionFactory.newConnection(ctx.channel());
             handleConnection(startTimeMillis);
         }
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/server/ServerMetricsEvent.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/ServerMetricsEvent.java
@@ -34,8 +34,8 @@ public class ServerMetricsEvent<T extends Enum> extends AbstractMetricsEvent<T> 
         ConnectionCloseFailed(true, true, Void.class),
 
         /* Write events on underlying connection, this has no associated protocol, so it is raw bytes written. */
-        WriteStart(false, false, Integer.class),
-        WriteSuccess(true, false, Integer.class),
+        WriteStart(false, false, Long.class),
+        WriteSuccess(true, false, Long.class),
         WriteFailed(true, true, Integer.class),
         FlushStart(false, false, Void.class),
         FlushSuccess(true, false, Void.class),

--- a/rx-netty/src/main/java/io/reactivex/netty/util/MultipleFutureListener.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/util/MultipleFutureListener.java
@@ -88,7 +88,6 @@ public class MultipleFutureListener implements ChannelFutureListener {
          * If all complete (listen count == 0) we complete the subscribers.
          */
         if (!future.isSuccess()) {
-            cancelPendingFutures(true);
             completionPromise.tryFailure(future.cause());
         } else if (nowListeningTo == 0) {
             completionPromise.trySuccess(null);

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
@@ -69,7 +69,7 @@ public class CookieTest {
     public void testSetCookie() throws Exception {
         DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
         HttpServerResponse<ByteBuf> response =
-                new HttpServerResponse<ByteBuf>(new NoOpChannelHandlerContext(), nettyResponse,
+                new HttpServerResponse<ByteBuf>(new NoOpChannelHandlerContext().channel(), nettyResponse,
                                                 new MetricEventsSubject<HttpServerMetricsEvent<?>>());
         String cookieName = "name";
         String cookieValue = "value";

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
@@ -86,12 +86,13 @@ public class HttpServerTest {
         HttpServer<ByteBuf, ByteBuf> server = RxNetty.newHttpServerBuilder(0, new RequestHandler<ByteBuf, ByteBuf>() {
             @Override
             public Observable<Void> handle(HttpServerRequest<ByteBuf> request, final HttpServerResponse<ByteBuf> serverResponse) {
-                return Observable.just(1L, Schedulers.computation())
+                return Observable.just(1L).subscribeOn(Schedulers.computation())
                                  .flatMap(new Func1<Long, Observable<Void>>() {
                                      @Override
                                      public Observable<Void> call(Long aLong) {
                                          serverResponse.setStatus(HttpResponseStatus.NOT_FOUND);
-                                         return serverResponse.close(true); // Processing in a separate thread needs a flush.
+                                         return serverResponse.close(
+                                                 true); // Processing in a separate thread needs a flush.
                                      }
                                  });
             }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/file/FileRequestHandlerTest.java
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/file/FileRequestHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.reactivex.netty.protocol.http.server.file;
 
 import io.netty.buffer.ByteBuf;
@@ -7,18 +22,16 @@ import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
 import io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import io.reactivex.netty.protocol.http.server.HttpServer;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.Assert;
 import org.junit.Test;
-
 import rx.Observable;
 import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func1;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class FileRequestHandlerTest {
     @Test


### PR DESCRIPTION
#243 HttpServerListener requestReadTimes metric value is incorrect
#245 Race condition between write and flush in `HttpClient.submit()`
#248 Connection close cancels pending writes
#249 `BytesInspector` does not record events for `ByteBufHolder` and `FileRegion`
#250 Connection closing and content stream behavior
#251 Metric events for Request content source error and request write failure
#252 Upgrade RxJava to 1.0.0-RC7
#229 Remove deprecated method `DefaultChannelWriter.getChannelHandlerContext()`
