### PR TITLE
Comprehensive HTTP Router

### DIFF
--- a/rx-netty/build.gradle
+++ b/rx-netty/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     compile "io.netty:netty-codec-http:${netty_version}"
     compile "com.netflix.rxjava:rxjava-core:${rxjava_version}"
 
+    testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
+    testCompile 'cglib:cglib-nodep:3.1' // for spock interactions
+    testCompile 'org.objenesis:objenesis:2.1' // for spock interactions
+
     testCompile 'junit:junit:4.10'
 }
 

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpRouter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/HttpRouter.java
@@ -1,0 +1,250 @@
+package io.reactivex.netty.protocol.http.server;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import rx.Observable;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class HttpRouter<I, O> implements RequestHandler<I, O> {
+    private final List<PatternBinding> getBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> putBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> postBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> deleteBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> optionsBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> headBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> traceBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> connectBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private final List<PatternBinding> patchBindings = new CopyOnWriteArrayList<PatternBinding>();
+    private RequestHandler<I, O> noMatchHandler;
+
+    @Override
+    public Observable<Void> handle(HttpServerRequest<I> request, HttpServerResponse<O> response) {
+        String method = request.getHttpMethod().toString();
+
+        if("GET".equals(method))
+            route(request, response, getBindings);
+        else if("PUT".equals(method))
+            route(request, response, putBindings);
+        else if("POST".equals(method))
+            route(request, response, postBindings);
+        else if("DELETE".equals(method))
+            route(request, response, deleteBindings);
+        else if("OPTIONS".equals(method))
+            route(request, response, optionsBindings);
+        else if("HEAD".equals(method))
+            route(request, response, headBindings);
+        else if("TRACE".equals(method))
+            route(request, response, traceBindings);
+        else if("PATCH".equals(method))
+            route(request, response, patchBindings);
+        else if("CONNECT".equals(method))
+            route(request, response, connectBindings);
+        else
+            notFound(request, response);
+
+        if(!response.isCloseIssued()) // might have been issued by an overzealous handler
+            return response.close();
+        return Observable.empty();
+    }
+
+    public HttpRouter<I, O> get(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, getBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> put(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, putBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> post(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, postBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> delete(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, deleteBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> options(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, optionsBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> head(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, headBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> trace(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, traceBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> connect(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, connectBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> patch(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, patchBindings);
+        return this;
+    }
+
+    /**
+     * Specify a handler that will be called for all HTTP methods
+     * @param pattern The simple pattern
+     * @param handler The handler to call
+     */
+    public HttpRouter<I, O> all(String pattern, RequestHandler<I, O> handler) {
+        addPattern(pattern, handler, getBindings);
+        addPattern(pattern, handler, putBindings);
+        addPattern(pattern, handler, postBindings);
+        addPattern(pattern, handler, deleteBindings);
+        addPattern(pattern, handler, optionsBindings);
+        addPattern(pattern, handler, headBindings);
+        addPattern(pattern, handler, traceBindings);
+        addPattern(pattern, handler, connectBindings);
+        addPattern(pattern, handler, patchBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> getWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, getBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> putWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, putBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> postWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, postBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> deleteWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, deleteBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> optionsWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, optionsBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> headWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, headBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> traceWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, traceBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> connectWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, connectBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> patchWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, patchBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> allWithRegEx(String regex, RequestHandler<I, O> handler) {
+        addRegEx(regex, handler, getBindings);
+        addRegEx(regex, handler, putBindings);
+        addRegEx(regex, handler, postBindings);
+        addRegEx(regex, handler, deleteBindings);
+        addRegEx(regex, handler, optionsBindings);
+        addRegEx(regex, handler, headBindings);
+        addRegEx(regex, handler, traceBindings);
+        addRegEx(regex, handler, connectBindings);
+        addRegEx(regex, handler, patchBindings);
+        return this;
+    }
+
+    public HttpRouter<I, O> noMatch(RequestHandler<I, O> handler) {
+        noMatchHandler = handler;
+        return this;
+    }
+
+    private void addPattern(String input, RequestHandler<I, O> handler, List<PatternBinding> bindings) {
+        // We need to search for any :<token name> tokens in the String and replace them with named capture groups
+        Matcher m =  Pattern.compile(":([A-Za-z][A-Za-z0-9_]*)").matcher(input);
+        StringBuffer sb = new StringBuffer();
+        Set<String> groups = new HashSet<String>();
+        while (m.find()) {
+            String group = m.group().substring(1);
+            if (groups.contains(group)) {
+                throw new IllegalArgumentException("Cannot use identifier " + group + " more than once in pattern string");
+            }
+            m.appendReplacement(sb, "(?<$1>[^\\/]+)");
+            groups.add(group);
+        }
+        m.appendTail(sb);
+        String regex = sb.toString();
+        PatternBinding binding = new PatternBinding(Pattern.compile(regex), groups, handler);
+        bindings.add(binding);
+    }
+
+    private void addRegEx(String input, RequestHandler<I, O> handler, List<PatternBinding> bindings) {
+        PatternBinding binding = new PatternBinding(Pattern.compile(input), null, handler);
+        bindings.add(binding);
+    }
+
+    private void route(HttpServerRequest<I> request, HttpServerResponse<O> response, List<PatternBinding> bindings) {
+        for (PatternBinding binding: bindings) {
+            Matcher m = binding.pattern.matcher(request.getPath()); // FIXME what is the difference between path and uri?
+            if (m.matches()) {
+                if (binding.paramNames != null) {
+                    // Named params
+                    for (String param: binding.paramNames)
+                        addQueryParam(request, param, m.group(param));
+                } else {
+                    // Un-named params
+                    for (int i = 0; i < m.groupCount(); i++)
+                        addQueryParam(request, "param" + i, m.group(i+1));
+                }
+                binding.handler.handle(request, response);
+                return;
+            }
+        }
+        notFound(request, response);
+    }
+
+    private void addQueryParam(HttpServerRequest<I> request, String key, String val) {
+        List<String> params = request.getQueryParameters().get(key);
+        if(params == null) {
+            params = new ArrayList<String>();
+            request.getQueryParameters().put(key, params);
+        }
+        params.add(val);
+    }
+
+    private void notFound(HttpServerRequest<I> request, HttpServerResponse<O> response) {
+        if (noMatchHandler != null)
+            noMatchHandler.handle(request, response);
+        else
+            response.setStatus(HttpResponseStatus.NOT_FOUND);
+    }
+
+    private class PatternBinding {
+        final Pattern pattern;
+        final RequestHandler<I, O> handler;
+        final Set<String> paramNames;
+
+        private PatternBinding(Pattern pattern, Set<String> paramNames, RequestHandler<I, O> handler) {
+            this.pattern = pattern;
+            this.handler = handler;
+            this.paramNames = paramNames;
+        }
+    }
+}

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/UriInfoHolder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/UriInfoHolder.java
@@ -17,6 +17,7 @@ package io.reactivex.netty.protocol.http.server;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +54,7 @@ public class UriInfoHolder {
     }
 
     public synchronized Map<String, List<String>> getQueryParameters() {
-        return decoder.parameters();
+        // decoder.parameters() sometimes returns an immutable map
+        return new HashMap<String, List<String>>(decoder.parameters());
     }
 }

--- a/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpRouterSpec.groovy
+++ b/rx-netty/src/test/java/io/reactivex/netty/protocol/http/server/HttpRouterSpec.groovy
@@ -1,0 +1,73 @@
+package io.reactivex.netty.protocol.http.server
+
+import io.netty.handler.codec.http.HttpMethod
+import spock.lang.Ignore
+import spock.lang.Specification
+
+class HttpRouterSpec extends Specification {
+    def 'router matches by method and path'() {
+        setup:
+        def request = Mock(HttpServerRequest)
+        def response = Mock(HttpServerResponse)
+
+        when:
+        new HttpRouter().get('/endpoint', { req, resp -> resp.write('hit') } as RequestHandler).handle(request, response)
+
+        then:
+        request.httpMethod >> method
+        request.path >> path
+        hits * response.write('hit')
+
+        where:
+        method      |   path            |   hits
+        HttpMethod.GET         |   '/endpoint'     |   1
+        HttpMethod.GET         |   '/unmapped'     |   0
+        HttpMethod.POST        |   '/endpoint'     |   0
+    }
+
+    def 'router matches by method and regex'() {
+        setup:
+        def request = Mock(HttpServerRequest)
+        def response = Mock(HttpServerResponse)
+
+        when:
+        new HttpRouter().get('/a+', { req, resp -> resp.write('hit') } as RequestHandler).handle(request, response)
+
+        then:
+        request.httpMethod >> method
+        request.path >> path
+        hits * response.write('hit')
+
+        where:
+        method      |   path            |   hits
+        HttpMethod.GET         |   '/a'            |   1
+        HttpMethod.GET         |   '/aa'           |   1
+        HttpMethod.GET         |   '/ab'           |   0
+        HttpMethod.POST        |   '/a'            |   0
+    }
+
+    def 'router extracts request parameters from the path'() {
+        setup:
+        def request = Mock(HttpServerRequest)
+        def response = Mock(HttpServerResponse)
+        request.httpMethod >> HttpMethod.GET
+
+        def params = [:]
+        request.queryParameters >> params
+
+        when:
+        new HttpRouter().get('/:blogname/:post', { req, resp ->
+            resp.write(req.queryParameters['blogname'])
+            resp.write(req.queryParameters['post'])
+        } as RequestHandler).handle(request, response)
+
+        then:
+        request.getPath() >> "/blog/post"
+        1 * response.write(['blog'])
+        1 * response.write(['post'])
+
+        then:
+        request.getPath() >> "/blog"
+        0 * response.write(_)
+    }
+}


### PR DESCRIPTION
Here is a partial solution to Issue #202, at least for different HTTP methods.  There is no provision for websocket or SSE support here.  This is more or less a port of the excellent Vert.x RouteMatcher for RxNetty.  I do want to point out that I had to force queryParameters to be mutable on HttpRequest for this particular implementation.
