### PR TITLE
UnicastContentSubject unsubscribes eagerly

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/UnicastContentSubject.java
@@ -156,11 +156,7 @@ public final class UnicastContentSubject<T> extends Subject<T, T> {
 
         private final Action0 onUnsubscribe;
 
-        public State() {
-            this(null);
-        }
-
-        public State(Action0 onUnsubscribe) {
+        private State(Action0 onUnsubscribe) {
             this.onUnsubscribe = onUnsubscribe;
             final BufferUntilSubscriber<T> bufferedSubject = BufferUntilSubscriber.create();
             bufferedObservable = bufferedSubject.lift(new AutoReleaseByteBufOperator<T>()); // Always auto-release
@@ -223,7 +219,7 @@ public final class UnicastContentSubject<T> extends Subject<T, T> {
                     }
                 }));
 
-                state.bufferedObservable.subscribe(subscriber);
+                state.bufferedObservable.unsafeSubscribe(subscriber);
 
             } else if(State.STATES.SUBSCRIBED.ordinal() == state.state) {
                 subscriber.onError(new IllegalStateException("Content can only have one subscription. Use Observable.publish() if you want to multicast."));


### PR DESCRIPTION
`UnicastContentSubject` delegates buffering to a `BufferUntilSubscriber` subject. However, it subscribes the downstream subscriber to this subject using `Observable.unsubscribe()`. This causes a `SafeSubscriber` subscribing to the buffer subject which unsubscribes on termination of the upstream source.

The following code reproduces the issue:

``` java
        UnicastContentSubject<Long> subject = UnicastContentSubject.createWithoutNoSubscriptionTimeout();

        subject.onNext(1l);
        subject.onCompleted();

        subject.flatMap(aLong -> Observable.never()
                                           .doOnUnsubscribe(() -> System.out.println("unsubscribed")))
               .toBlocking().toFuture().get();
```

In the above code the flatmap returns `Observable.never()` which should not get unsubscribed, unless the eventual subscriber unsubscribes.

Using `unsafeSubscribe()` to subscribe to the `BufferUntilSubscriber` will not eagerly unsubscribe.
