### PR TITLE
Properly handling max header/initline/content breach.

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/ServerRequestResponseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,24 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders.Names;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
 import io.reactivex.netty.metrics.Clock;
 import io.reactivex.netty.metrics.MetricEventsSubject;
 import io.reactivex.netty.protocol.http.UnicastContentSubject;
 import io.reactivex.netty.server.ServerMetricsEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +69,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class ServerRequestResponseConverter extends ChannelDuplexHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(ServerRequestResponseConverter.class);
+
     public static final IOException CONN_CLOSE_BEFORE_REQUEST_COMPLETE = new IOException("Connection closed by peer before sending the entire request.");
 
     private final MetricEventsSubject<ServerMetricsEvent<?>> eventsSubject;
@@ -83,11 +92,35 @@ public class ServerRequestResponseConverter extends ChannelDuplexHandler {
         boolean isHttpRequest = false;
 
         if (HttpRequest.class.isAssignableFrom(recievedMsgClass)) {
-            eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HEADERS_RECEIVED);
-            stateToUse.createRxRequest(ctx, (HttpRequest) msg); // Update the state to use.
-            stateToUse.onProcessingStart(Clock.newStartTimeMillis());
-            super.channelRead(ctx, stateToUse.rxRequest);
             isHttpRequest = true;
+            HttpRequest httpRequest = (HttpRequest) msg;
+            DecoderResult decoderResult = httpRequest.getDecoderResult();
+            if (decoderResult.isSuccess()) {
+                eventsSubject.onEvent(HttpServerMetricsEvent.REQUEST_HEADERS_RECEIVED);
+                stateToUse.createRxRequest(ctx, (HttpRequest) msg); // Update the state to use.
+                stateToUse.onProcessingStart(Clock.newStartTimeMillis());
+                super.channelRead(ctx, stateToUse.rxRequest);
+            } else {
+                logger.error("Invalid HTTP request recieved. Decoder error.", decoderResult.cause());
+                // As per the spec, we should send 414/431 for URI too long and headers too long, but we do not have
+                // enough info to decide which kind of failure has caused this error here.
+                DefaultFullHttpResponse errResponse = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(),
+                                                                                  HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE);
+                // Netty rejects all data after decode failure. So, closing connection here.
+                // Issue: https://github.com/netty/netty/issues/3362
+                errResponse.headers()
+                           .set(Names.CONNECTION, HttpHeaders.Values.CLOSE)
+                           .set(Names.CONTENT_LENGTH, 0);
+                ctx.writeAndFlush(errResponse).addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        if (!future.isSuccess()) {
+                            logger.error("Failed to write response for invalid HTTP request.", future.cause());
+                        }
+                    }
+                });
+                return;
+            }
         }
 
         if (HttpContent.class.isAssignableFrom(recievedMsgClass)) {// This will be executed if the incoming message is a FullHttpRequest or only HttpContent.

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/RequestProcessor.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/RequestProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import rx.Observable;
 import rx.functions.Func1;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +45,12 @@ public class RequestProcessor implements RequestHandler<ByteBuf, ByteBuf> {
 
     public static final long KEEP_ALIVE_TIMEOUT_SECONDS = 1;
 
+    public static final String ONE_KB_VALUE;
+
     static {
+        final byte[] onekb = new byte[1024];
+        Arrays.fill(onekb, (byte) 'c');
+        ONE_KB_VALUE = new String(onekb);
 
         List<String> smallStreamListLocal = new ArrayList<String>();
         for (int i = 0; i < 3; i++) {
@@ -60,6 +66,11 @@ public class RequestProcessor implements RequestHandler<ByteBuf, ByteBuf> {
     }
 
     public static final String SINGLE_ENTITY_BODY = "Hello world";
+
+    public Observable<Void> handleLargeHeaders(HttpServerResponse<ByteBuf> response) {
+        response.getHeaders().add("LargeHeader", ONE_KB_VALUE);
+        return response.writeBytesAndFlush(SINGLE_ENTITY_BODY.getBytes());
+    }
 
     public Observable<Void> handleSingleEntity(HttpServerResponse<ByteBuf> response) {
         byte[] responseBytes = SINGLE_ENTITY_BODY.getBytes();


### PR DESCRIPTION
Netty's `HttpRequestDecoder` and `HttpResponseDecoder` return an incomplete `HttpRequest`/`HttpResponse`
 (Issue: https://github.com/netty/netty/issues/3362) whenever the request/response has a larger HTTP initial line, larger HTTP headers or content than configured.
This means that HttpClientResponse/HttpServerResponse content stream will never complete (in absence of `LastHttpContent`)

The following fix is done:
#### Client

When such an error occurs in decoding, the error is propagated to the subscriber of the response. The connection is closed.
#### Server

When such an error occurs, the request is not sent to the `RequestHandler` and instead an error response is sent with the response code of 431. The connection is also set to close.
