### PR TITLE
Fix for stack overflow in CompositeHttpClient.shutdown().

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/CompositeHttpClient.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/CompositeHttpClient.java
@@ -101,8 +101,12 @@ public class CompositeHttpClient<I, O> extends HttpClientImpl<I, O> {
 
     @Override
     public void shutdown() {
-        for (HttpClient<I, O> client : httpClients.values()) { // This map also contains the default client, so we don't need to shut the default explicitly.
-            client.shutdown();
+        super.shutdown();
+        for (HttpClient<I, O> client : httpClients.values()) {
+            // Constructor adds 'this' as the default client; special-case it to avoid stack overflow.
+            if (client != this) {
+                client.shutdown();
+            }
         }
     }
 


### PR DESCRIPTION
The `CompositeHttpClient`'s constructor adds itself to the `httpClients` map as the default client. If you call `shutdown()` on a `CompositeHttpClient`, it ends up recursively calling `shutdown()` on itself, and you end up with a StackOverflowError. This change first calls `super.shutdown()` to shut down this client, then shuts down any other clients from the `httpClients` map.
