### PR TITLE
Fixes #288 #287 #277

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 buildscript {
   repositories { jcenter() }
   dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:1.12.+' }
@@ -13,7 +28,7 @@ configure(subprojects) {
   apply plugin: 'rxjava-project'
 
   dependencies {
-    compile "io.reactivex:rxjava:1.0.0"
+    compile "io.reactivex:rxjava:1.0.1"
 
     testCompile 'junit:junit-dep:4.10'
   }

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/plaintext/PlainTextServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/plaintext/PlainTextServer.java
@@ -48,6 +48,7 @@ public final class PlainTextServer {
                                              @Override
                                              public Observable<Void> handle(HttpServerRequest<ByteBuf> request,
                                                                             final HttpServerResponse<ByteBuf> response) {
+                                                 response.flushOnlyOnChannelReadComplete(true); // Leverage gathering writes for HTTP pipelined requests.
                                                  response.getHeaders().set(HttpHeaders.Names.CONTENT_LENGTH,
                                                                            CONTENT_LENGTH_HEADER_VAL); // This makes RxNetty write a single Full response as opposed to writing header, content & lastHttpContent.
                                                  ByteBuf content = response.getAllocator()

--- a/rxnetty-remote-observable/build.gradle
+++ b/rxnetty-remote-observable/build.gradle
@@ -31,9 +31,9 @@
 
  dependencies {
      compile project(':rxnetty')
-	compile 'com.netflix.numerus:numerus:1.1'
-    compile "com.netflix.rxjava:rxjava-math:0.20.6"
-	compile "org.slf4j:slf4j-log4j12:${slf4j_version}"
+     compile 'com.netflix.numerus:numerus:1.1'
+     compile 'io.reactivex:rxjava-math:1.0.0'
+     compile "org.slf4j:slf4j-log4j12:${slf4j_version}"
 
      testCompile 'junit:junit:4.10'
  }

--- a/rxnetty/src/test/java/io/reactivex/netty/metrics/RxMetricEventsTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/metrics/RxMetricEventsTest.java
@@ -116,7 +116,7 @@ public class RxMetricEventsTest {
         testServerEventFired(listener, ServerMetricsEvent.EventType.ConnectionCloseSuccess, 1);
         testServerEventFired(listener, ServerMetricsEvent.EventType.WriteStart);
         testServerEventFired(listener, ServerMetricsEvent.EventType.WriteSuccess);
-        testServerEventFired(listener, ServerMetricsEvent.EventType.FlushStart, 1);
+        testServerEventFired(listener, ServerMetricsEvent.EventType.FlushStart, 2); // Auto-flush on request handling complete.
         testServerEventFired(listener, ServerMetricsEvent.EventType.FlushSuccess, 1);
         testServerEventFired(listener, ServerMetricsEvent.EventType.BytesRead);
 

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/sse/ServerSentEventEndToEndTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/sse/ServerSentEventEndToEndTest.java
@@ -99,10 +99,17 @@ public class ServerSentEventEndToEndTest {
         Assert.assertEquals("Unexpected event data.", "0", result.contentAsString());
         Assert.assertNull("Unexpected event type.", result.getEventType());
         Assert.assertNull("Unexpected event id.", result.getEventId());
+        result.release();
     }
 
     protected ServerSentEvent receivesSingleEvent() {
-        return receiveSse().take(1).toBlocking().singleOrDefault(null);
+        return receiveSse().take(1).map(new Func1<ServerSentEvent, ServerSentEvent>() {
+            @Override
+            public ServerSentEvent call(ServerSentEvent serverSentEvent) {
+                serverSentEvent.retain();
+                return serverSentEvent;
+            }
+        }).toBlocking().singleOrDefault(null);
     }
 
     private Observable<ServerSentEvent> receiveSse() {


### PR DESCRIPTION
Multiple fixes for milestone 0.4.1
#277 Short-circuiting if `PassThruObserver` is already draining the notifications. Since, the observer is serialized, this only ensures that we do not drain recursively on every re-entrant call.
#287 Flushing `HttpServerResponse` when the `Observable` returned from `RequestHandler.handle()` terminates. Added a method `flushOnlyOnChannelReadComplete()` to turn off this auto-flush on terminate.
#288 Upgraded to rxjava-1.0.1
