### PR TITLE
Fixing close & finish order in HttpConnectionHandler.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # RxNetty Releases #
 
+### Version 0.4.1 ###
+
+[Milestone](https://github.com/ReactiveX/RxNetty/issues?q=milestone%3A0.4.1+is%3Aclosed)
+
+* [Issue 277] (https://github.com/ReactiveX/RxNetty/issue/277) StackOverflow while draining`UnicastContentSubject`
+* [Issue 287] (https://github.com/ReactiveX/RxNetty/issue/287) Flush HTTP response on completion of `RequestHandler.handle()`
+* [Issue 288] (https://github.com/ReactiveX/RxNetty/issue/288) Upgrade to rx-java 1.0.1
+
+
+Artifacts: [Maven Central](http://search.maven.org/#artifactdetails%7Cio.reactivex%7Crxnetty%7C0.4.1%7C)
+
 ### Version 0.4.0 ###
 
 [Milestone](https://github.com/ReactiveX/RxNetty/issues?q=milestone%3A0.4.0+is%3Aclosed)

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpConnectionHandler.java
@@ -114,10 +114,11 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                             public void onCompleted() {
                                 eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_SUCCESS,
                                                       Clock.onEndMillis(startTimeMillis));
+                                response.close(false); // Since close() can be called only once, the flush is separated from close.
+                                // Close will write the last HTTP content and hence the flush must be done post close.
                                 if (!response.isFlushOnlyOnReadComplete()) {
                                     response.flush();
                                 }
-                                response.close(false); // Since close() can be called only once, the flush is separated from close.
                             }
 
                             @Override
@@ -127,8 +128,9 @@ class HttpConnectionHandler<I, O> implements ConnectionHandler<HttpServerRequest
                                 if (!response.isHeaderWritten()) {
                                     responseGenerator.updateResponse(response, throwable);
                                 }
-                                response.flush(); // Response should be flushed for errors: https://github.com/ReactiveX/RxNetty/issues/226
                                 response.close(false); // Since close() can be called only once, the flush is separated from close.
+                                // Close will write the last HTTP content and hence the flush must be done post close.
+                                response.flush(); // Response should be flushed for errors: https://github.com/ReactiveX/RxNetty/issues/226
                             }
 
                             @Override


### PR DESCRIPTION
Since `close()` writes the `LastHttpContent`, we should be flushing after close.
