### PR TITLE
HttpServerRequest.getPath should only return path

### DIFF
--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerRequestUriTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerRequestUriTest.java
@@ -84,6 +84,16 @@ public class HttpServerRequestUriTest {
         Assert.assertEquals("Unexpected query string", "", request.getQueryString());
     }
 
+    @Test
+    public void testAbsolute() throws Exception {
+        String uri = "http://localhost:54321/a/b|c?foo=bar|baz";
+        DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
+        HttpServerRequest<ByteBuf> request = newServerRequest(nettyRequest);
+        Assert.assertEquals("Unexpected uri string", uri, request.getUri());
+        Assert.assertEquals("Unexpected query string", "foo=bar|baz", request.getQueryString());
+        Assert.assertEquals("Unexpected path string", "/a/b|c", request.getPath());
+    }
+
     protected HttpServerRequest<ByteBuf> newServerRequest(DefaultHttpRequest nettyRequest) {
         Channel noOpChannel = new NoOpChannelHandlerContext().channel();
         return new HttpServerRequest<ByteBuf>(noOpChannel, nettyRequest,

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/UriInfoHolderTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/UriInfoHolderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.netty.protocol.http.server;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UriInfoHolderTest {
+
+    @Test
+    public void relativeUri() throws Exception {
+        UriInfoHolder holder = new UriInfoHolder("/foo/%20bar");
+        Assert.assertEquals("/foo/%20bar", holder.getRawUriString());
+        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("", holder.getQueryString());
+    }
+
+    @Test
+    public void relativeUriWithQuery() throws Exception {
+        UriInfoHolder holder = new UriInfoHolder("/foo/%20bar?foo=bar%3D");
+        Assert.assertEquals("/foo/%20bar?foo=bar%3D", holder.getRawUriString());
+        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("foo=bar%3D", holder.getQueryString());
+    }
+
+    // This test will fail with a strict URI parser
+    @Test
+    public void relativeUriWithQueryUnescaped() throws Exception {
+        UriInfoHolder holder = new UriInfoHolder("/foo/%20bar?foo=bar|||");
+        Assert.assertEquals("/foo/%20bar?foo=bar|||", holder.getRawUriString());
+        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("foo=bar|||", holder.getQueryString());
+    }
+
+    @Test
+    public void relativeUriNoStartingSlash() throws Exception {
+        UriInfoHolder holder = new UriInfoHolder("foo/bar");
+        Assert.assertEquals("foo/bar", holder.getRawUriString());
+        Assert.assertEquals("foo/bar", holder.getPath());
+        Assert.assertEquals("", holder.getQueryString());
+    }
+
+    @Test
+    public void absoluteUri() throws Exception {
+        UriInfoHolder holder = new UriInfoHolder("http://www.foo.com/foo/%20bar");
+        Assert.assertEquals("http://www.foo.com/foo/%20bar", holder.getRawUriString());
+        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("", holder.getQueryString());
+    }
+
+    @Test
+    public void absoluteUriWithQuery() throws Exception {
+        UriInfoHolder holder = new UriInfoHolder("http://www.foo.com/foo/%20bar?foo=bar%3D");
+        Assert.assertEquals("http://www.foo.com/foo/%20bar?foo=bar%3D", holder.getRawUriString());
+        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("foo=bar%3D", holder.getQueryString());
+    }
+
+}


### PR DESCRIPTION
If an absolute URI is passed in the request line, e.g.:

```
GET http://localhost:8090/hello HTTP/1.1
```

Then the HttpServerRequest.getPath method was returning
the full URI up to the query portion. If the user wanted
the full URI they can call HttpServerRequest.getUri. It
seems confusing to have getPath return the scheme and
host.

This change updates the UriInfoHolder used by
HttpServerRequest to have getPath only return the path.
Note, it does not use java.net.URI to do the parsing because
it is strict and fails for many URIs that are common in
practice, e.g. the URIs with `|` in the query.
