### PR TITLE
Fixes #344 #352 #354 #355

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-netty_version=4.0.25.Final
+netty_version=4.0.27.Final
 slf4j_version=1.7.6

--- a/rxnetty/build.gradle
+++ b/rxnetty/build.gradle
@@ -2,4 +2,6 @@ dependencies {
     compile "io.netty:netty-codec-http:${netty_version}"
     compile "io.netty:netty-transport-native-epoll:${netty_version}"
     compile "org.slf4j:slf4j-api:${slf4j_version}"
+
+    testCompile 'com.jcraft:jzlib:1.1.3'
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/RxNetty.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/RxNetty.java
@@ -271,25 +271,21 @@ public final class RxNetty {
      *
      * <h2>Http Server</h2>
      <pre>
-     * {@code
        RxNetty.newHttpServerBuilder(8888, new RequestHandler<Object, Object>() {
-            @Override
+
             public Observable<Void> handle(HttpServerRequest<Object> request, HttpServerResponse<Object> response) {
             return null;
             }
        }).channel(EpollServerSocketChannel.class)
          .eventLoop(new EpollEventLoopGroup());
-      }
      </pre>
      *
      * <h2>Http Client</h2>
      *
      <pre>
-     {@code
      RxNetty.newHttpClientBuilder("localhost", 8888)
             .channel(EpollSocketChannel.class)
             .eventloop(new EpollEventLoopGroup());
-     }
      </pre>
      */
     public static void useNativeTransportIfApplicable() {

--- a/rxnetty/src/main/java/io/reactivex/netty/client/CompositePoolLimitDeterminationStrategy.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/client/CompositePoolLimitDeterminationStrategy.java
@@ -42,11 +42,12 @@ public class CompositePoolLimitDeterminationStrategy implements PoolLimitDetermi
         for (int i = 0; i < strategies.length; i++) {
             PoolLimitDeterminationStrategy strategy = strategies[i];
             if (!strategy.acquireCreationPermit(acquireStartTime, timeUnit)) {
+                PoolExhaustedException throwable = new PoolExhaustedException();
                 if (i > 0) {
                     long now = timeUnit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
                     for (int j = i - 1; j >= 0; j--) {
                         strategies[j].onEvent(ClientMetricsEvent.CONNECT_FAILED, now - acquireStartTime,
-                                              timeUnit, ConnectionPoolImpl.POOL_EXHAUSTED_EXCEPTION,
+                                              timeUnit, throwable,
                                               null); // release all permits acquired before this failure.
                     }
                 }

--- a/rxnetty/src/main/java/io/reactivex/netty/client/ConnectionPoolImpl.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/client/ConnectionPoolImpl.java
@@ -42,6 +42,8 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
 
     private static final Logger logger = LoggerFactory.getLogger(ConnectionPoolImpl.class);
 
+    @Deprecated
+    @SuppressWarnings("unused")
     public static final PoolExhaustedException POOL_EXHAUSTED_EXCEPTION = new PoolExhaustedException("Rx Connection Pool exhausted.");
 
     private final ConcurrentLinkedQueue<PooledConnection<I, O>> idleConnections;
@@ -142,9 +144,10 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
                             newConnectionSubscriber.onError(throwable);
                         }
                     } else { // Pool Exhausted
+                        PoolExhaustedException e = new PoolExhaustedException();
                         metricEventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_FAILED,
-                                                    Clock.onEndMillis(startTimeMillis), POOL_EXHAUSTED_EXCEPTION);
-                        subscriber.onError(POOL_EXHAUSTED_EXCEPTION);
+                                                    Clock.onEndMillis(startTimeMillis), e);
+                        subscriber.onError(e);
                     }
                 } catch (Throwable throwable) {
                     metricEventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_FAILED,

--- a/rxnetty/src/main/java/io/reactivex/netty/pipeline/InternalReadTimeoutHandler.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/pipeline/InternalReadTimeoutHandler.java
@@ -1,0 +1,214 @@
+package io.reactivex.netty.pipeline;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A copy of netty's {@link ReadTimeoutHandler}. This is required because {@link ReadTimeoutHandler} does not allow
+ * reuse in the same pipeline, which is required for connection pooling.
+ * See issue https://github.com/ReactiveX/RxNetty/issues/344
+ */
+class InternalReadTimeoutHandler extends ChannelDuplexHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(InternalReadTimeoutHandler.class);
+
+
+    private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private final long timeoutNanos;
+
+    private volatile ScheduledFuture<?> timeout;
+    private volatile long lastReadTime;
+
+    private enum State {
+        Created,
+        Active,
+        Paused,
+        Destroyed
+    }
+
+    private volatile State state = State.Created;
+
+    private boolean closed;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param timeout
+     *        read timeout
+     * @param unit
+     *        the {@link TimeUnit} of {@code timeout}
+     */
+    public InternalReadTimeoutHandler(long timeout, TimeUnit unit) {
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+
+        if (timeout <= 0) {
+            timeoutNanos = 0;
+        } else {
+            timeoutNanos = Math.max(unit.toNanos(timeout), MIN_TIMEOUT_NANOS);
+        }
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        if (ctx.channel().isActive() && ctx.channel().isRegistered()) {
+            // channelActive() event has been fired already, which means this.channelActive() will
+            // not be invoked. We have to scheduleAfresh here instead.
+            scheduleAfresh(ctx);
+        } else {
+            // channelActive() event has not been fired yet.  this.channelActive() will be invoked
+            // and initialization will occur there.
+        }
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        // Initialize early if channel is active already.
+        if (ctx.channel().isActive()) {
+            scheduleAfresh(ctx);
+        }
+        super.channelRegistered(ctx);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        // This method will be invoked only if this handler was added
+        // before channelActive() event is fired.  If a user adds this handler
+        // after the channelActive() event, scheduleAfresh() will be called by beforeAdd().
+        scheduleAfresh(ctx);
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        lastReadTime = System.nanoTime();
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (State.Paused == state) {
+            // Add the timeout handler when write is complete.
+            promise.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    if (State.Paused == state) {
+                        /*
+                         * Multiple writes can all add a listener, till it is active again (on write success), so it is
+                         * required to only schedule next when the state is actually paused.
+                         */
+                        scheduleAfresh(ctx);
+                    }
+                }
+            });
+        }
+
+        super.write(ctx, msg, promise);
+    }
+
+    void cancelTimeoutSchedule(ChannelHandlerContext ctx) {
+        assert ctx.channel().eventLoop().inEventLoop(); /*should only be called from the owner eventloop*/
+        if (State.Active == state) {
+            state = State.Paused;
+            timeout.cancel(false);
+        }
+    }
+
+    private void scheduleAfresh(ChannelHandlerContext ctx) {
+        // Avoid the case where destroy() is called before scheduling timeouts.
+        // See: https://github.com/netty/netty/issues/143
+        switch (state) {
+        case Created:
+            break;
+        case Active:
+            logger.warn("Not scheduling next read timeout task as it is already active.");
+            return;
+        case Paused:
+            break;
+        case Destroyed:
+            logger.warn("Not scheduling next read timeout task as the channel handler is removed.");
+            return;
+        }
+
+        state = State.Active;
+
+        lastReadTime = System.nanoTime();
+        if (timeoutNanos > 0) {
+            timeout = ctx.executor().schedule(new ReadTimeoutTask(ctx), timeoutNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private void destroy() {
+        state = State.Destroyed;
+
+        if (timeout != null) {
+            timeout.cancel(false);
+            timeout = null;
+        }
+    }
+
+    /**
+     * Is called when a read timeout was detected.
+     */
+    protected void readTimedOut(ChannelHandlerContext ctx) throws Exception {
+        if (!closed) {
+            ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+            ctx.close();
+            closed = true;
+        }
+    }
+
+    private final class ReadTimeoutTask implements Runnable {
+
+        private final ChannelHandlerContext ctx;
+
+        ReadTimeoutTask(ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void run() {
+            if (!ctx.channel().isOpen()) {
+                return;
+            }
+
+            long currentTime = System.nanoTime();
+            long nextDelay = timeoutNanos - (currentTime - lastReadTime);
+            if (nextDelay <= 0) {
+                // Read timed out - set a new timeout and notify the callback.
+                timeout = ctx.executor().schedule(this, timeoutNanos, TimeUnit.NANOSECONDS);
+                try {
+                    readTimedOut(ctx);
+                } catch (Throwable t) {
+                    ctx.fireExceptionCaught(t);
+                }
+            } else {
+                // Read occurred before the timeout - set a new timeout with shorter delay.
+                timeout = ctx.executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
+            }
+        }
+    }
+}

--- a/rxnetty/src/test/java/io/reactivex/netty/client/AcceptEncodingGZipTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/client/AcceptEncodingGZipTest.java
@@ -1,0 +1,177 @@
+package io.reactivex.netty.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import io.netty.handler.codec.http.HttpMethod;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.pipeline.PipelineConfigurator;
+import io.reactivex.netty.pipeline.PipelineConfiguratorComposite;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientBuilder;
+import io.reactivex.netty.protocol.http.client.HttpClientPipelineConfigurator;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.server.HttpServerPipelineConfigurator;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ * This unit test fires up a client and server and then tests that the client can request gzip content from the server.
+ * @author Tom Haggie
+ */
+public class AcceptEncodingGZipTest {
+
+    private static final String MESSAGE = "Hello world!";
+
+    private int port;
+    private HttpServer<ByteBuf, ByteBuf> server;
+    private HttpClient<ByteBuf, ByteBuf> client;
+
+    @Before
+    public void setupServer() {
+        server = createServer();
+        server.start();
+        port = server.getServerPort();
+        client = createClient("localhost", port);
+    }
+
+    @After
+    public void stopServer() throws InterruptedException {
+        server.shutdown();
+        client.shutdown();
+    }
+
+    /**
+     * Just here to show that things work without the compression
+     */
+    @Test
+    public void getUnzippedContent() {
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.create(HttpMethod.GET, "/test");
+        testRequest(client, request);
+    }
+
+    /**
+     * The actual test - fails with a IllegalReferenceCountException
+     */
+    @Test
+    public void getZippedContent() {
+        HttpClientRequest<ByteBuf> request = HttpClientRequest.create(HttpMethod.GET, "/test");
+        request.withHeader("Accept-Encoding", "gzip, deflate");
+        testRequest(client, request);
+    }
+
+    /**
+     * Test a request by sending it to the server and then asserting the answer we get back is correct.
+     */
+    private static void testRequest(HttpClient<ByteBuf, ByteBuf> client, HttpClientRequest<ByteBuf> request) {
+        String message = client.submit(request)
+                               .flatMap(getContent)
+                               .map(toString)
+                               .toBlocking()
+                               .single();
+        Assert.assertEquals(MESSAGE, message);
+    }
+
+    /**
+     * Ignore the headers etc. just get the response content.
+     */
+    private static final Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>> getContent = new Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>>() {
+        @Override
+        public Observable<ByteBuf> call(HttpClientResponse<ByteBuf> response) {
+            return response.getContent();
+        }
+    };
+
+    /**
+     * Converts a ByteBuf to a string - assumes UTF-8
+     */
+    private static final Func1<ByteBuf, String> toString = new Func1<ByteBuf, String>() {
+        @Override
+        public String call(ByteBuf byteBuf) {
+            return byteBuf.toString(StandardCharsets.UTF_8);
+        }
+    };
+
+    /**
+     * Create a dumb server that just responds to any request with the same "Hello World!" response.
+     * If there's an "Accept-Encoding" header with gzip the response will be zipped before its returned.
+     */
+    private static HttpServer<ByteBuf, ByteBuf> createServer() {
+        return RxNetty.newHttpServerBuilder(0, new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, final HttpServerResponse<ByteBuf> response) {
+                String acceptEncoding = request.getHeaders().get("Accept-Encoding");
+                if (acceptEncoding != null && acceptEncoding.contains("gzip")) {
+                    response.getHeaders().add("Content-Encoding", "gzip");
+                    byte[] zMessage = zipMessage(MESSAGE);
+                    return response.writeBytesAndFlush(zMessage);
+                } else {
+                    return response.writeStringAndFlush(MESSAGE);
+                }
+            }
+        }).pipelineConfigurator(new HttpServerPipelineConfigurator<ByteBuf, ByteBuf>()).build();
+    }
+
+    /**
+     * Create a simple client with the a content decompressor
+     */
+    private static HttpClient<ByteBuf, ByteBuf> createClient(String host, int port) {
+        HttpClientBuilder<ByteBuf, ByteBuf> builder = RxNetty.newHttpClientBuilder(host, port);
+
+        builder.pipelineConfigurator(
+                new PipelineConfiguratorComposite<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>>(
+                        new HttpClientPipelineConfigurator<ByteBuf, ByteBuf>(),
+                        gzipPipelineConfigurator)
+        );
+
+        return builder.build();
+    }
+
+    /**
+     * Configurator so that we can support setting the "Accept-Encoding: gzip, deflate" header.
+     */
+    private static final PipelineConfigurator<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>> gzipPipelineConfigurator = new PipelineConfigurator<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>>() {
+        @Override
+        public void configureNewPipeline(ChannelPipeline pipeline) {
+            ChannelHandler handlers = new HttpContentDecompressor();
+            pipeline.addLast(handlers);
+        }
+    };
+
+    /**
+     * Returns a byte array with the message gzipped.
+     */
+    private static byte[] zipMessage(String message) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            GZIPOutputStream gzos = new GZIPOutputStream(out);
+            try {
+                gzos.write(message.getBytes(StandardCharsets.UTF_8));
+            } finally {
+                gzos.close();
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return out.toByteArray();
+    }
+}

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientServerTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/websocket/WebSocketClientServerTest.java
@@ -213,7 +213,7 @@ public class WebSocketClientServerTest {
                         }
                     });
                 }
-            }).withMessageAggregator(messageAggregation).enableWireLogging(LogLevel.ERROR).build().start();
+            }).withMessageAggregator(messageAggregation)./*enableWireLogging(LogLevel.ERROR).*/build().start();
 
             final CountDownLatch clientLatch = new CountDownLatch(expectedOnClient);
             RxNetty.newWebSocketClientBuilder("localhost", server.getServerPort())


### PR DESCRIPTION
Fixed multiple issues:
#344:

The usage of read timeout handler was wrong for pooled connections.

Created a new class `InternalReadTimeoutHandler` that supports pausing read timeout checking when the connection is idle.
#352: Removed the cached PoolExhaustedException, now creating it inline.
#354 and #355 Upgraded to netty 4.0.27 to fix the duplicate `AttributeKey` name.
