### PR TITLE
Removing client name uniqueness.

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/client/AbstractClientBuilder.java
@@ -297,7 +297,7 @@ public abstract class AbstractClientBuilder<I, O, B extends AbstractClientBuilde
             return name;
         }
 
-        name = generatedNamePrefix() + clientUniqueNameCounter.incrementAndGet();
+        name = generatedNamePrefix() + "-no-name";
         return name;
     }
 


### PR DESCRIPTION
The client name is just used for reporting metrics and having a unique name bloats metrics (number of metrics reported).
This change removes the uniqueness and has a common suffix "-no-name-" for all clients with no name explicitly specified.
If a unique name is required, it can be set explicitly on the client.
