### PR TITLE
configure maxChunkSize

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/pipeline/PipelineConfigurators.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/pipeline/PipelineConfigurators.java
@@ -82,7 +82,12 @@ public final class PipelineConfigurators {
 
     public static <I, O> PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> httpClientConfigurator() {
         return new PipelineConfiguratorComposite<HttpClientResponse<O>, HttpClientRequest<I>>(new HttpClientPipelineConfigurator<I, O>(),
-                                                                                  new HttpObjectAggregationConfigurator());
+                new HttpObjectAggregationConfigurator());
+    }
+
+    public static <I, O> PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> httpClientConfigurator(int maxChunkSize) {
+        return new PipelineConfiguratorComposite<HttpClientResponse<O>, HttpClientRequest<I>>(new HttpClientPipelineConfigurator<I, O>(),
+                new HttpObjectAggregationConfigurator(maxChunkSize));
     }
 
     public static <I> PipelineConfigurator<HttpClientResponse<ServerSentEvent>, HttpClientRequest<I>> clientSseConfigurator() {


### PR DESCRIPTION
http://stackoverflow.com/questions/16879104/netty-4-0-0-cr3-lengthfieldbasedframedecoder-maxframelength-exceeds-integer-ma

HttpObjectAggregationConfigurator.DEFAULT_CHUNK_SIZE = 1048576;

configure maxChunkSize
