### PR TITLE
Fixes for 0.3.16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # RxNetty Releases #
 
+### Version 0.3.16 ###
+
+[Milestone](https://github.com/ReactiveX/RxNetty/issues?q=milestone%3A0.3.16+is%3Aclosed)
+
+* [Issue 258] (https://github.com/Netflix/RxNetty/issues/258) Include port in the HTTP HOST header.
+* [Issue 259] (https://github.com/Netflix/RxNetty/issues/259) Support native netty protocol as a runtime choice.
+* [Issue 260] (https://github.com/Netflix/RxNetty/issues/260) Convert `RxEventLoopProvider` and `MetricEventsListenerFactory` to abstract classes.
+* [Issue 261] (https://github.com/Netflix/RxNetty/issues/261) `ServerSentEventEncoder` is sub-optimal in using StringBuilder
+
+##### Incompatible changes
+
+* [Issue 260] (https://github.com/Netflix/RxNetty/issues/260) Convert `RxEventLoopProvider` and `MetricEventsListenerFactory` to abstract classes.
+
+Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.rxnetty%22%20AND%20v%3A%220.3.15%22)
+
 ### Version 0.3.15 ###
 
 [Milestone](https://github.com/ReactiveX/RxNetty/issues?q=milestone%3A0.3.15+is%3Aclosed)

--- a/rx-netty-servo/src/main/java/io/reactivex/netty/servo/ServoEventsListenerFactory.java
+++ b/rx-netty-servo/src/main/java/io/reactivex/netty/servo/ServoEventsListenerFactory.java
@@ -38,7 +38,7 @@ import io.reactivex.netty.servo.udp.UdpServerListener;
 /**
  * @author Nitesh Kant
  */
-public class ServoEventsListenerFactory implements MetricEventsListenerFactory {
+public class ServoEventsListenerFactory extends MetricEventsListenerFactory {
 
     private final String clientMetricNamePrefix;
     private final String serverMetricNamePrefix;

--- a/rx-netty/build.gradle
+++ b/rx-netty/build.gradle
@@ -27,6 +27,7 @@ tasks.withType(Javadoc).each {
 
 dependencies {
     compile "io.netty:netty-codec-http:${netty_version}"
+    compile "io.netty:netty-transport-native-epoll:${netty_version}"
     compile "io.reactivex:rxjava:${rxjava_version}"
 
     testCompile 'junit:junit:4.10'

--- a/rx-netty/src/main/java/io/reactivex/netty/RxNetty.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/RxNetty.java
@@ -64,6 +64,8 @@ public final class RxNetty {
 
     private static MetricEventsListenerFactory metricEventsListenerFactory;
 
+    private static volatile boolean usingNativeTransport;
+
     private RxNetty() {
     }
 
@@ -255,6 +257,54 @@ public final class RxNetty {
 
     public static RxEventLoopProvider getRxEventLoopProvider() {
         return rxEventLoopProvider;
+    }
+
+    /**
+     * A global flag to start using netty's <a href="https://github.com/netty/netty/wiki/Native-transports">native protocol</a>
+     * if applicable for a client or server.
+     *
+     * <b>This does not evaluate whether the native transport is available for the OS or not.</b>
+     *
+     * So, this method should be called conditionally when the caller is sure that the OS supports the native protocol.
+     *
+     * Alternatively, this can be done selectively per client and server instance by doing the following:
+     *
+     * <h2>Http Server</h2>
+     <pre>
+     * {@code
+       RxNetty.newHttpServerBuilder(8888, new RequestHandler<Object, Object>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<Object> request, HttpServerResponse<Object> response) {
+            return null;
+            }
+       }).channel(EpollServerSocketChannel.class)
+         .eventLoop(new EpollEventLoopGroup());
+      }
+     </pre>
+     *
+     * <h2>Http Client</h2>
+     *
+     <pre>
+     {@code
+     RxNetty.newHttpClientBuilder("localhost", 8888)
+            .channel(EpollSocketChannel.class)
+            .eventloop(new EpollEventLoopGroup());
+     }
+     </pre>
+     */
+    public static void useNativeTransportIfApplicable() {
+        usingNativeTransport = true;
+    }
+
+    /**
+     * A global flag to disable the effects of calling {@link #useNativeTransportIfApplicable()}
+     */
+    public static void disableNativeTransport() {
+        usingNativeTransport = false;
+    }
+
+    public static boolean isUsingNativeTransport() {
+        return usingNativeTransport;
     }
 
     private static RxClient.ServerInfo getServerInfoFromRequest(HttpClientRequest<ByteBuf> request)

--- a/rx-netty/src/main/java/io/reactivex/netty/RxNetty.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/RxNetty.java
@@ -61,6 +61,7 @@ public final class RxNetty {
 
     private static final CompositeHttpClient<ByteBuf, ByteBuf> globalClient =
             new CompositeHttpClientBuilder<ByteBuf, ByteBuf>().withMaxConnections(DEFAULT_MAX_CONNECTIONS).build();
+
     private static MetricEventsListenerFactory metricEventsListenerFactory;
 
     private RxNetty() {

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
@@ -55,4 +55,39 @@ public abstract class RxEventLoopProvider {
      * @return The {@link EventLoopGroup} to be used for all servers.
      */
     public abstract EventLoopGroup globalServerParentEventLoop();
+
+    /**
+     * The {@link EventLoopGroup} to be used by all {@link RxClient} instances if it is not explicitly provided using
+     * {@link ClientBuilder#eventloop(EventLoopGroup)}.
+     *
+     * @param nativeTransport {@code true} If the eventloop for native transport is to be returned (if configured)
+     *
+     * @return The {@link EventLoopGroup} to be used for all client. If {@code nativeTransport} was {@code true} then
+     * return the {@link EventLoopGroup} for native transport.
+     */
+    public abstract EventLoopGroup globalClientEventLoop(boolean nativeTransport);
+
+    /**
+     * The {@link EventLoopGroup} to be used by all {@link RxServer} instances if it is not explicitly provided using
+     * {@link ServerBuilder#eventLoop(EventLoopGroup)} or {@link ServerBuilder#eventLoops(EventLoopGroup, EventLoopGroup)} .
+     *
+     * @param nativeTransport {@code true} If the eventloop for native transport is to be returned (if configured)
+     *
+     * @return The {@link EventLoopGroup} to be used for all servers. If {@code nativeTransport} was {@code true} then
+     * return the {@link EventLoopGroup} for native transport.     *
+     */
+    public abstract EventLoopGroup globalServerEventLoop(boolean nativeTransport);
+
+    /**
+     * The {@link EventLoopGroup} to be used by all {@link RxServer} instances as a parent eventloop group
+     * (First argument to this method: {@link io.netty.bootstrap.ServerBootstrap#group(EventLoopGroup, EventLoopGroup)}),
+     * if it is not explicitly provided using {@link ServerBuilder#eventLoop(EventLoopGroup)} or
+     * {@link ServerBuilder#eventLoops(EventLoopGroup, EventLoopGroup)}.
+     *
+     * @param nativeTransport {@code true} If the eventloop for native transport is to be returned (if configured)
+     *
+     * @return The {@link EventLoopGroup} to be used for all servers. If {@code nativeTransport} was {@code true} then
+     * return the {@link EventLoopGroup} for native transport.
+     */
+    public abstract EventLoopGroup globalServerParentEventLoop(boolean nativeTransport);
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/RxEventLoopProvider.java
@@ -28,7 +28,7 @@ import io.reactivex.netty.server.ServerBuilder;
  *
  * @author Nitesh Kant
  */
-public interface RxEventLoopProvider {
+public abstract class RxEventLoopProvider {
 
     /**
      * The {@link EventLoopGroup} to be used by all {@link RxClient} instances if it is not explicitly provided using
@@ -36,7 +36,7 @@ public interface RxEventLoopProvider {
      *
      * @return The {@link EventLoopGroup} to be used for all clients.
      */
-    EventLoopGroup globalClientEventLoop();
+    public abstract EventLoopGroup globalClientEventLoop();
 
     /**
      * The {@link EventLoopGroup} to be used by all {@link RxServer} instances if it is not explicitly provided using
@@ -44,7 +44,7 @@ public interface RxEventLoopProvider {
      *
      * @return The {@link EventLoopGroup} to be used for all servers.
      */
-    EventLoopGroup globalServerEventLoop();
+    public abstract EventLoopGroup globalServerEventLoop();
 
     /**
      * The {@link EventLoopGroup} to be used by all {@link RxServer} instances as a parent eventloop group
@@ -54,5 +54,5 @@ public interface RxEventLoopProvider {
      *
      * @return The {@link EventLoopGroup} to be used for all servers.
      */
-    EventLoopGroup globalServerParentEventLoop();
+    public abstract EventLoopGroup globalServerParentEventLoop();
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Nitesh Kant
  */
-public class SingleNioLoopProvider implements RxEventLoopProvider {
+public class SingleNioLoopProvider extends RxEventLoopProvider {
 
     private final SharedNioEventLoopGroup eventLoop;
     private final SharedNioEventLoopGroup parentEventLoop;

--- a/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
@@ -17,11 +17,14 @@
 package io.reactivex.netty.channel;
 
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.Future;
+import io.reactivex.netty.RxNetty;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An implementation of {@link RxEventLoopProvider} that returns the same {@link EventLoopGroup} instance for both
@@ -33,6 +36,10 @@ public class SingleNioLoopProvider extends RxEventLoopProvider {
 
     private final SharedNioEventLoopGroup eventLoop;
     private final SharedNioEventLoopGroup parentEventLoop;
+    private final AtomicReference<EpollEventLoopGroup> nativeEventLoop;
+    private final AtomicReference<EpollEventLoopGroup> nativeParentEventLoop;
+    private final int parentEventLoopCount;
+    private final int childEventLoopCount;
 
     public SingleNioLoopProvider() {
         this(Runtime.getRuntime().availableProcessors());
@@ -41,11 +48,18 @@ public class SingleNioLoopProvider extends RxEventLoopProvider {
     public SingleNioLoopProvider(int threadCount) {
         eventLoop = new SharedNioEventLoopGroup(threadCount);
         parentEventLoop = eventLoop;
+        parentEventLoopCount = childEventLoopCount = threadCount;
+        nativeEventLoop = new AtomicReference<EpollEventLoopGroup>();
+        nativeParentEventLoop = nativeEventLoop;
     }
 
     public SingleNioLoopProvider(int parentEventLoopCount, int childEventLoopCount) {
-        eventLoop = new SharedNioEventLoopGroup(childEventLoopCount);
+        this.parentEventLoopCount = parentEventLoopCount;
+        this.childEventLoopCount = childEventLoopCount;
         parentEventLoop = new SharedNioEventLoopGroup(parentEventLoopCount);
+        eventLoop = new SharedNioEventLoopGroup(childEventLoopCount);
+        nativeParentEventLoop = new AtomicReference<EpollEventLoopGroup>();
+        nativeEventLoop = new AtomicReference<EpollEventLoopGroup>();
     }
 
     @Override
@@ -63,6 +77,56 @@ public class SingleNioLoopProvider extends RxEventLoopProvider {
     @Override
     public EventLoopGroup globalServerParentEventLoop() {
         return parentEventLoop;
+    }
+
+    @Override
+    public EventLoopGroup globalClientEventLoop(boolean nativeTransport) {
+        if (nativeTransport && RxNetty.isUsingNativeTransport()) {
+            return getNativeEventLoop();
+        }
+        return globalClientEventLoop();
+    }
+
+    @Override
+    public EventLoopGroup globalServerEventLoop(boolean nativeTransport) {
+        if (nativeTransport && RxNetty.isUsingNativeTransport()) {
+            return getNativeEventLoop();
+        }
+        return globalServerEventLoop();
+    }
+
+    @Override
+    public EventLoopGroup globalServerParentEventLoop(boolean nativeTransport) {
+        if (nativeTransport && RxNetty.isUsingNativeTransport()) {
+            return getNativeParentEventLoop();
+        }
+        return globalServerParentEventLoop();
+    }
+
+    private EpollEventLoopGroup getNativeParentEventLoop() {
+        if (nativeParentEventLoop == nativeEventLoop) { // Means using same event loop for acceptor and worker pool.
+            return getNativeEventLoop();
+        }
+
+        EpollEventLoopGroup eventLoopGroup = nativeParentEventLoop.get();
+        if (null == eventLoopGroup) {
+            EpollEventLoopGroup newEventLoopGroup = new EpollEventLoopGroup(parentEventLoopCount);
+            if (!nativeParentEventLoop.compareAndSet(null, newEventLoopGroup)) {
+                newEventLoopGroup.shutdownGracefully();
+            }
+        }
+        return nativeParentEventLoop.get();
+    }
+
+    private EpollEventLoopGroup getNativeEventLoop() {
+        EpollEventLoopGroup eventLoopGroup = nativeEventLoop.get();
+        if (null == eventLoopGroup) {
+            EpollEventLoopGroup newEventLoopGroup = new EpollEventLoopGroup(childEventLoopCount);
+            if (!nativeEventLoop.compareAndSet(null, newEventLoopGroup)) {
+                newEventLoopGroup.shutdownGracefully();
+            }
+        }
+        return nativeEventLoop.get();
     }
 
     public static class SharedNioEventLoopGroup extends NioEventLoopGroup {

--- a/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
@@ -21,6 +21,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -230,15 +231,15 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
 
     public C build() {
         if (null == socketChannel) {
-            socketChannel = NioSocketChannel.class;
+            socketChannel = defaultSocketChannelClass();
             if (null == eventLoopGroup) {
-                eventLoopGroup = RxNetty.getRxEventLoopProvider().globalClientEventLoop();
+                eventLoopGroup = defaultEventloop(socketChannel);
             }
         }
 
         if (null == eventLoopGroup) {
-            if (NioSocketChannel.class == socketChannel) {
-                eventLoopGroup = RxNetty.getRxEventLoopProvider().globalClientEventLoop();
+            if (defaultSocketChannelClass() == socketChannel) {
+                eventLoopGroup = defaultEventloop(socketChannel);
             } else {
                 // Fail fast for defaults we do not support.
                 throw new IllegalStateException("Specified a channel class but not the event loop group.");
@@ -261,6 +262,14 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
             client.subscribe(listener);
         }
         return client;
+    }
+
+    protected EventLoopGroup defaultEventloop(Class<? extends Channel> socketChannel) {
+        return RxNetty.getRxEventLoopProvider().globalClientEventLoop();
+    }
+
+    protected Class<? extends SocketChannel> defaultSocketChannelClass() {
+        return NioSocketChannel.class;
     }
 
     protected abstract C createClient();

--- a/rx-netty/src/main/java/io/reactivex/netty/client/ClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/client/ClientBuilder.java
@@ -16,6 +16,11 @@
 package io.reactivex.netty.client;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.metrics.MetricEventsListener;
 import io.reactivex.netty.metrics.MetricEventsListenerFactory;
@@ -62,6 +67,19 @@ public class ClientBuilder<I, O> extends AbstractClientBuilder<I,O, ClientBuilde
     @Override
     protected String generatedNamePrefix() {
         return "TcpClient-";
+    }
+
+    @Override
+    protected Class<? extends SocketChannel> defaultSocketChannelClass() {
+        if (RxNetty.isUsingNativeTransport()) {
+            return EpollSocketChannel.class;
+        }
+        return super.defaultSocketChannelClass();
+    }
+
+    @Override
+    protected EventLoopGroup defaultEventloop(Class<? extends Channel> socketChannel) {
+        return RxNetty.getRxEventLoopProvider().globalClientEventLoop(true); // get native eventloop if configured.
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/metrics/MetricEventsListenerFactory.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/metrics/MetricEventsListenerFactory.java
@@ -33,23 +33,23 @@ import io.reactivex.netty.server.ServerMetricsEvent;
  *
  * @author Nitesh Kant
  */
-public interface MetricEventsListenerFactory {
+public abstract class MetricEventsListenerFactory {
 
-    MetricEventsListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> forTcpClient(
+    public abstract MetricEventsListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> forTcpClient(
             @SuppressWarnings("rawtypes") RxClient client);
 
-    MetricEventsListener<ClientMetricsEvent<?>> forHttpClient(@SuppressWarnings("rawtypes")HttpClient client);
+    public abstract MetricEventsListener<ClientMetricsEvent<?>> forHttpClient(@SuppressWarnings("rawtypes")HttpClient client);
 
-    MetricEventsListener<ClientMetricsEvent<?>> forWebSocketClient(@SuppressWarnings("rawtypes")WebSocketClient client);
+    public abstract MetricEventsListener<ClientMetricsEvent<?>> forWebSocketClient(@SuppressWarnings("rawtypes")WebSocketClient client);
 
-    MetricEventsListener<ClientMetricsEvent<?>> forUdpClient(@SuppressWarnings("rawtypes")UdpClient client);
+    public abstract MetricEventsListener<ClientMetricsEvent<?>> forUdpClient(@SuppressWarnings("rawtypes")UdpClient client);
 
-    MetricEventsListener<ServerMetricsEvent<ServerMetricsEvent.EventType>> forTcpServer(
+    public abstract MetricEventsListener<ServerMetricsEvent<ServerMetricsEvent.EventType>> forTcpServer(
             @SuppressWarnings("rawtypes") RxServer server);
 
-    MetricEventsListener<ServerMetricsEvent<?>> forHttpServer(@SuppressWarnings("rawtypes")HttpServer server);
+    public abstract MetricEventsListener<ServerMetricsEvent<?>> forHttpServer(@SuppressWarnings("rawtypes")HttpServer server);
 
-    MetricEventsListener<ServerMetricsEvent<?>> forWebSocketServer(@SuppressWarnings("rawtypes")WebSocketServer server);
+    public abstract MetricEventsListener<ServerMetricsEvent<?>> forWebSocketServer(@SuppressWarnings("rawtypes")WebSocketServer server);
 
-    MetricEventsListener<ServerMetricsEvent<?>> forUdpServer(@SuppressWarnings("rawtypes")UdpServer server);
+    public abstract MetricEventsListener<ServerMetricsEvent<?>> forUdpServer(@SuppressWarnings("rawtypes")UdpServer server);
 }

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/CompositeHttpClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/CompositeHttpClientBuilder.java
@@ -17,6 +17,11 @@
 package io.reactivex.netty.protocol.http.client;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.client.AbstractClientBuilder;
 import io.reactivex.netty.client.ClientChannelFactory;
@@ -86,6 +91,19 @@ public class CompositeHttpClientBuilder<I, O>
     @Override
     public CompositeHttpClientBuilder<I, O> withMaxConnections(int maxConnections) {
         return super.withMaxConnections(maxConnections);
+    }
+
+    @Override
+    protected Class<? extends SocketChannel> defaultSocketChannelClass() {
+        if (RxNetty.isUsingNativeTransport()) {
+            return EpollSocketChannel.class;
+        }
+        return super.defaultSocketChannelClass();
+    }
+
+    @Override
+    protected EventLoopGroup defaultEventloop(Class<? extends Channel> socketChannel) {
+        return RxNetty.getRxEventLoopProvider().globalClientEventLoop(true); // get native eventloop if configured.
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientBuilder.java
@@ -16,6 +16,11 @@
 package io.reactivex.netty.protocol.http.client;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.client.AbstractClientBuilder;
 import io.reactivex.netty.client.ClientChannelFactory;
@@ -62,6 +67,19 @@ public class HttpClientBuilder<I, O>
         super(bootstrap, host, port, poolBuilder);
         clientConfig = HttpClient.HttpClientConfig.Builder.newDefaultConfig();
         pipelineConfigurator(PipelineConfigurators.<I, O>httpClientConfigurator());
+    }
+
+    @Override
+    protected Class<? extends SocketChannel> defaultSocketChannelClass() {
+        if (RxNetty.isUsingNativeTransport()) {
+            return EpollSocketChannel.class;
+        }
+        return super.defaultSocketChannelClass();
+    }
+
+    @Override
+    protected EventLoopGroup defaultEventloop(Class<? extends Channel> socketChannel) {
+        return RxNetty.getRxEventLoopProvider().globalClientEventLoop(true); // get native eventloop if configured.
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientBuilder.java
@@ -16,8 +16,13 @@
 package io.reactivex.netty.protocol.http.websocket;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.client.AbstractClientBuilder;
 import io.reactivex.netty.client.ClientChannelFactory;
@@ -58,6 +63,19 @@ public class WebSocketClientBuilder<I extends WebSocketFrame, O extends WebSocke
                                   ClientConnectionFactory<O, I, ? extends ObservableConnection<O, I>> connectionFactory,
                                   ClientChannelFactory<O, I> factory) {
         super(bootstrap, host, port, connectionFactory, factory);
+    }
+
+    @Override
+    protected Class<? extends SocketChannel> defaultSocketChannelClass() {
+        if (RxNetty.isUsingNativeTransport()) {
+            return EpollSocketChannel.class;
+        }
+        return super.defaultSocketChannelClass();
+    }
+
+    @Override
+    protected EventLoopGroup defaultEventloop(Class<? extends Channel> socketChannel) {
+        return RxNetty.getRxEventLoopProvider().globalClientEventLoop(true); // get native eventloop if configured.
     }
 
     @Override

--- a/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/AbstractServerBuilder.java
@@ -67,7 +67,7 @@ public abstract class AbstractServerBuilder<I, O, T extends AbstractBootstrap<T,
         return returnBuilder();
     }
 
-    public B channel(Class<C> serverChannelClass) {
+    public B channel(Class<? extends C> serverChannelClass) {
         this.serverChannelClass = serverChannelClass;
         return returnBuilder();
     }

--- a/rx-netty/src/main/java/io/reactivex/netty/server/ConnectionBasedServerBuilder.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/server/ConnectionBasedServerBuilder.java
@@ -21,6 +21,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.channel.ConnectionHandler;
@@ -53,13 +54,16 @@ public abstract class ConnectionBasedServerBuilder<I, O, B extends ConnectionBas
 
     @Override
     protected Class<? extends ServerChannel> defaultServerChannelClass() {
+        if (RxNetty.isUsingNativeTransport()) {
+            return EpollServerSocketChannel.class;
+        }
         return NioServerSocketChannel.class;
     }
 
     @Override
     protected void configureDefaultEventloopGroup() {
-        serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerParentEventLoop(),
-                              RxNetty.getRxEventLoopProvider().globalServerEventLoop());
+        serverBootstrap.group(RxNetty.getRxEventLoopProvider().globalServerParentEventLoop(true),
+                              RxNetty.getRxEventLoopProvider().globalServerEventLoop(true));
     }
 
     @Override


### PR DESCRIPTION
Fixed the following issues:
#260 Convert `RxEventLoopProvider` and `MetricEventsListenerFactory` to abstract classes. This aids in adding new methods without breaking existing implementations.
#261 `ServerSentEventEncoder` is sub-optimal in using StringBuilder. Removed `StringBuilder` and using `ByteBuf`
#258 Adding port to HTTP host header.
#259 Support native netty protocol as a runtime choice.
