### PR TITLE
move classes from com.netflix to io.reactivex

### DIFF
--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/AbstractServerContextHandler.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/AbstractServerContextHandler.java
@@ -15,7 +15,6 @@
  */
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.BiDirectional;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import org.slf4j.Logger;

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/BiDirectional.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/BiDirectional.java
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.server.context;
-
-import io.reactivex.netty.contexts.ContextKeySupplier;
-import io.reactivex.netty.contexts.ContextsContainer;
+package io.reactivex.netty.contexts;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextHolder.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextHolder.java
@@ -16,11 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.BiDirectional;
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-import com.netflix.server.context.DirectionAwareContextSerializer;
-
 /**
  * A holder of an contexts containing augmenting information about the context.
  *

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextSerializationException.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextSerializationException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.server.context;
+package io.reactivex.netty.contexts;
 
 /**
  * Exception thrown for any errors during serialization/de-serialization of contexts.

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextSerializationHelper.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextSerializationHelper.java
@@ -16,10 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-import com.netflix.server.context.DirectionAwareContextSerializer;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextSerializer.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextSerializer.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.server.context;
-
-import io.reactivex.netty.contexts.ContextsContainer;
+package io.reactivex.netty.contexts;
 
 /**
  * A serializer for serialization/de-serialization any arbitrary context objects added to {@link ContextsContainer}. <p/>

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextsContainer.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextsContainer.java
@@ -16,10 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.BiDirectional;
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-
 import java.util.Map;
 
 /**

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextsContainerImpl.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextsContainerImpl.java
@@ -16,10 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-import com.netflix.server.context.DirectionAwareContextSerializer;
-import com.netflix.server.context.MergeableContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/DirectionAwareContextSerializer.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/DirectionAwareContextSerializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.server.context;
+package io.reactivex.netty.contexts;
 
 /**
  * A replacement for {@link ContextSerializer} for {@link BiDirectional} contexts that requires information about the

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/DirectionAwareSerializerAdapter.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/DirectionAwareSerializerAdapter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.server.context;
+package io.reactivex.netty.contexts;
 
 /**
  * An implementation of {@link DirectionAwareContextSerializer} to provide consistent behavior for callers who are

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/MergeableContext.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/MergeableContext.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.server.context;
+package io.reactivex.netty.contexts;
 
 /**
  * Merge contract for {@link BiDirectional} contexts.

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/StringSerializer.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/StringSerializer.java
@@ -16,9 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.DirectionAwareContextSerializer;
-
 /**
  * A dumb serializer that does nothing. Its existence is to follow the pattern that a context always has a serializer.
  *

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/BidirectionalTestContext.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/BidirectionalTestContext.java
@@ -16,8 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.BiDirectional;
-
 /**
  * @author Nitesh Kant
  */

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/BidirectionalTestContextSerializer.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/BidirectionalTestContextSerializer.java
@@ -16,9 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-
 /**
  * @author Nitesh Kant (nkant@netflix.com)
  */

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/ContextSerializationTest.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/ContextSerializationTest.java
@@ -16,8 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/MergeableBidirectionalTestContext.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/MergeableBidirectionalTestContext.java
@@ -16,9 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.BiDirectional;
-import com.netflix.server.context.MergeableContext;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/MergeableBidirectionalTestContextSerializer.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/MergeableBidirectionalTestContextSerializer.java
@@ -16,9 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-
 import java.util.regex.Pattern;
 
 /**

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/TestContextDirectionalSerializer.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/TestContextDirectionalSerializer.java
@@ -16,9 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.DirectionAwareSerializerAdapter;
-
 /**
  * @author Nitesh Kant (nkant@netflix.com)
  */

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/TestContextSerializer.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/TestContextSerializer.java
@@ -16,9 +16,6 @@
 
 package io.reactivex.netty.contexts;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
-
 /**
  * @author Nitesh Kant (nkant@netflix.com)
  */

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/http/ClientHandlerTest.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/http/ClientHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package io.reactivex.netty.contexts.http;
 
-import com.netflix.server.context.ContextSerializationException;
+import io.reactivex.netty.contexts.ContextSerializationException;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpMethod;

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/http/ContextPropagationTest.java
@@ -16,7 +16,7 @@
 
 package io.reactivex.netty.contexts.http;
 
-import com.netflix.server.context.ContextSerializationException;
+import io.reactivex.netty.contexts.ContextSerializationException;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.logging.LogLevel;

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/http/HandlerHolder.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/http/HandlerHolder.java
@@ -15,8 +15,8 @@
  */
 package io.reactivex.netty.contexts.http;
 
-import com.netflix.server.context.ContextSerializationException;
-import com.netflix.server.context.ContextSerializer;
+import io.reactivex.netty.contexts.ContextSerializationException;
+import io.reactivex.netty.contexts.ContextSerializer;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.util.AttributeMap;


### PR DESCRIPTION
There were a handful of classes in rxnetty-contexts
that were still in a com.netflix.server.context package.
This change moves them into the io.reactivex.netty.contexts
package to make them consistent.
