### PR TITLE
Add bindings for spectator

### DIFF
--- a/rxnetty-spectator/README.md
+++ b/rxnetty-spectator/README.md
@@ -1,0 +1,146 @@
+# RxNetty Spectator Plugin
+
+This plugin provides metrics support for RxNetty using [spectator](https://github.com/Netflix/spectator)
+ 
+### Usage
+
+#### Global registration
+
+`RxNetty` provides a way to register spectator metrics for all clients and servers created by `RxNetty`. This can be 
+achieved by the following code:
+
+ ```java
+ 
+ import io.reactivex.netty.RxNetty;
+ import io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
+ 
+ public class MyApplication {
+ 
+     public static void main(String[] args) {
+         RxNetty.useMetricListenersFactory(new SpectatorEventsListenerFactory());
+     }
+ }
+ 
+ ```
+
+#### Instance registrations
+ 
+ If for some reason, global registration is not appropriate, one can register the listeners returned by 
+ `SpectatorEventsListenerFactory` on a instance of server or client. The following sample code demonstrates how:
+ 
+ ```java
+ 
+        HttpServer<ByteBuf, ByteBuf> server = RxNetty.createHttpServer(0, new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return Observable.empty();
+            }
+        });
+        
+        SpectatorEventsListenerFactory factory = new SpectatorEventsListenerFactory();
+        
+        HttpServerListener listener = factory.forHttpServer(server);
+        
+        server.subscribe(listener);
+ ```
+  
+##### Multiple registrations
+  
+It is perfectly valid for the same `MetricEventsListener` to be registered with multiple client or server instances. In
+ such a case, one can get aggregated metrics over the clients or servers with which this listener is registered.
+ The following sample code demonstrates how:
+ 
+ ```java
+ 
+        HttpClient<ByteBuf, ByteBuf> client = RxNetty.createHttpClient("localhost", 7777);
+        SpectatorEventsListenerFactory factory = new SpectatorEventsListenerFactory();
+        HttpClientListener listener = factory.forHttpClient(client);
+        client.subscribe(listener);
+        RxNetty.createHttpClient("localhost", 7778).subscribe(listener);
+ ```
+ 
+### Available Metrics
+ 
+#### Server
+
+##### TCP
+ 
+ * **Live Connections**: The number of open connections from all clients to this server. This is a gauge.
+ * **Inflight Connections**: The number of connections that are currently being processed by this server.  This is a gauge.
+ * **Failed Connections**: The number of times that connection handling failed.  This is a monotonically increasing counter.
+ * **Connection processing times**: Time taken for processing a connection.
+ * **Pending connection close**: Number of connections which are requested to be closed but are not yet closed. This is a gauge. 
+ * **Failed connection close**: Number of times when the connection close failed. This is a monotonically increasing counter.
+ * **Connection close times**: Time taken for closing a connection.
+ * **Pending Writes**: Writes that are pending to be written over the socket. This includes writes which are not flushed. 
+ This is a gauge.
+ * **Pending Flushes**: Flushes that are issued but are not over yet. This is a gauge.
+ * **Bytes Written**: Total number of bytes written. This is a monotonically increasing counter.
+ * **Write Times**: The time taken to finish a write.
+ * **Bytes Read**: The total number of bytes read. This is a monotonically increasing counter.
+ * **Failed Writes**: The total number of writes that failed. This is a monotonically increasing counter.
+ * **Failed Flushes**: The total number of flushes that failed. This is a monotonically increasing counter.
+ * **Flush times**: The time taken to finish a flush. 
+ 
+##### HTTP
+ 
+ HTTP contains all the metrics that are available from TCP. The following metrics are specific to HTTP:
+  
+* **Request backlog**: The number of requests that have been received but not started processing. This is a gauge. 
+* **Inflight requests**: The number of requests that have been started processing but not yet finished processing. This is a gauge.
+* **Response Write Times**: Time taken to write responses, including headers and content.
+* **Request Read Times**: Time taken to read a request.
+* **Processed Requests**: Total number of requests processed. This is a monotonically increasing counter.
+* **Failed Requests**: Total number of requests for which the request handling failed.
+* **Failed response writes**: Total number of responses for which the writes failed.
+ 
+##### UDP
+
+UDP contains all the metrics that are available from TCP.
+
+#### Client
+
+##### TCP
+ 
+ * **Live Connections**: The number of open connections from this clients to a server. This is a gauge.
+ * **Connection count**: The total number of connections ever created by this client.  This is a monotonically increasing counter.
+ * **Pending Connections**: The number of connections that are pending. This is a gauge.
+ * **Failed connects**: Total number of connect failures.
+ * **Connection times**: Time taken to establish a connection.
+ * **Pending connection close**: Number of connections which are requested to be closed but are not yet closed. This is a gauge. 
+ * **Failed connection close**: Number of times when the connection close failed. This is a monotonically increasing counter.
+ * **Pending pool acquires**: For clients with a connection pool, the number of acquires that are pending. This is a gauge. 
+ * **Failed pool acquires**: For clients with a connection pool, the number of acquires that failed. This is a monotonically increasing counter.
+ * **Pool acquire times**: For clients with a connection pool, time taken to acquire a connection from the pool.
+ * **Pending pool releases**: For clients with a connection pool, the number of releases that are pending. This is a gauge. 
+ * **Failed pool releases**: For clients with a connection pool, the number of releases that failed. This is a monotonically increasing counter.
+ * **Pool releases times**: For clients with a connection pool, time taken to release a connection to the pool.
+ * **Pool acquires**: For clients with a connection pool, the total number of acquires from the pool.
+ * **Pool evictions**: For clients with a connection pool, the total number of evictions from the pool.
+ * **Pool reuse**: For clients with a connection pool, the total number of times a connection from the pool was reused.
+ * **Pool releases**: For clients with a connection pool, the total number of releases to the pool.
+ * **Pending Writes**: Writes that are pending to be written over the socket. This includes writes which are not flushed. 
+ This is a gauge.
+ * **Pending Flushes**: Flushes that are issued but are not over yet. This is a gauge.
+ * **Bytes Written**: Total number of bytes written. This is a monotonically increasing counter.
+ * **Write Times**: The time taken to finish a write.
+ * **Bytes Read**: The total number of bytes read. This is a monotonically increasing counter.
+ * **Failed Writes**: The total number of writes that failed. This is a monotonically increasing counter.
+ * **Failed Flushes**: The total number of flushes that failed. This is a monotonically increasing counter.
+ * **Flush times**: The time taken to finish a flush. 
+ 
+##### HTTP
+ 
+ HTTP contains all the metrics that are available from TCP. The following metrics are specific to HTTP:
+  
+* **Request backlog**: The number of requests that have been submitted but not started processing. This is a gauge. 
+* **Inflight requests**: The number of requests that have been started processing but not yet finished processing. This is a gauge.
+* **Processed Requests**: Total number of requests processed. This is a monotonically increasing counter.
+* **Request Write Times**: Time taken to write requests, including headers and content.
+* **Response Read Times**: Time taken to read a response.
+* **Failed Responses**: Total number of responses that failed i.e. for which the requests were sent but response was an error.
+* **Failed request writes**: Total number of requests for which the writes failed.
+ 
+##### UDP
+
+UDP contains all the metrics that are available from TCP.

--- a/rxnetty-spectator/build.gradle
+++ b/rxnetty-spectator/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    compile project(':rxnetty')
+    compile 'com.netflix.spectator:spectator-api:0.14.2'
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/SpectatorEventsListenerFactory.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/SpectatorEventsListenerFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.spectator;
+
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.client.RxClient;
+import io.reactivex.netty.metrics.MetricEventsListenerFactory;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.websocket.WebSocketClient;
+import io.reactivex.netty.protocol.http.websocket.WebSocketServer;
+import io.reactivex.netty.protocol.udp.client.UdpClient;
+import io.reactivex.netty.protocol.udp.server.UdpServer;
+import io.reactivex.netty.server.RxServer;
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.http.HttpClientListener;
+import io.reactivex.netty.spectator.http.HttpServerListener;
+import io.reactivex.netty.spectator.http.websocket.WebSocketClientListener;
+import io.reactivex.netty.spectator.http.websocket.WebSocketServerListener;
+import io.reactivex.netty.spectator.tcp.TcpClientListener;
+import io.reactivex.netty.spectator.tcp.TcpServerListener;
+import io.reactivex.netty.spectator.udp.UdpClientListener;
+import io.reactivex.netty.spectator.udp.UdpServerListener;
+
+/**
+ * @author Nitesh Kant
+ */
+public class SpectatorEventsListenerFactory extends MetricEventsListenerFactory {
+
+    private final String clientMetricNamePrefix;
+    private final String serverMetricNamePrefix;
+
+    public SpectatorEventsListenerFactory() {
+        this("rxnetty-client-", "rxnetty-server-");
+    }
+
+    public SpectatorEventsListenerFactory(String clientMetricNamePrefix, String serverMetricNamePrefix) {
+        this.clientMetricNamePrefix = clientMetricNamePrefix;
+        this.serverMetricNamePrefix = serverMetricNamePrefix;
+    }
+
+    @Override
+    public TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> forTcpClient(@SuppressWarnings("rawtypes") RxClient client) {
+        return TcpClientListener.newListener(clientMetricNamePrefix + client.name());
+    }
+
+    @Override
+    public HttpClientListener forHttpClient(@SuppressWarnings("rawtypes") HttpClient client) {
+        return HttpClientListener.newHttpListener(clientMetricNamePrefix + client.name());
+    }
+
+    @Override
+    public WebSocketClientListener forWebSocketClient(@SuppressWarnings("rawtypes") WebSocketClient client) {
+        return WebSocketClientListener.newWebSocketListener(clientMetricNamePrefix + client.name());
+    }
+
+    @Override
+    public UdpClientListener forUdpClient(@SuppressWarnings("rawtypes") UdpClient client) {
+        return UdpClientListener.newUdpListener(clientMetricNamePrefix + client.name());
+    }
+
+    @Override
+    public TcpServerListener<ServerMetricsEvent<ServerMetricsEvent.EventType>> forTcpServer( @SuppressWarnings("rawtypes") RxServer server) {
+        return TcpServerListener.newListener(serverMetricNamePrefix + server.getServerPort());
+    }
+
+    @Override
+    public HttpServerListener forHttpServer(@SuppressWarnings("rawtypes") HttpServer server) {
+        return HttpServerListener.newHttpListener(serverMetricNamePrefix + server.getServerPort());
+    }
+
+    @Override
+    public WebSocketServerListener forWebSocketServer(@SuppressWarnings("rawtypes") WebSocketServer server) {
+        return WebSocketServerListener.newWebSocketListener(serverMetricNamePrefix + server.getServerPort());
+    }
+
+    @Override
+    public UdpServerListener forUdpServer(@SuppressWarnings("rawtypes") UdpServer server) {
+        return UdpServerListener.newUdpListener(serverMetricNamePrefix + server.getServerPort());
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/SpectatorUtils.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/SpectatorUtils.java
@@ -1,0 +1,26 @@
+package io.reactivex.netty.spectator;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.ExtendedRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.api.Timer;
+
+public final class SpectatorUtils {
+    private SpectatorUtils() {
+    }
+
+    public static Counter newCounter(String name, String id) {
+        return Spectator.registry().counter(name, "id", id);
+    }
+
+    public static Timer newTimer(String name, String id) {
+        return Spectator.registry().timer(name, "id", id);
+    }
+
+    public static <T extends Number> T newGauge(String name, String id, T number) {
+        final ExtendedRegistry registry = Spectator.registry();
+        Id gaugeId = registry.createId(name, "id", id);
+        return registry.gauge(gaugeId, number);
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/HttpClientListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/HttpClientListener.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.http;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Timer;
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.metrics.HttpClientMetricEventsListener;
+import io.reactivex.netty.spectator.tcp.TcpClientListener;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.reactivex.netty.spectator.SpectatorUtils.newCounter;
+import static io.reactivex.netty.spectator.SpectatorUtils.newGauge;
+import static io.reactivex.netty.spectator.SpectatorUtils.newTimer;
+/**
+ * HttpClientListener.
+ *  */
+public class HttpClientListener extends TcpClientListener<ClientMetricsEvent<?>> {
+
+    private final AtomicInteger requestBacklog;
+    private final AtomicInteger inflightRequests;
+    private final Counter processedRequests;
+    private final Counter requestWriteFailed;
+    private final Counter failedResponses;
+    private final Counter failedContentSource;
+    private final Timer requestWriteTimes;
+    private final Timer responseReadTimes;
+    private final Timer requestProcessingTimes;
+
+    private final HttpClientMetricEventsListenerImpl delegate = new HttpClientMetricEventsListenerImpl();
+
+    protected HttpClientListener(String monitorId) {
+        super(monitorId);
+        requestBacklog = newGauge("requestBacklog", monitorId, new AtomicInteger());
+        inflightRequests = newGauge("inflightRequests", monitorId, new AtomicInteger());
+        requestWriteTimes = newTimer("requestWriteTimes", monitorId);
+        responseReadTimes = newTimer("responseReadTimes", monitorId);
+        processedRequests = newCounter("processedRequests", monitorId);
+        requestWriteFailed = newCounter("requestWriteFailed", monitorId);
+        failedResponses = newCounter("failedResponses", monitorId);
+        failedContentSource = newCounter("failedContentSource", monitorId);
+        requestProcessingTimes = newTimer("requestProcessingTimes", monitorId);
+    }
+
+    @Override
+    public void onEvent(ClientMetricsEvent<?> event, long duration, TimeUnit timeUnit, Throwable throwable,
+                        Object value) {
+        delegate.onEvent(event, duration, timeUnit, throwable, value);
+    }
+
+    public static HttpClientListener newHttpListener(String monitorId) {
+        return new HttpClientListener(monitorId);
+    }
+
+    public long getRequestBacklog() {
+        return requestBacklog.get();
+    }
+
+    public long getInflightRequests() {
+        return inflightRequests.get();
+    }
+
+    public long getProcessedRequests() {
+        return processedRequests.count();
+    }
+
+    public long getRequestWriteFailed() {
+        return requestWriteFailed.count();
+    }
+
+    public long getFailedResponses() {
+        return failedResponses.count();
+    }
+
+    public long getFailedContentSource() {
+        return failedContentSource.count();
+    }
+
+    public Timer getRequestWriteTimes() {
+        return requestWriteTimes;
+    }
+
+    public Timer getResponseReadTimes() {
+        return responseReadTimes;
+    }
+
+    private class HttpClientMetricEventsListenerImpl extends HttpClientMetricEventsListener {
+
+        @Override
+        protected void onRequestProcessingComplete(long duration, TimeUnit timeUnit) {
+            requestProcessingTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onResponseReceiveComplete(long duration, TimeUnit timeUnit) {
+            inflightRequests.decrementAndGet();
+            processedRequests.increment();
+            responseReadTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onResponseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            inflightRequests.decrementAndGet();
+            processedRequests.increment();
+            failedResponses.increment();
+        }
+
+        @Override
+        protected void onRequestContentSourceError(Throwable throwable) {
+            failedContentSource.increment();
+        }
+
+        @Override
+        protected void onRequestWriteComplete(long duration, TimeUnit timeUnit) {
+            requestWriteTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onRequestWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            inflightRequests.decrementAndGet();
+            requestWriteFailed.increment();
+        }
+
+        @Override
+        protected void onRequestHeadersWriteStart() {
+            requestBacklog.decrementAndGet();
+        }
+
+        @Override
+        protected void onRequestSubmitted() {
+            requestBacklog.incrementAndGet();
+            inflightRequests.incrementAndGet();
+        }
+
+        @Override
+        protected void onByteRead(long bytesRead) {
+            HttpClientListener.this.onByteRead(bytesRead);
+        }
+
+        @Override
+        protected void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpClientListener.this.onFlushFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onFlushSuccess(long duration, TimeUnit timeUnit) {
+            HttpClientListener.this.onFlushSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onFlushStart() {
+            HttpClientListener.this.onFlushStart();
+        }
+
+        @Override
+        protected void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpClientListener.this.onWriteFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
+            HttpClientListener.this.onWriteSuccess(duration, timeUnit, bytesWritten);
+        }
+
+        @Override
+        protected void onWriteStart() {
+            HttpClientListener.this.onWriteStart();
+        }
+
+        @Override
+        protected void onPoolReleaseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpClientListener.this.onPoolReleaseFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onPoolReleaseSuccess(long duration, TimeUnit timeUnit) {
+            HttpClientListener.this.onPoolReleaseSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onPoolReleaseStart() {
+            HttpClientListener.this.onPoolReleaseStart();
+        }
+
+        @Override
+        protected void onPooledConnectionEviction() {
+            HttpClientListener.this.onPooledConnectionEviction();
+        }
+
+        @Override
+        protected void onPooledConnectionReuse(long duration, TimeUnit timeUnit) {
+            HttpClientListener.this.onPooledConnectionReuse(duration, timeUnit);
+        }
+
+        @Override
+        protected void onPoolAcquireFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpClientListener.this.onPoolAcquireFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onPoolAcquireSuccess(long duration, TimeUnit timeUnit) {
+            HttpClientListener.this.onPoolAcquireSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onPoolAcquireStart() {
+            HttpClientListener.this.onPoolAcquireStart();
+        }
+
+        @Override
+        protected void onConnectionCloseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpClientListener.this.onConnectionCloseFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
+            HttpClientListener.this.onConnectionCloseSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onConnectionCloseStart() {
+            HttpClientListener.this.onConnectionCloseStart();
+        }
+
+        @Override
+        protected void onConnectFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpClientListener.this.onConnectFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onConnectSuccess(long duration, TimeUnit timeUnit) {
+            HttpClientListener.this.onConnectSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onConnectStart() {
+            HttpClientListener.this.onConnectStart();
+        }
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/HttpServerListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/HttpServerListener.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.http;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Timer;
+
+import io.reactivex.netty.metrics.HttpServerMetricEventsListener;
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.tcp.TcpServerListener;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.reactivex.netty.spectator.SpectatorUtils.newCounter;
+import static io.reactivex.netty.spectator.SpectatorUtils.newGauge;
+import static io.reactivex.netty.spectator.SpectatorUtils.newTimer;
+
+/**
+ * HttpServerListener.
+ */
+public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>> {
+
+    private final AtomicInteger requestBacklog;
+    private final AtomicInteger inflightRequests;
+    private final Counter processedRequests;
+    private final Counter failedRequests;
+    private final Counter responseWriteFailed;
+    private final Timer responseWriteTimes;
+    private final Timer requestReadTimes;
+
+    private final HttpServerMetricEventsListenerImpl delegate;
+
+    protected HttpServerListener(String monitorId) {
+        super(monitorId);
+        requestBacklog = newGauge("requestBacklog", monitorId, new AtomicInteger());
+        inflightRequests = newGauge("inflightRequests", monitorId, new AtomicInteger());
+        responseWriteTimes = newTimer("responseWriteTimes", monitorId);
+        requestReadTimes = newTimer("requestReadTimes", monitorId);
+        processedRequests = newCounter("processedRequests", monitorId);
+        failedRequests = newCounter("failedRequests", monitorId);
+        responseWriteFailed = newCounter("responseWriteFailed", monitorId);
+        delegate = new HttpServerMetricEventsListenerImpl();
+    }
+
+    @Override
+    public void onEvent(ServerMetricsEvent<?> event, long duration, TimeUnit timeUnit, Throwable throwable,
+                        Object value) {
+        delegate.onEvent(event, duration, timeUnit, throwable, value);
+    }
+
+    public long getRequestBacklog() {
+        return requestBacklog.get();
+    }
+
+    public long getInflightRequests() {
+        return inflightRequests.get();
+    }
+
+    public long getProcessedRequests() {
+        return processedRequests.count();
+    }
+
+    public long getFailedRequests() {
+        return failedRequests.count();
+    }
+
+    public long getResponseWriteFailed() {
+        return responseWriteFailed.count();
+    }
+
+    public Timer getResponseWriteTimes() {
+        return responseWriteTimes;
+    }
+
+    public Timer getRequestReadTimes() {
+        return requestReadTimes;
+    }
+
+    public static HttpServerListener newHttpListener(String monitorId) {
+        return new HttpServerListener(monitorId);
+    }
+
+    private class HttpServerMetricEventsListenerImpl extends HttpServerMetricEventsListener {
+
+        @Override
+        protected void onRequestHandlingFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            processedRequests.increment();
+            inflightRequests.decrementAndGet();
+            failedRequests.increment();
+        }
+
+        @Override
+        protected void onRequestHandlingSuccess(long duration, TimeUnit timeUnit) {
+            inflightRequests.decrementAndGet();
+            processedRequests.increment();
+        }
+
+        @Override
+        protected void onResponseContentWriteSuccess(long duration, TimeUnit timeUnit) {
+            responseWriteTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onResponseHeadersWriteSuccess(long duration, TimeUnit timeUnit) {
+            responseWriteTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onResponseContentWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            responseWriteFailed.increment();
+        }
+
+        @Override
+        protected void onResponseHeadersWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            responseWriteFailed.increment();
+        }
+
+        @Override
+        protected void onRequestReceiveComplete(long duration, TimeUnit timeUnit) {
+            requestReadTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onRequestHandlingStart(long duration, TimeUnit timeUnit) {
+            requestBacklog.decrementAndGet();
+        }
+
+        @Override
+        protected void onNewRequestReceived() {
+            requestBacklog.incrementAndGet();
+            inflightRequests.incrementAndGet();
+        }
+
+        @Override
+        protected void onConnectionHandlingFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpServerListener.this.onConnectionHandlingFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onConnectionHandlingSuccess(long duration, TimeUnit timeUnit) {
+            HttpServerListener.this.onConnectionHandlingSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onConnectionHandlingStart(long duration, TimeUnit timeUnit) {
+            HttpServerListener.this.onConnectionHandlingStart(duration, timeUnit);
+        }
+
+        @Override
+        protected void onNewClientConnected() {
+            HttpServerListener.this.onNewClientConnected();
+        }
+
+        @Override
+        protected void onByteRead(long bytesRead) {
+            HttpServerListener.this.onByteRead(bytesRead);
+        }
+
+        @Override
+        protected void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpServerListener.this.onFlushFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onFlushSuccess(long duration, TimeUnit timeUnit) {
+            HttpServerListener.this.onFlushSuccess(duration, timeUnit);
+        }
+
+        @Override
+        protected void onFlushStart() {
+            HttpServerListener.this.onFlushStart();
+        }
+
+        @Override
+        protected void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+            HttpServerListener.this.onWriteFailed(duration, timeUnit, throwable);
+        }
+
+        @Override
+        protected void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
+            HttpServerListener.this.onWriteSuccess(duration, timeUnit, bytesWritten);
+        }
+
+        @Override
+        protected void onWriteStart() {
+            HttpServerListener.this.onWriteStart();
+        }
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/websocket/WebSocketClientListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/websocket/WebSocketClientListener.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.spectator.http.websocket;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Timer;
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.metrics.WebSocketClientMetricEventsListener;
+import io.reactivex.netty.protocol.http.websocket.WebSocketClientMetricsEvent;
+import io.reactivex.netty.spectator.tcp.TcpClientListener;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.reactivex.netty.spectator.SpectatorUtils.newCounter;
+import static io.reactivex.netty.spectator.SpectatorUtils.newGauge;
+import static io.reactivex.netty.spectator.SpectatorUtils.newTimer;
+/**
+ * @author Tomasz Bak
+ */
+public class WebSocketClientListener extends TcpClientListener<ClientMetricsEvent<?>> {
+    private final AtomicInteger inflightHandshakes;
+    private final Counter processedHandshakes;
+    private final Counter failedHandshakes;
+    private final Counter webSocketWrites;
+    private final Counter getWebSocketReads;
+    private final Timer handshakeProcessingTimes;
+
+    private final WebSocketClientMetricEventsListenerImpl delegate = new WebSocketClientMetricEventsListenerImpl();
+
+    protected WebSocketClientListener(String monitorId) {
+        super(monitorId);
+        inflightHandshakes = newGauge("inflightHandshakes", monitorId, new AtomicInteger());
+        processedHandshakes = newCounter("processedHandshakes", monitorId);
+        failedHandshakes = newCounter("failedHandshakes", monitorId);
+        webSocketWrites = newCounter("webSocketWrites", monitorId);
+        getWebSocketReads = newCounter("getWebSocketReads", monitorId);
+        handshakeProcessingTimes = newTimer("handshakeProcessingTimes", monitorId);
+    }
+
+    public static WebSocketClientListener newWebSocketListener(String monitorId) {
+        return new WebSocketClientListener(monitorId);
+    }
+
+    @Override
+    public void onEvent(ClientMetricsEvent<?> event, long duration, TimeUnit timeUnit, Throwable throwable,
+                        Object value) {
+        if (event.getType().getClass() == WebSocketClientMetricsEvent.EventType.class) {
+            delegate.onEvent(event, duration, timeUnit, throwable, value);
+        } else {
+            super.onEvent(event, duration, timeUnit, throwable, value);
+        }
+    }
+
+    public long getInflightHandshakes() {
+        return inflightHandshakes.get();
+    }
+
+    public long getProcessedHandshakes() {
+        return processedHandshakes.count();
+    }
+
+    public long getFailedHandshakes() {
+        return failedHandshakes.count();
+    }
+
+    public Timer getHandshakeProcessingTimes() {
+        return handshakeProcessingTimes;
+    }
+
+    public long getWebSocketWrites() {
+        return webSocketWrites.count();
+    }
+
+    public long getWebSocketReads() {
+        return getWebSocketReads.count();
+    }
+
+    private class WebSocketClientMetricEventsListenerImpl extends WebSocketClientMetricEventsListener {
+        @Override
+        protected void onHandshakeStart() {
+            inflightHandshakes.incrementAndGet();
+        }
+
+        @Override
+        protected void onHandshakeSuccess(long duration, TimeUnit timeUnit) {
+            inflightHandshakes.decrementAndGet();
+            processedHandshakes.increment();
+            handshakeProcessingTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onHandshakeFailure(long duration, TimeUnit timeUnit, Throwable throwable) {
+            inflightHandshakes.decrementAndGet();
+            processedHandshakes.increment();
+            failedHandshakes.increment();
+            handshakeProcessingTimes.record(duration, timeUnit);
+        }
+
+        @Override
+        protected void onWebSocketWrites() {
+            webSocketWrites.increment();
+        }
+
+        @Override
+        protected void onWebSocketReads() {
+            getWebSocketReads.increment();
+        }
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/websocket/WebSocketServerListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/http/websocket/WebSocketServerListener.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.spectator.http.websocket;
+
+import com.netflix.spectator.api.Counter;
+import io.reactivex.netty.metrics.WebSocketServerMetricEventsListener;
+import io.reactivex.netty.protocol.http.websocket.WebSocketServerMetricsEvent;
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.tcp.TcpServerListener;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.reactivex.netty.spectator.SpectatorUtils.newCounter;
+
+/**
+ *
+ */
+public class WebSocketServerListener extends TcpServerListener<ServerMetricsEvent<?>> {
+
+    private final Counter processedHandshakes;
+    private final Counter failedHandshakes;
+    private final Counter webSocketWrites;
+    private final Counter getWebSocketReads;
+
+    private final WebSocketServerMetricEventsListenerImpl delegate = new WebSocketServerMetricEventsListenerImpl();
+
+    protected WebSocketServerListener(String monitorId) {
+        super(monitorId);
+        processedHandshakes = newCounter("processedHandshakes", monitorId);
+        failedHandshakes = newCounter("failedHandshakes", monitorId);
+        webSocketWrites = newCounter("webSocketWrites", monitorId);
+        getWebSocketReads = newCounter("getWebSocketReads", monitorId);
+    }
+
+    @Override
+    public void onEvent(ServerMetricsEvent<?> event, long duration, TimeUnit timeUnit, Throwable throwable,
+                        Object value) {
+        if (event.getType().getClass() == WebSocketServerMetricsEvent.EventType.class) {
+            delegate.onEvent(event, duration, timeUnit, throwable, value);
+        } else {
+            super.onEvent(event, duration, timeUnit, throwable, value);
+        }
+    }
+
+    public long getProcessedHandshakes() {
+        return processedHandshakes.count();
+    }
+
+    public long getFailedHandshakes() {
+        return failedHandshakes.count();
+    }
+
+    public long getWebSocketWrites() {
+        return webSocketWrites.count();
+    }
+
+    public long getWebSocketReads() {
+        return getWebSocketReads.count();
+    }
+
+    public static WebSocketServerListener newWebSocketListener(String monitorId) {
+        return new WebSocketServerListener(monitorId);
+    }
+
+    private class WebSocketServerMetricEventsListenerImpl extends WebSocketServerMetricEventsListener {
+
+        @Override
+        protected void onHandshakeProcessed() {
+            processedHandshakes.increment();
+        }
+
+        @Override
+        protected void onHandshakeFailure() {
+            processedHandshakes.increment();
+            failedHandshakes.increment();
+        }
+
+        @Override
+        protected void onWebSocketWrites() {
+            webSocketWrites.increment();
+        }
+
+        @Override
+        protected void onWebSocketReads() {
+            getWebSocketReads.increment();
+        }
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/tcp/TcpClientListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/tcp/TcpClientListener.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.tcp;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Timer;
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.metrics.ClientMetricEventsListener;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.reactivex.netty.spectator.SpectatorUtils.newCounter;
+import static io.reactivex.netty.spectator.SpectatorUtils.newGauge;
+import static io.reactivex.netty.spectator.SpectatorUtils.newTimer;
+
+/**
+ * TcpClientListener
+ */
+public class TcpClientListener<T extends ClientMetricsEvent<?>> extends ClientMetricEventsListener<T> {
+    private final AtomicInteger liveConnections;
+    private final Counter connectionCount;
+    private final AtomicInteger pendingConnects;
+    private final Counter failedConnects;
+    private final Timer connectionTimes;
+
+    private final AtomicInteger pendingConnectionClose;
+    private final Counter failedConnectionClose;
+
+    private final AtomicInteger pendingPoolAcquires;
+    private final Counter failedPoolAcquires;
+    private final Timer poolAcquireTimes;
+
+    private final AtomicInteger pendingPoolReleases;
+    private final Counter failedPoolReleases;
+    private final Timer poolReleaseTimes;
+
+    private final Counter poolAcquires;
+    private final Counter poolEvictions;
+    private final Counter poolReuse;
+    private final Counter poolReleases;
+
+    private final AtomicInteger pendingWrites;
+    private final AtomicInteger pendingFlushes;
+
+    private final Counter bytesWritten;
+    private final Timer writeTimes;
+    private final Counter bytesRead;
+    private final Counter failedWrites;
+    private final Counter failedFlushes;
+    private final Timer flushTimes;
+
+    protected TcpClientListener(String monitorId) {
+        liveConnections = newGauge("liveConnections", monitorId, new AtomicInteger());
+        connectionCount = newCounter("connectionCount", monitorId);
+        pendingConnects = newGauge("pendingConnects", monitorId, new AtomicInteger());
+        failedConnects = newCounter("failedConnects", monitorId);
+        connectionTimes = newTimer("connectionTimes", monitorId);
+        pendingConnectionClose = newGauge("pendingConnectionClose", monitorId, new AtomicInteger());
+        failedConnectionClose = newCounter("failedConnectionClose", monitorId);
+        pendingPoolAcquires = newGauge("pendingPoolAcquires", monitorId, new AtomicInteger());
+        poolAcquireTimes = newTimer("poolAcquireTimes", monitorId);
+        failedPoolAcquires = newCounter("failedPoolAcquires", monitorId);
+        pendingPoolReleases = newGauge("pendingPoolReleases", monitorId, new AtomicInteger());
+        poolReleaseTimes = newTimer("poolReleaseTimes", monitorId);
+        failedPoolReleases = newCounter("failedPoolReleases", monitorId);
+        poolAcquires = newCounter("poolAcquires", monitorId);
+        poolEvictions = newCounter("poolEvictions", monitorId);
+        poolReuse = newCounter("poolReuse", monitorId);
+        poolReleases = newCounter("poolReleases", monitorId);
+
+        pendingWrites = newGauge("pendingWrites", monitorId, new AtomicInteger());
+        pendingFlushes = newGauge("pendingFlushes", monitorId, new AtomicInteger());
+
+        bytesWritten = newCounter("bytesWritten", monitorId);
+        writeTimes = newTimer("writeTimes", monitorId);
+        bytesRead = newCounter("bytesRead", monitorId);
+        failedWrites = newCounter("failedWrites", monitorId);
+        failedFlushes = newCounter("failedFlushes", monitorId);
+        flushTimes = newTimer("flushTimes", monitorId);
+    }
+
+    @Override
+    protected void onByteRead(long bytesRead) {
+        this.bytesRead.increment(bytesRead);
+    }
+
+    @Override
+    protected void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingFlushes.decrementAndGet();
+        failedFlushes.increment();
+    }
+
+    @Override
+    protected void onFlushSuccess(long duration, TimeUnit timeUnit) {
+        pendingFlushes.decrementAndGet();
+        flushTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onFlushStart() {
+        pendingFlushes.incrementAndGet();
+    }
+
+    @Override
+    protected void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingWrites.decrementAndGet();
+        failedWrites.increment();
+    }
+
+    @Override
+    protected void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
+        pendingWrites.decrementAndGet();
+        this.bytesWritten.increment(bytesWritten);
+        writeTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onWriteStart() {
+        pendingWrites.incrementAndGet();
+    }
+
+    @Override
+    protected void onPoolReleaseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingPoolReleases.decrementAndGet();
+        poolReleases.increment();
+        failedPoolReleases.increment();
+    }
+
+    @Override
+    protected void onPoolReleaseSuccess(long duration, TimeUnit timeUnit) {
+        pendingPoolReleases.decrementAndGet();
+        poolReleases.increment();
+        poolReleaseTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onPoolReleaseStart() {
+        pendingPoolReleases.incrementAndGet();
+    }
+
+    @Override
+    protected void onPooledConnectionEviction() {
+        poolEvictions.increment();
+    }
+
+    @Override
+    protected void onPooledConnectionReuse(long duration, TimeUnit timeUnit) {
+        poolReuse.increment();
+    }
+
+    @Override
+    protected void onPoolAcquireFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingPoolAcquires.decrementAndGet();
+        poolAcquires.increment();
+        failedPoolAcquires.increment();
+    }
+
+    @Override
+    protected void onPoolAcquireSuccess(long duration, TimeUnit timeUnit) {
+        pendingPoolAcquires.decrementAndGet();
+        poolAcquires.increment();
+        poolAcquireTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onPoolAcquireStart() {
+        pendingPoolAcquires.incrementAndGet();
+    }
+
+    @Override
+    protected void onConnectionCloseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        liveConnections.decrementAndGet(); // Even though the close failed, the connection isn't live.
+        pendingConnectionClose.decrementAndGet();
+        failedConnectionClose.increment();
+    }
+
+    @Override
+    protected void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
+        liveConnections.decrementAndGet();
+        pendingConnectionClose.decrementAndGet();
+    }
+
+    @Override
+    protected void onConnectionCloseStart() {
+        pendingConnectionClose.incrementAndGet();
+    }
+
+    @Override
+    protected void onConnectFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingConnects.decrementAndGet();
+        failedConnects.increment();
+    }
+
+    @Override
+    protected void onConnectSuccess(long duration, TimeUnit timeUnit) {
+        pendingConnects.decrementAndGet();
+        liveConnections.incrementAndGet();
+        connectionCount.increment();
+        connectionTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onConnectStart() {
+        pendingConnects.incrementAndGet();
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+
+    @Override
+    public void onSubscribe() {
+    }
+
+    public long getLiveConnections() {
+        return liveConnections.get();
+    }
+
+    public long getConnectionCount() {
+        return connectionCount.count();
+    }
+
+    public long getPendingConnects() {
+        return pendingConnects.get();
+    }
+
+    public long getFailedConnects() {
+        return failedConnects.count();
+    }
+
+    public Timer getConnectionTimes() {
+        return connectionTimes;
+    }
+
+    public long getPendingConnectionClose() {
+        return pendingConnectionClose.get();
+    }
+
+    public long getFailedConnectionClose() {
+        return failedConnectionClose.count();
+    }
+
+    public long getPendingPoolAcquires() {
+        return pendingPoolAcquires.get();
+    }
+
+    public long getFailedPoolAcquires() {
+        return failedPoolAcquires.count();
+    }
+
+    public Timer getPoolAcquireTimes() {
+        return poolAcquireTimes;
+    }
+
+    public long getPendingPoolReleases() {
+        return pendingPoolReleases.get();
+    }
+
+    public long getFailedPoolReleases() {
+        return failedPoolReleases.count();
+    }
+
+    public Timer getPoolReleaseTimes() {
+        return poolReleaseTimes;
+    }
+
+    public long getPoolEvictions() {
+        return poolEvictions.count();
+    }
+
+    public long getPoolReuse() {
+        return poolReuse.count();
+    }
+
+    public long getPendingWrites() {
+        return pendingWrites.get();
+    }
+
+    public long getPendingFlushes() {
+        return pendingFlushes.get();
+    }
+
+    public long getBytesWritten() {
+        return bytesWritten.count();
+    }
+
+    public Timer getWriteTimes() {
+        return writeTimes;
+    }
+
+    public long getBytesRead() {
+        return bytesRead.count();
+    }
+
+    public long getFailedWrites() {
+        return failedWrites.count();
+    }
+
+    public long getFailedFlushes() {
+        return failedFlushes.count();
+    }
+
+    public Timer getFlushTimes() {
+        return flushTimes;
+    }
+
+    public long getPoolAcquires() {
+        return poolAcquires.count();
+    }
+
+    public long getPoolReleases() {
+        return poolReleases.count();
+    }
+
+    public static TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> newListener(String monitorId) {
+        return new TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>>(monitorId);
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/tcp/TcpServerListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/tcp/TcpServerListener.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.tcp;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Timer;
+import io.reactivex.netty.metrics.ServerMetricEventsListener;
+import io.reactivex.netty.server.ServerMetricsEvent;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.reactivex.netty.spectator.SpectatorUtils.newCounter;
+import static io.reactivex.netty.spectator.SpectatorUtils.newGauge;
+import static io.reactivex.netty.spectator.SpectatorUtils.newTimer;
+
+/**
+ * TcpServerListener.
+ */
+public class TcpServerListener<T extends ServerMetricsEvent<?>> extends ServerMetricEventsListener<T> {
+
+    private final AtomicInteger liveConnections;
+    private final AtomicInteger inflightConnections;
+    private final Counter failedConnections;
+    private final Timer connectionProcessingTimes;
+    private final AtomicInteger pendingConnectionClose;
+    private final Counter failedConnectionClose;
+    private final Timer connectionCloseTimes;
+
+    private final AtomicInteger pendingWrites;
+    private final AtomicInteger pendingFlushes;
+
+    private final Counter bytesWritten;
+    private final Timer writeTimes;
+    private final Counter bytesRead;
+    private final Counter failedWrites;
+    private final Counter failedFlushes;
+    private final Timer flushTimes;
+
+    protected TcpServerListener(String monitorId) {
+        liveConnections = newGauge("liveConnections", monitorId, new AtomicInteger());
+        inflightConnections = newGauge("inflightConnections", monitorId, new AtomicInteger());
+        pendingConnectionClose = newGauge("pendingConnectionClose", monitorId, new AtomicInteger());
+        failedConnectionClose = newCounter("failedConnectionClose", monitorId);
+        failedConnections = newCounter("failedConnections", monitorId);
+        connectionProcessingTimes = newTimer("connectionProcessingTimes", monitorId);
+        connectionCloseTimes = newTimer("connectionCloseTimes", monitorId);
+
+        pendingWrites = newGauge("pendingWrites", monitorId, new AtomicInteger());
+        pendingFlushes = newGauge("pendingFlushes", monitorId, new AtomicInteger());
+
+        bytesWritten = newCounter("bytesWritten", monitorId);
+        writeTimes = newTimer("writeTimes", monitorId);
+        bytesRead = newCounter("bytesRead", monitorId);
+        failedWrites = newCounter("failedWrites", monitorId);
+        failedFlushes = newCounter("failedFlushes", monitorId);
+        flushTimes = newTimer("flushTimes", monitorId);
+    }
+
+    @Override
+    protected void onConnectionHandlingFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        inflightConnections.decrementAndGet();
+        failedConnections.increment();
+    }
+
+    @Override
+    protected void onConnectionHandlingSuccess(long duration, TimeUnit timeUnit) {
+        inflightConnections.decrementAndGet();
+        connectionProcessingTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onConnectionHandlingStart(long duration, TimeUnit timeUnit) {
+        inflightConnections.incrementAndGet();
+    }
+
+    @Override
+    protected void onConnectionCloseStart() {
+        pendingConnectionClose.incrementAndGet();
+    }
+
+    @Override
+    protected void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
+        liveConnections.decrementAndGet();
+        pendingConnectionClose.decrementAndGet();
+        connectionCloseTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onConnectionCloseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        liveConnections.decrementAndGet();
+        pendingConnectionClose.decrementAndGet();
+        connectionCloseTimes.record(duration, timeUnit);
+        failedConnectionClose.increment();
+    }
+
+    @Override
+    protected void onNewClientConnected() {
+        liveConnections.incrementAndGet();
+    }
+
+    @Override
+    protected void onByteRead(long bytesRead) {
+        this.bytesRead.increment(bytesRead);
+    }
+
+    @Override
+    protected void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingFlushes.decrementAndGet();
+        failedFlushes.increment();
+    }
+
+    @Override
+    protected void onFlushSuccess(long duration, TimeUnit timeUnit) {
+        pendingFlushes.decrementAndGet();
+        flushTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onFlushStart() {
+        pendingFlushes.incrementAndGet();
+    }
+
+    @Override
+    protected void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
+        pendingWrites.decrementAndGet();
+        failedWrites.increment();
+    }
+
+    @Override
+    protected void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
+        pendingWrites.decrementAndGet();
+        this.bytesWritten.increment(bytesWritten);
+        writeTimes.record(duration, timeUnit);
+    }
+
+    @Override
+    protected void onWriteStart() {
+        pendingWrites.incrementAndGet();
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+
+    @Override
+    public void onSubscribe() {
+    }
+
+    public static TcpServerListener<ServerMetricsEvent<ServerMetricsEvent.EventType>> newListener(String monitorId) {
+        return new TcpServerListener<ServerMetricsEvent<ServerMetricsEvent.EventType>>(monitorId);
+    }
+
+    public long getLiveConnections() {
+        return liveConnections.get();
+    }
+
+    public long getInflightConnections() {
+        return inflightConnections.get();
+    }
+
+    public long getFailedConnections() {
+        return failedConnections.count();
+    }
+
+    public Timer getConnectionProcessingTimes() {
+        return connectionProcessingTimes;
+    }
+
+    public long getPendingWrites() {
+        return pendingWrites.get();
+    }
+
+    public long getPendingFlushes() {
+        return pendingFlushes.get();
+    }
+
+    public long getBytesWritten() {
+        return bytesWritten.count();
+    }
+
+    public Timer getWriteTimes() {
+        return writeTimes;
+    }
+
+    public long getBytesRead() {
+        return bytesRead.count();
+    }
+
+    public long getFailedWrites() {
+        return failedWrites.count();
+    }
+
+    public long getFailedFlushes() {
+        return failedFlushes.count();
+    }
+
+    public Timer getFlushTimes() {
+        return flushTimes;
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/udp/UdpClientListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/udp/UdpClientListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.udp;
+
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.spectator.tcp.TcpClientListener;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Nitesh Kant
+ */
+public class UdpClientListener extends TcpClientListener<ClientMetricsEvent<?>> {
+
+    protected UdpClientListener(String monitorId) {
+        super(monitorId);
+    }
+
+    @Override
+    public void onEvent(ClientMetricsEvent<?> event, long duration, TimeUnit timeUnit, Throwable throwable,
+                        Object value) {
+        if (event.getType() instanceof ClientMetricsEvent.EventType) {
+            super.onEvent(event, duration, timeUnit, throwable, value);
+        }
+    }
+
+    public static UdpClientListener newUdpListener(String monitorId) {
+        return new UdpClientListener(monitorId);
+    }
+}

--- a/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/udp/UdpServerListener.java
+++ b/rxnetty-spectator/src/main/java/io/reactivex/netty/spectator/udp/UdpServerListener.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.udp;
+
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.tcp.TcpServerListener;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Nitesh Kant
+ */
+public class UdpServerListener extends TcpServerListener<ServerMetricsEvent<?>> {
+
+    protected UdpServerListener(String monitorId) {
+        super(monitorId);
+    }
+
+    @Override
+    public void onEvent(ServerMetricsEvent<?> event, long duration, TimeUnit timeUnit, Throwable throwable,
+                        Object value) {
+        if (event.getType() instanceof ServerMetricsEvent.EventType) {
+            super.onEvent(event, duration, timeUnit, throwable, value);
+        }
+    }
+
+    public static UdpServerListener newUdpListener(String monitorId) {
+        return new UdpServerListener(monitorId);
+    }
+}

--- a/rxnetty-spectator/src/test/java/io/reactivex/netty/spectator/http/HttpMetricsTest.java
+++ b/rxnetty-spectator/src/test/java/io/reactivex/netty/spectator/http/HttpMetricsTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.spectator.http;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.metrics.MetricEventsSubject;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientBuilder;
+import io.reactivex.netty.protocol.http.client.HttpClientMetricsEvent;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.server.HttpServerMetricsEvent;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import rx.Observable;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Nitesh Kant
+ */
+public class HttpMetricsTest {
+
+    private SpectatorEventsListenerFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new SpectatorEventsListenerFactory("http-metric-test-client", "http-metric-test-server");
+    }
+
+    @Test
+    public void testServerMetrics() throws Exception {
+        HttpServer<ByteBuf, ByteBuf> server = RxNetty.createHttpServer(0, new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return Observable.empty();
+            }
+        });
+        MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject = server.getEventsSubject();
+
+        HttpServerListener listener = factory.forHttpServer(server);
+        server.subscribe(listener);
+        long responseTimes = listener.getResponseWriteTimes().totalTime();
+
+        doRequestStart(eventsSubject, listener);
+        Assert.assertEquals("Unexpected live connections.", 1, listener.getLiveConnections());
+
+        eventsSubject.onEvent(HttpServerMetricsEvent.RESPONSE_HEADERS_WRITE_START);
+        eventsSubject.onEvent(HttpServerMetricsEvent.RESPONSE_HEADERS_WRITE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected inflight requests.", 0, listener.getInflightRequests());
+        Assert.assertEquals("Unexpected response write times.", TimeUnit.MILLISECONDS.toNanos(1) + responseTimes,
+                listener.getResponseWriteTimes().totalTime());
+        Assert.assertEquals("Unexpected processed requests.", 1, listener.getProcessedRequests());
+
+        doRequestStart(eventsSubject, listener);
+        Assert.assertEquals("Unexpected live connections.", 2, listener.getLiveConnections());
+
+        responseTimes = listener.getResponseWriteTimes().totalTime();
+        eventsSubject.onEvent(HttpServerMetricsEvent.RESPONSE_HEADERS_WRITE_START);
+        eventsSubject.onEvent(HttpServerMetricsEvent.RESPONSE_HEADERS_WRITE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_FAILED, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected inflight requests.", 0, listener.getInflightRequests());
+        Assert.assertEquals("Unexpected response write times.", responseTimes + TimeUnit.MILLISECONDS.toNanos(1),
+                listener.getResponseWriteTimes().totalTime());
+        Assert.assertEquals("Unexpected processed requests.", 2, listener.getProcessedRequests());
+        Assert.assertEquals("Unexpected failed requests.", 1, listener.getFailedRequests());
+    }
+
+    @Test
+    public void testClientMetrics() throws Exception {
+        HttpClientBuilder<ByteBuf, ByteBuf> builder = RxNetty.newHttpClientBuilder("localhost", 0);
+        MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject = builder.getEventsSubject();
+        HttpClient<ByteBuf, ByteBuf> client = builder.build();
+        HttpClientListener listener = factory.forHttpClient(client);
+        client.subscribe(listener);
+
+        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_SUBMITTED);
+        Assert.assertEquals("Unexpected request backlog.", 1, listener.getRequestBacklog());
+
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_START);
+        Assert.assertEquals("Invalid pending connect count.", 1, listener.getPendingConnects());
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending connect count after connect success.", 0, listener.getPendingConnects());
+
+        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_HEADERS_WRITE_START);
+        Assert.assertEquals("Unexpected request backlog.", 0, listener.getRequestBacklog());
+        Assert.assertEquals("Unexpected inflight requests.", 1, listener.getInflightRequests());
+
+        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_HEADERS_WRITE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_WRITE_COMPLETE, 1, TimeUnit.MILLISECONDS);
+        eventsSubject.onEvent(HttpClientMetricsEvent.RESPONSE_RECEIVE_COMPLETE, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected request backlog.", 0, listener.getInflightRequests());
+        Assert.assertEquals("Unexpected processed request.", 1, listener.getProcessedRequests());
+
+        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_SUBMITTED);
+        Assert.assertEquals("Unexpected request backlog.", 1, listener.getRequestBacklog());
+
+        eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_HEADERS_WRITE_START);
+        Assert.assertEquals("Unexpected request backlog.", 0, listener.getRequestBacklog());
+        Assert.assertEquals("Unexpected inflight requests.", 1, listener.getInflightRequests());
+
+        eventsSubject.onEvent(HttpClientMetricsEvent.RESPONSE_FAILED, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected inflight requests.", 0, listener.getInflightRequests());
+        Assert.assertEquals("Unexpected processed request.", 2, listener.getProcessedRequests());
+        Assert.assertEquals("Unexpected failed requests.", 1, listener.getFailedResponses());
+
+    }
+
+    private static void doRequestStart(MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject,
+                                       HttpServerListener listener) {
+        long reqReadTimes = listener.getRequestReadTimes().totalTime();
+        eventsSubject.onEvent(ServerMetricsEvent.NEW_CLIENT_CONNECTED);
+        eventsSubject.onEvent(HttpServerMetricsEvent.NEW_REQUEST_RECEIVED);
+        Assert.assertEquals("Unexpected request backlog.", 1, listener.getRequestBacklog());
+        eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HANDLING_START, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected inflight requests.", 1, listener.getInflightRequests());
+        Assert.assertEquals("Unexpected request backlog..", 0, listener.getRequestBacklog());
+        eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_RECEIVE_COMPLETE, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected inflight requests.", reqReadTimes + TimeUnit.MILLISECONDS.toNanos(1),
+                listener.getRequestReadTimes().totalTime());
+    }
+}

--- a/rxnetty-spectator/src/test/java/io/reactivex/netty/spectator/http/websocket/WebSocketMetricsTest.java
+++ b/rxnetty-spectator/src/test/java/io/reactivex/netty/spectator/http/websocket/WebSocketMetricsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.spectator.http.websocket;
+
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.channel.ConnectionHandler;
+import io.reactivex.netty.channel.ObservableConnection;
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.metrics.MetricEventsSubject;
+import io.reactivex.netty.protocol.http.websocket.WebSocketClient;
+import io.reactivex.netty.protocol.http.websocket.WebSocketClientBuilder;
+import io.reactivex.netty.protocol.http.websocket.WebSocketClientMetricsEvent;
+import io.reactivex.netty.protocol.http.websocket.WebSocketServer;
+import io.reactivex.netty.protocol.http.websocket.WebSocketServerMetricsEvent;
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
+import org.junit.Before;
+import org.junit.Test;
+import rx.Observable;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Tomasz Bak
+ */
+public class WebSocketMetricsTest {
+
+    private SpectatorEventsListenerFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new SpectatorEventsListenerFactory("websocket-metric-test-client", "websocket-metric-test-server");
+    }
+
+    @Test
+    public void testWebSocketServerMetrics() throws Exception {
+        WebSocketServer<WebSocketFrame, WebSocketFrame> server = RxNetty.newWebSocketServerBuilder(0, new ConnectionHandler<WebSocketFrame, WebSocketFrame>() {
+            @Override
+            public Observable<Void> handle(ObservableConnection<WebSocketFrame, WebSocketFrame> newConnection) {
+                return Observable.empty();
+            }
+        }).build();
+        MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject = server.getEventsSubject();
+
+        WebSocketServerListener listener = factory.forWebSocketServer(server);
+        server.subscribe(listener);
+
+        eventsSubject.onEvent(ServerMetricsEvent.NEW_CLIENT_CONNECTED);
+        assertEquals("Unexpected live connections.", 1, listener.getLiveConnections());
+
+        eventsSubject.onEvent(WebSocketServerMetricsEvent.HANDSHAKE_PROCESSED);
+        assertEquals("Expected one processed handshake", 1, listener.getProcessedHandshakes());
+
+        eventsSubject.onEvent(WebSocketServerMetricsEvent.HANDSHAKE_FAILURE);
+        assertEquals("Expected one failed handshake", 1, listener.getFailedHandshakes());
+        assertEquals("Expected two processed connections", 2, listener.getProcessedHandshakes());
+
+        eventsSubject.onEvent(WebSocketServerMetricsEvent.WEB_SOCKET_FRAME_WRITES);
+        assertEquals("Expected one written frame", 1, listener.getWebSocketWrites());
+
+        eventsSubject.onEvent(WebSocketServerMetricsEvent.WEB_SOCKET_FRAME_READS);
+        assertEquals("Expected one read frame", 1, listener.getWebSocketReads());
+    }
+
+    @Test
+    public void testWebSocketClientMetrics() throws Exception {
+        WebSocketClientBuilder<WebSocketFrame, WebSocketFrame> builder = RxNetty.newWebSocketClientBuilder("localhost", 0);
+        MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject = builder.getEventsSubject();
+        WebSocketClient<WebSocketFrame, WebSocketFrame> client = builder.build();
+        WebSocketClientListener listener = factory.forWebSocketClient(client);
+        client.subscribe(listener);
+
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_START);
+        assertEquals("Invalid pending connect count.", 1, listener.getPendingConnects());
+
+        eventsSubject.onEvent(WebSocketClientMetricsEvent.HANDSHAKE_START);
+        assertEquals("Expected one inflight handshake", 1, listener.getInflightHandshakes());
+        eventsSubject.onEvent(WebSocketClientMetricsEvent.HANDSHAKE_SUCCESS, 10, TimeUnit.MILLISECONDS);
+        assertEquals("Expected one processed handshake", 1, listener.getProcessedHandshakes());
+        assertEquals("Expected none inflight handshake", 0, listener.getInflightHandshakes());
+        assertEquals("Expected handshake processing time of 10ms", TimeUnit.MILLISECONDS.toNanos(10),
+                listener.getHandshakeProcessingTimes().totalTime());
+
+        eventsSubject.onEvent(WebSocketClientMetricsEvent.HANDSHAKE_START);
+        assertEquals("Expected one inflight handshake", 1, listener.getInflightHandshakes());
+        eventsSubject.onEvent(WebSocketClientMetricsEvent.HANDSHAKE_FAILURE, 10, TimeUnit.MILLISECONDS);
+        assertEquals("Expected one failed handshake", 1, listener.getFailedHandshakes());
+        assertEquals("Expected two processed connections", 2, listener.getProcessedHandshakes());
+        assertEquals("Expected none inflight handshake", 0, listener.getInflightHandshakes());
+        assertEquals("Expected handshake processing time of 10ms", TimeUnit.MILLISECONDS.toNanos(20),
+                listener.getHandshakeProcessingTimes().totalTime());
+
+        eventsSubject.onEvent(WebSocketClientMetricsEvent.WEB_SOCKET_FRAME_WRITES);
+        assertEquals("Expected one written frame", 1, listener.getWebSocketWrites());
+
+        eventsSubject.onEvent(WebSocketClientMetricsEvent.WEB_SOCKET_FRAME_READS);
+        assertEquals("Expected one read frame", 1, listener.getWebSocketReads());
+    }
+}

--- a/rxnetty-spectator/src/test/java/io/reactivex/netty/spectator/tcp/TcpMetricsTest.java
+++ b/rxnetty-spectator/src/test/java/io/reactivex/netty/spectator/tcp/TcpMetricsTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.spectator.tcp;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.channel.ConnectionHandler;
+import io.reactivex.netty.channel.ObservableConnection;
+import io.reactivex.netty.client.ClientBuilder;
+import io.reactivex.netty.client.ClientMetricsEvent;
+import io.reactivex.netty.client.RxClient;
+import io.reactivex.netty.metrics.MetricEventsSubject;
+import io.reactivex.netty.server.RxServer;
+import io.reactivex.netty.server.ServerMetricsEvent;
+import io.reactivex.netty.spectator.SpectatorEventsListenerFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import rx.Observable;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Nitesh Kant
+ */
+public class TcpMetricsTest {
+
+    private SpectatorEventsListenerFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new SpectatorEventsListenerFactory("tcp-metric-test-client", "tcp-metric-test-server");
+    }
+
+    @Test
+    public void testServerMetrics() throws Exception {
+        RxServer<ByteBuf, ByteBuf> server = RxNetty.createTcpServer(0, new ConnectionHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(ObservableConnection<ByteBuf, ByteBuf> newConnection) {
+                return Observable.empty();
+            }
+        });
+        MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject = server.getEventsSubject();
+
+        TcpServerListener<ServerMetricsEvent<ServerMetricsEvent.EventType>> listener = factory.forTcpServer(server);
+        server.subscribe(listener);
+
+        eventsSubject.onEvent(ServerMetricsEvent.NEW_CLIENT_CONNECTED);
+        Assert.assertEquals("Unexpected live connections.", 1, listener.getLiveConnections());
+
+        eventsSubject.onEvent(ServerMetricsEvent.CONNECTION_HANDLING_START);
+        Assert.assertEquals("Unexpected live connections.", 1, listener.getLiveConnections());
+        Assert.assertEquals("Unexpected inflight connections.", 1, listener.getInflightConnections());
+
+        eventsSubject.onEvent(ServerMetricsEvent.CONNECTION_HANDLING_SUCCESS , 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected live connections.", 1, listener.getLiveConnections());
+        Assert.assertEquals("Unexpected inflight connections.", 0, listener.getInflightConnections());
+
+        eventsSubject.onEvent(ServerMetricsEvent.CONNECTION_CLOSE_START);
+        Assert.assertEquals("Unexpected live connections.", 1, listener.getLiveConnections());
+        Assert.assertEquals("Unexpected inflight connections.", 0, listener.getInflightConnections());
+        eventsSubject.onEvent(ServerMetricsEvent.CONNECTION_CLOSE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Unexpected live connections.", 0, listener.getLiveConnections());
+        Assert.assertEquals("Unexpected inflight connections.", 0, listener.getInflightConnections());
+
+        eventsSubject.onEvent(ServerMetricsEvent.WRITE_START, (Object) 1000);
+        Assert.assertEquals("Invalid pending flush count.", 1, listener.getPendingWrites());
+        eventsSubject.onEvent(ServerMetricsEvent.WRITE_SUCCESS, 1, TimeUnit.MILLISECONDS, 1000);
+        Assert.assertEquals("Invalid write time metric.", TimeUnit.MILLISECONDS.toNanos(1), listener.getWriteTimes().totalTime());
+        Assert.assertEquals("Invalid bytes written metric.", 1000, listener.getBytesWritten());
+
+        eventsSubject.onEvent(ServerMetricsEvent.FLUSH_START, (Object) 1000);
+        Assert.assertEquals("Invalid pending flush count.", 1, listener.getPendingFlushes());
+        eventsSubject.onEvent(ServerMetricsEvent.FLUSH_SUCCESS, 1, TimeUnit.MILLISECONDS, 1000);
+        Assert.assertEquals("Invalid flush metric.", TimeUnit.MILLISECONDS.toNanos(1), listener.getFlushTimes().totalTime());
+
+        eventsSubject.onEvent(ServerMetricsEvent.FLUSH_START, (Object) 1000);
+        Assert.assertEquals("Invalid pending flush count.", 1, listener.getPendingFlushes());
+        eventsSubject.onEvent(ServerMetricsEvent.FLUSH_FAILED, 1, TimeUnit.MILLISECONDS, 1000);
+        Assert.assertEquals("Invalid pending flush count.", 1, listener.getFailedFlushes());
+        Assert.assertEquals("Invalid flush metric.", TimeUnit.MILLISECONDS.toNanos(1), listener.getFlushTimes().totalTime());
+
+        eventsSubject.onEvent(ServerMetricsEvent.BYTES_READ, (Object) 1000);
+        Assert.assertEquals("Invalid bytes read.", 1000, listener.getBytesRead());
+
+    }
+
+    @Test
+    public void testClientMetrics() throws Exception {
+        ClientBuilder<Object, Object> builder = RxNetty.newTcpClientBuilder("localhost", 9999);
+        MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject = builder.getEventsSubject();
+
+        RxClient<Object, Object> client = builder.build();
+        TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener = factory.forTcpClient(client);
+        client.subscribe(listener);
+
+        doConnectSuccess(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect success.", 1, listener.getConnectionCount());
+
+        doConnectCloseSuccess(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after  connection close.", 1, listener.getConnectionCount());
+
+        doConnectFailed(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect failure.", 1, listener.getConnectionCount());
+
+        doConnectSuccess(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect success.", 2, listener.getConnectionCount());
+
+        doConnCloseFailed(eventsSubject, listener);
+
+        doPoolAcquireSuccess(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect success.", 3, listener.getConnectionCount());
+        Assert.assertEquals("Invalid pool acquire count.", 1, listener.getPoolAcquires());
+
+        doPoolReuse(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect reuse.", 3, listener.getConnectionCount());
+        Assert.assertEquals("Invalid pool acquire count.", 2, listener.getPoolAcquires());
+
+        doEviction(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after eviction.", 3, listener.getConnectionCount());
+
+        doPoolAcquireSuccess(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect success.", 4, listener.getConnectionCount());
+        Assert.assertEquals("Invalid pool acquire count.", 3, listener.getPoolAcquires());
+
+        doPoolReleaseSuccess(eventsSubject, listener);
+        Assert.assertEquals("Invalid total connections count after connect success.", 4, listener.getConnectionCount());
+
+        doWrite(eventsSubject, listener);
+
+        doFlush(eventsSubject, listener);
+
+        doRead(eventsSubject, listener);
+    }
+
+    private static void doRead(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                               TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        eventsSubject.onEvent(ClientMetricsEvent.BYTES_READ, (Object) 1000);
+        Assert.assertEquals("Invalid bytes read metric.", 1000, listener.getBytesRead());
+    }
+
+    private static void doFlush(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        long flushTimes = listener.getFlushTimes().totalTime();
+        eventsSubject.onEvent(ClientMetricsEvent.FLUSH_START, (Object) 1000);
+        Assert.assertEquals("Invalid pending flush count.", 1, listener.getPendingFlushes());
+        eventsSubject.onEvent(ClientMetricsEvent.FLUSH_SUCCESS, 1, TimeUnit.MILLISECONDS, 1000);
+
+        Assert.assertEquals("Invalid flush metric.", flushTimes + TimeUnit.MILLISECONDS.toNanos(1),
+                listener.getFlushTimes().totalTime());
+        Assert.assertEquals("Invalid bytes written metric.", 1000, listener.getBytesWritten());
+    }
+
+    private static void doWrite(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        long writeTimes = listener.getWriteTimes().totalTime();
+        eventsSubject.onEvent(ClientMetricsEvent.WRITE_START, (Object) 1000);
+        Assert.assertEquals("Invalid pending flush count.", 1, listener.getPendingWrites());
+        eventsSubject.onEvent(ClientMetricsEvent.WRITE_SUCCESS, 1, TimeUnit.MILLISECONDS, 1000);
+
+        Assert.assertEquals("Invalid write time metric.", writeTimes + TimeUnit.MILLISECONDS.toNanos(1),
+                listener.getWriteTimes().totalTime());
+        Assert.assertEquals("Invalid bytes written metric.", 1000, listener.getBytesWritten());
+    }
+
+    private static void doPoolReleaseSuccess(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                             TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        eventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_START);
+        eventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid live connect count.", 1, listener.getLiveConnections());
+        Assert.assertEquals("Invalid pending connect count.", 0, listener.getPendingConnects());
+        Assert.assertEquals("Invalid pool acquire count.", 1, listener.getPoolReleases());
+    }
+
+    private static void doConnectFailed(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                        TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        long connectionTimes = listener.getConnectionTimes().totalTime();
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_START);
+        Assert.assertEquals("Invalid pending connect count.", 1, listener.getPendingConnects());
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_FAILED, 1, TimeUnit.MILLISECONDS, new IllegalStateException());
+        Assert.assertEquals("Invalid pending connect count after connect failure.", 0, listener.getPendingConnects());
+        Assert.assertEquals("Invalid live connect count after connect failure.", 0, listener.getLiveConnections());
+        Assert.assertEquals("Invalid failed connect count after connect failure.", 1, listener.getFailedConnects());
+        Assert.assertEquals("Invalid connect time after failed connect.",
+                connectionTimes, listener.getConnectionTimes().totalTime());
+    }
+
+    private static void doConnectCloseSuccess(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                              TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECTION_CLOSE_START);
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECTION_CLOSE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid live connect count after connection close.", 0, listener.getLiveConnections());
+        Assert.assertEquals("Invalid pending connect count after connection close.", 0, listener.getPendingConnects());
+    }
+
+    private static void doConnectSuccess(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                         TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        long totalTime = listener.getConnectionTimes().totalTime();
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_START);
+        Assert.assertEquals("Invalid pending connect count.", 1, listener.getPendingConnects());
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending connect count after connect success.", 0, listener.getPendingConnects());
+        Assert.assertEquals("Invalid live connect count after connect success.", 1, listener.getLiveConnections());
+        Assert.assertEquals("Invalid connect time.", totalTime + TimeUnit.MILLISECONDS.toNanos(1),
+                listener.getConnectionTimes().totalTime());
+    }
+
+    private static void doConnCloseFailed(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                          TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECTION_CLOSE_START);
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECTION_CLOSE_FAILED, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending connect count after connection close.", 0, listener.getPendingConnects());
+        Assert.assertEquals("Invalid live connect count after connection close.", 0, listener.getLiveConnections());
+        Assert.assertEquals("Invalid live connect count after connection close.", 1, listener.getFailedConnectionClose());
+    }
+
+    private static void doEviction(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                   TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        eventsSubject.onEvent(ClientMetricsEvent.POOLED_CONNECTION_EVICTION);
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECTION_CLOSE_START); // Eviction does not mean a connection close, this event is explicit.
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECTION_CLOSE_SUCCESS);
+        Assert.assertEquals("Invalid live connect count after eviction.", 0, listener.getLiveConnections());
+        Assert.assertEquals("Invalid pool eviction count after eviction.", 1, listener.getPoolEvictions());
+    }
+
+    private static void doPoolReuse(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                    TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        eventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_START);
+        Assert.assertEquals("Invalid pending pool acquire count.", 1, listener.getPendingPoolAcquires());
+        eventsSubject.onEvent(ClientMetricsEvent.POOLED_CONNECTION_REUSE, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending connect count after connection reuse.", 0, listener.getPendingConnects());
+        Assert.assertEquals("Invalid live connect count after connect reuse.", 1, listener.getLiveConnections());
+        Assert.assertEquals("Invalid pool reuse count after connect reuse.", 1, listener.getPoolReuse());
+        eventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending pool acquire count.", 0, listener.getPendingPoolAcquires());
+    }
+
+    private static void doPoolAcquireSuccess(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+                                             TcpClientListener<ClientMetricsEvent<ClientMetricsEvent.EventType>> listener) {
+        long poolTime = listener.getPoolAcquireTimes().totalTime();
+        eventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_START);
+        Assert.assertEquals("Invalid pending pool acquire count.", 1, listener.getPendingPoolAcquires());
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_START);
+        eventsSubject.onEvent(ClientMetricsEvent.CONNECT_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending connect count after connection success.", 0, listener.getPendingConnects());
+        Assert.assertEquals("Invalid live connect count after connect success.", 1, listener.getLiveConnections());
+
+        eventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_SUCCESS, 1, TimeUnit.MILLISECONDS);
+        Assert.assertEquals("Invalid pending connect count after connection success.", 0,
+                listener.getPendingPoolAcquires());
+        Assert.assertEquals("Invalid pool acquire times after connection success.",
+                poolTime + TimeUnit.MILLISECONDS.toNanos(1), listener.getPoolAcquireTimes().totalTime());
+    }
+}

--- a/rxnetty/src/main/java/io/reactivex/netty/metrics/AbstractMetricsEvent.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/metrics/AbstractMetricsEvent.java
@@ -57,17 +57,8 @@ public abstract class AbstractMetricsEvent<T extends Enum> implements MetricsEve
 
         AbstractMetricsEvent that = (AbstractMetricsEvent) o;
 
-        if (isError != that.isError) {
-            return false;
-        }
-        if (isTimed != that.isTimed) {
-            return false;
-        }
-        if (name != that.name) {
-            return false;
-        }
+        return isError == that.isError && isTimed == that.isTimed && name == that.name;
 
-        return true;
     }
 
     @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 rootProject.name='RxNetty'
-include 'rxnetty', 'rxnetty-remote-observable', 'rxnetty-contexts', 'rxnetty-examples', 'rxnetty-servo'
+include 'rxnetty', 'rxnetty-remote-observable', 'rxnetty-contexts', 'rxnetty-examples', 'rxnetty-servo', 'rxnetty-spectator'
 


### PR DESCRIPTION
Adds a plugin to generate [spectator](https://github.com/Netflix/spectator) metrics. Spectator has the benefit of being able to bind to [servo](https://github.com/Netflix/servo) or other metrics libraries such as [metrics](https://github.com/dropwizard/metrics).
