### PR TITLE
Matching artifact/module name changes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # RxNetty Releases #
 
+### Version 0.4.0 ###
+
+[Milestone](https://github.com/ReactiveX/RxNetty/issues?q=milestone%3A0.4.0+is%3Aclosed)
+
+* [Pull 275] (https://github.com/ReactiveX/RxNetty/pull/275) Changing package and artifact org from netflix.rxjava -> io.reactivex.  
+
+Artifacts: [Maven Central](http://search.maven.org/#artifactdetails%7Cio.reactivex%7Crxnetty%7C0.4.0%7C)
+
 ### Version 0.3.18 ###
 
 [Milestone](https://github.com/ReactiveX/RxNetty/issues?q=milestone%3A0.3.18+is%3Aclosed)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -182,7 +182,7 @@ Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com
 
 [Milestone](https://github.com/Netflix/RxNetty/issues?milestone=4&state=closed)
 
-* [Issue 98] (https://github.com/Netflix/RxNetty/issues/98) Added pluggable metrics infrastructure with rx-netty-servo implementation.
+* [Issue 98] (https://github.com/Netflix/RxNetty/issues/98) Added pluggable metrics infrastructure with rxnetty-servo implementation.
 * [Issue 106] (https://github.com/Netflix/RxNetty/issues/106) Added TLS support for TCP & HTTP (HTTPS)
 * [Issue 115] (https://github.com/Netflix/RxNetty/issues/115) ByteBuf leak fixed for both HTTP client and server.
 * [Issue 141] (https://github.com/Netflix/RxNetty/issues/141) ServerSentEventEncoder modified to match the specifications and the decoder.

--- a/rxnetty-contexts/README.md
+++ b/rxnetty-contexts/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-This module of rx-netty handles transparent propagation of infrastructure contexts (eg: tracing information) across
+This module of RxNetty handles transparent propagation of infrastructure contexts (eg: tracing information) across
 service boundaries. Any object that can provide a mechanism to serialze/de-serialize to/from a String, can be used as
 a context. However, it is recommended that any business specific information should not be passed using these contexts.
 Instead, your APIs should have explicit contract with the clients to pass this information as parameters and not
@@ -16,9 +16,9 @@ different protocols. Out of the box, we have implemented the plugin for HTTP.
 
 ### Usage
 
-The factory class [RxContexts](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RxContexts.java)
+The factory class [RxContexts](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/RxContexts.java)
 is provided to create Client and Servers with this feature enabled. The easiest way to use this feature is to start from
-this class. This factory class similar to RxNetty core, uses another factory [ContextPipelineConfigurators](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/ContextPipelineConfigurators.java)
+this class. This factory class similar to RxNetty core, uses another factory [ContextPipelineConfigurators](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextPipelineConfigurators.java)
 for netty's pipeline configurations. If RxContexts does not fit your needs, the ContextPipelineConfigurators can be
  used to configure netty's pipelines for your clients and servers.
  Since, these factory methods return the first class RxNetty clients and servers, the usage after creating these
@@ -28,27 +28,27 @@ for netty's pipeline configurations. If RxContexts does not fit your needs, the 
 
 - _**Request**_: Any infrastructure context is always associated with a unique request. The concept of a request does not
 necessarily mean that the end user has to send one request at a time on a connection. Out of the box HTTP plugin supports
-HTTP pipelining. [RequestCorrelator](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RequestCorrelator.java)
-and [RequestIdProvider](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/RequestIdProvider.java)
+HTTP pipelining. [RequestCorrelator](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/RequestCorrelator.java)
+and [RequestIdProvider](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/RequestIdProvider.java)
 interfaces together provides the required pluggability to define the "request" abstraction.
 
-- _**Context Container**_: All contexts for a request is contained in a [ContextsContainer](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/ContextsContainer.java)
+- _**Context Container**_: All contexts for a request is contained in a [ContextsContainer](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextsContainer.java)
 All operations for managing a context is provided via this interface.
 
 - _**Context Capturing**_: Since a request processing may involve multiple threads, ThreadLocals are not always a good
 way to capture these contexts in the application layer (from when a request is received and if an outbound call to other
-services is made). So, this module provides an abstraction [ContextCapturer](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/ContextCapturer.java)
+services is made). So, this module provides an abstraction [ContextCapturer](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextCapturer.java)
 to capture these contexts within the application boundaries.
 
 - _**Context Keys**_: Since there can be multiple contexts per request, every context has a locally unique key (unique
 within the request). Each of these contexts are passed between services as these key-value pairs. Since, how these pairs
-are passed over the wire is governed by the protocol itself, we have defined an abstraction [ContextKeySupplier](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/io/reactivex/netty/contexts/ContextKeySupplier.java)
+are passed over the wire is governed by the protocol itself, we have defined an abstraction [ContextKeySupplier](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextKeySupplier.java)
 to define this contract. In HTTP, these pairs are passed as headers by the default plugin.
 
 - _**Bidrectional Contexts**_: By default all contexts are uni-directional i.e. any change made to the context in the
 downstream dependencies, is not available inside the upstream services. However, if your context is to be made available
 to upstream services (after the downstream service call ends) you can mark your context with the annotation
-[BiDirectional](https://github.com/Netflix/RxNetty/blob/master/rx-netty-contexts/src/main/java/com/netflix/server/context/BiDirectional.java)
+[BiDirectional](https://github.com/Netflix/RxNetty/blob/master/rxnetty-contexts/src/main/java/com/netflix/server/context/BiDirectional.java)
 
 ### Practical usage
 

--- a/rxnetty-examples/README.md
+++ b/rxnetty-examples/README.md
@@ -32,7 +32,7 @@ Build
 To build:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew build
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/chunk/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/chunk/README.md
@@ -10,14 +10,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runChunkServer -PtextFile=<some_text_file>
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runChunkClient -Pword=<word_to_count>
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/cpuintensive/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/cpuintensive/README.md
@@ -5,7 +5,7 @@ An example of how to write a server which does some CPU intensive or Blocking wo
 the request processing in the channel's event loop.
 This is achieved by using netty's [`EventExecutorGroup`](https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java) 
 as a threadpool.
-`RxNetty` makes sure that the [`RequestHandler`](https://github.com/Netflix/RxNetty/blob/master/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandler.java)
+`RxNetty` makes sure that the [`RequestHandler`](https://github.com/Netflix/RxNetty/blob/master/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandler.java)
 as well as the subscribers of `HttpServerRequest`'s content happens on this executor.
 
 Running
@@ -14,13 +14,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runCpuIntensiveHttpServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runCpuIntensiveHttpClient
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/helloworld/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/helloworld/README.md
@@ -10,14 +10,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runHelloWorldServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runHelloWorldClient
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/logtail/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/logtail/README.md
@@ -12,7 +12,7 @@ Running
 You can run multiple log producers, but they have to have consecutive port numbers:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runLogTailProducer -Pport=<N> -Pinterval=<interval_in_ms> > logProducer1.log &
 $ ../gradlew runLogTailProducer -Pport=<N+1> -Pinterval=<interval_in_ms> > logProducer2.log &
 ...
@@ -22,13 +22,13 @@ $ ../gradlew runLogTailProducer -Pport=<N+M> -Pinterval=<interval_in_ms> > logPr
 next log aggregator has to be started:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runLogTailAggregator -PportFrom=<N> -PportTo=<N+M-1>
 ```
 
 and the last one is the client:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runLogTailClient
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/plaintext/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/plaintext/README.md
@@ -15,13 +15,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runPlainTextServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runPlainTextClient
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/post/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/post/README.md
@@ -10,14 +10,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSimplePostServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSimplePostClient
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/sse/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/sse/README.md
@@ -13,14 +13,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSseServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSseClient
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/ssl/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/ssl/README.md
@@ -11,14 +11,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSslHelloWorldServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSslHelloWorldClient
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/http/wordcounter/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/http/wordcounter/README.md
@@ -12,14 +12,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runWordCounterServer 
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runWordCounterClient -PtextFile=<some_text_file>
 ```
 

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/cpuintensive/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/cpuintensive/README.md
@@ -5,7 +5,7 @@ An example of how to write a server which does some CPU intensive or Blocking wo
 the connection processing in the channel's event loop.
 This is achieved by using netty's [`EventExecutorGroup`](https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java) 
 as a threadpool.
-`RxNetty` makes sure that the [`ConnectionHandler`](https://github.com/Netflix/RxNetty/blob/master/rx-netty/src/main/java/io/reactivex/netty/channel/ConnectionHandler.java)
+`RxNetty` makes sure that the [`ConnectionHandler`](https://github.com/Netflix/RxNetty/blob/master/rxnetty/src/main/java/io/reactivex/netty/channel/ConnectionHandler.java)
 as well as the subscribers of `ObservableConnection`'s content happens on this executor.
 
 Running
@@ -14,13 +14,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runCpuIntensiveTcpServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runCpuIntensiveTcpClient
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/echo/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/echo/README.md
@@ -9,13 +9,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEchoServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEchoClient
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/event/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/event/README.md
@@ -15,13 +15,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEventStreamServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEventStreamClient -Pdelay=<delay_in_ms> -Pevents=<no_of_events>
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/interval/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/interval/README.md
@@ -30,13 +30,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpIntervalServer -Pinterval=<sending_interval_in_ms>
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpIntervalClient -P<events=no_of_events>
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/ssl/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/tcp/ssl/README.md
@@ -10,13 +10,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSslTcpEchoServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSslTcpEchoClient
 ```

--- a/rxnetty-examples/bin/io/reactivex/netty/examples/udp/README.md
+++ b/rxnetty-examples/bin/io/reactivex/netty/examples/udp/README.md
@@ -9,13 +9,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runUdpClient
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runUdpServer
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/ExamplesEnvironment.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/ExamplesEnvironment.java
@@ -27,7 +27,7 @@ import io.reactivex.netty.servo.ServoEventsListenerFactory;
 public class ExamplesEnvironment {
 
     static {
-        RxNetty.useMetricListenersFactory(new ServoEventsListenerFactory("rx-netty-examples-client",
-                                                                         "rx-netty-examples-server"));
+        RxNetty.useMetricListenersFactory(new ServoEventsListenerFactory("rxnetty-examples-client",
+                                                                         "rxnetty-examples-server"));
     }
 }

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/chunk/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/chunk/README.md
@@ -10,14 +10,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runChunkServer -PtextFile=<some_text_file>
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runChunkClient -Pword=<word_to_count>
 ```
 

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/cpuintensive/README.md
@@ -5,7 +5,7 @@ An example of how to write a server which does some CPU intensive or Blocking wo
 the request processing in the channel's event loop.
 This is achieved by using netty's [`EventExecutorGroup`](https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java) 
 as a threadpool.
-`RxNetty` makes sure that the [`RequestHandler`](https://github.com/Netflix/RxNetty/blob/master/rx-netty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandler.java)
+`RxNetty` makes sure that the [`RequestHandler`](https://github.com/Netflix/RxNetty/blob/master/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/RequestHandler.java)
 as well as the subscribers of `HttpServerRequest`'s content happens on this executor.
 
 Running

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/logtail/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/logtail/README.md
@@ -12,7 +12,7 @@ Running
 You can run multiple log producers, but they have to have consecutive port numbers:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runLogTailProducer -Pport=<N> -Pinterval=<interval_in_ms> > logProducer1.log &
 $ ../gradlew runLogTailProducer -Pport=<N+1> -Pinterval=<interval_in_ms> > logProducer2.log &
 ...
@@ -22,13 +22,13 @@ $ ../gradlew runLogTailProducer -Pport=<N+M> -Pinterval=<interval_in_ms> > logPr
 next log aggregator has to be started:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runLogTailAggregator -PportFrom=<N> -PportTo=<N+M-1>
 ```
 
 and the last one is the client:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runLogTailClient
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/post/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/post/README.md
@@ -10,14 +10,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSimplePostServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSimplePostClient
 ```
 

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/README.md
@@ -13,14 +13,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSseServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSseClient
 ```
 

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/wordcounter/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/wordcounter/README.md
@@ -12,14 +12,14 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runWordCounterServer 
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runWordCounterClient -PtextFile=<some_text_file>
 ```
 

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/cpuintensive/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/cpuintensive/README.md
@@ -5,7 +5,7 @@ An example of how to write a server which does some CPU intensive or Blocking wo
 the connection processing in the channel's event loop.
 This is achieved by using netty's [`EventExecutorGroup`](https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java) 
 as a threadpool.
-`RxNetty` makes sure that the [`ConnectionHandler`](https://github.com/Netflix/RxNetty/blob/master/rx-netty/src/main/java/io/reactivex/netty/channel/ConnectionHandler.java)
+`RxNetty` makes sure that the [`ConnectionHandler`](https://github.com/Netflix/RxNetty/blob/master/rxnetty/src/main/java/io/reactivex/netty/channel/ConnectionHandler.java)
 as well as the subscribers of `ObservableConnection`'s content happens on this executor.
 
 Running
@@ -14,13 +14,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runCpuIntensiveTcpServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runCpuIntensiveTcpClient
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/README.md
@@ -9,13 +9,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEchoServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEchoClient
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/event/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/event/README.md
@@ -15,13 +15,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEventStreamServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpEventStreamClient -Pdelay=<delay_in_ms> -Pevents=<no_of_events>
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interval/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interval/README.md
@@ -30,13 +30,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpIntervalServer -Pinterval=<sending_interval_in_ms>
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runTcpIntervalClient -P<events=no_of_events>
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/ssl/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/ssl/README.md
@@ -10,13 +10,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSslTcpEchoServer
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runSslTcpEchoClient
 ```

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/udp/README.md
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/udp/README.md
@@ -9,13 +9,13 @@ Running
 To run the example execute:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runUdpClient
 ```
 
 and in another console:
 
 ```
-$ cd RxNetty/rx-netty-examples
+$ cd RxNetty/rxnetty-examples
 $ ../gradlew runUdpServer
 ```

--- a/rxnetty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/channel/SingleNioLoopProvider.java
@@ -111,7 +111,7 @@ public class SingleNioLoopProvider extends RxEventLoopProvider {
         EpollEventLoopGroup eventLoopGroup = nativeParentEventLoop.get();
         if (null == eventLoopGroup) {
             EpollEventLoopGroup newEventLoopGroup = new EpollEventLoopGroup(parentEventLoopCount,
-                                                                            new RxDefaultThreadFactory("rx-netty-epoll-eventloop"));
+                                                                            new RxDefaultThreadFactory("rxnetty-epoll-eventloop"));
             if (!nativeParentEventLoop.compareAndSet(null, newEventLoopGroup)) {
                 newEventLoopGroup.shutdownGracefully();
             }
@@ -123,7 +123,7 @@ public class SingleNioLoopProvider extends RxEventLoopProvider {
         EpollEventLoopGroup eventLoopGroup = nativeEventLoop.get();
         if (null == eventLoopGroup) {
             EpollEventLoopGroup newEventLoopGroup = new EpollEventLoopGroup(childEventLoopCount,
-                                                                            new RxDefaultThreadFactory("rx-netty-epoll-eventloop"));
+                                                                            new RxDefaultThreadFactory("rxnetty-epoll-eventloop"));
             if (!nativeEventLoop.compareAndSet(null, newEventLoopGroup)) {
                 newEventLoopGroup.shutdownGracefully();
             }
@@ -136,11 +136,11 @@ public class SingleNioLoopProvider extends RxEventLoopProvider {
         private final AtomicInteger refCount = new AtomicInteger();
 
         public SharedNioEventLoopGroup() {
-            super(0, new RxDefaultThreadFactory("rx-netty-nio-eventloop"));
+            super(0, new RxDefaultThreadFactory("rxnetty-nio-eventloop"));
         }
 
         public SharedNioEventLoopGroup(int threadCount) {
-            super(threadCount, new RxDefaultThreadFactory("rx-netty-nio-eventloop"));
+            super(threadCount, new RxDefaultThreadFactory("rxnetty-nio-eventloop"));
         }
 
         @Override


### PR DESCRIPTION
READMEs had rx-netty as opposed to rxnetty.
A few other places had the string rx-netty. Modified to be consistent with the module names.
