### PR TITLE
Errors in the pipeline post response header delivery were lost.

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
@@ -236,6 +236,12 @@ public class ClientRequestResponseConverter extends ChannelDuplexHandler {
         super.channelInactive(ctx);
     }
 
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        responseState.sendOnError(cause);
+        super.exceptionCaught(ctx, cause);
+    }
+
     @SuppressWarnings("unchecked")
     private static void invokeContentOnNext(Object nextObject, ResponseState stateToUse) {
         try {


### PR DESCRIPTION
HttpClient response processing unsubscribes from the TCP connection input subject after the HTTP response headers are delivered. The errors in the pipeline were only trapped by the `ObservableAdapter` and forwarded to the subscriber of the input subject. In this case, since, the input subject is unsubscribed, the error does not get propagated to the subscriber of the `HttpClient.submit()`.

This change makes `ClientRequestResponseConverter` intercept errors in the pipeline and propagate it to the subscriber of the response content.
