### PR TITLE
Make sure to release content buffer

### DIFF
--- a/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
+++ b/rx-netty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
@@ -133,6 +133,10 @@ public class ClientRequestResponseConverter extends ChannelDuplexHandler {
                 stateToUse.responseReceiveComplete();
                 if (content.isReadable()) {
                     invokeContentOnNext(content, stateToUse);
+                } else {
+                    // CompositeByteBuf and possibly other implementations may still need to be
+                    // released event if they are not readable.
+                    ReferenceCountUtil.release(content);
                 }
                 stateToUse.sendOnComplete();
             } else {


### PR DESCRIPTION
When using HttpObjectAggregationConfigurator I
was getting a leak error if the response from
the server was empty:

```
Nov 02, 2014 6:01:41 PM io.netty.util.ResourceLeakDetector reportLeak
SEVERE: LEAK: ByteBuf.release() was not called before it's garbage-collected.
```

The difference seems to be the type of ByteBuf
for the content. HttpObjectAggregationConfigurator
will cause the type to be CompositeByteBuf
instead of EmptyByteBuf and when the response
is empty it isn't readable, but still needs to
be cleaned up.
