### PR TITLE
Fixes #348 

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/metrics/BytesInspector.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/metrics/BytesInspector.java
@@ -79,6 +79,9 @@ public class BytesInspector extends ChannelDuplexHandler {
 
     @SuppressWarnings("unchecked")
     protected void publishBytesWritten(final long bytesToWrite, ChannelPromise promise) {
+        if (bytesToWrite <= 0) {
+            return;
+        }
         final long startTimeMillis = Clock.newStartTimeMillis();
         eventsSubject.onEvent(metricEventProvider.getWriteStartEvent(), (Object) bytesToWrite);
         promise.addListener(new ChannelFutureListener() {


### PR DESCRIPTION
`BytesInspector` was not checking if the bytes to be written are 0. In some cases, the associated promise is a `VoidPromise` and does not allow listeners, hence throwing errors on `promise.addListener`

Now, checking if there are any bytes available to be written.
