### PR TITLE
Bug fix in Pooled connection reuse.

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/ContentWriterImpl.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/ContentWriterImpl.java
@@ -58,7 +58,7 @@ final class ContentWriterImpl<C> extends ResponseContentWriter<C> {
                 if (!HttpHeaders.isTransferEncodingChunked(headers)) {
                     headers.headers().set(Names.CONTENT_LENGTH, 0);
                 }
-                connection.write(Observable.just(headers)).subscribe(subscriber);
+                connection.write(Observable.just(headers)).unsafeSubscribe(subscriber);
             }
         });
         this.connection = connection;
@@ -74,7 +74,7 @@ final class ContentWriterImpl<C> extends ResponseContentWriter<C> {
             @Override
             public void call(Subscriber<? super Void> subscriber) {
                 parent.connection.write(getHttpStream(parent, content, appendTrailer))
-                                 .subscribe(subscriber);
+                                 .unsafeSubscribe(subscriber);
             }
         });
         connection = parent.connection;

--- a/rxnetty/src/test/java/io/reactivex/netty/channel/pool/PoolingWithRealChannelTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/channel/pool/PoolingWithRealChannelTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.channel.pool;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.reactivex.netty.protocol.tcp.TcpClientRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * This tests the code paths which are not invoked for {@link EmbeddedChannel} as it does not schedule any task
+ * (an EmbeddedChannelEventLopp never returns false for isInEventLoop())
+ */
+public class PoolingWithRealChannelTest {
+
+    @Rule
+    public final TcpClientRule clientRule = new TcpClientRule();
+
+    /**
+     * This test validates the async onNext and synchronous onComplete/onError nature of pooling when the connection is
+     * reused.
+     */
+    @Test(timeout = 60000)
+    public void testReuse() throws Exception {
+        clientRule.startServer(1);
+        PooledConnection<ByteBuf, ByteBuf> connection = clientRule.connect();
+        connection.closeNow();
+
+        assertThat("Pooled connection is closed.", connection.unsafeNettyChannel().isOpen(), is(true));
+
+        PooledConnection<ByteBuf, ByteBuf> connection2 = clientRule.connect();
+
+        assertThat("Connection is not reused.", connection2, is(connection));
+    }
+}

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/TcpClientRule.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/TcpClientRule.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reactivex.netty.protocol.tcp;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.channel.Connection;
+import io.reactivex.netty.channel.pool.PooledConnection;
+import io.reactivex.netty.protocol.tcp.client.TcpClient;
+import io.reactivex.netty.protocol.tcp.server.ConnectionHandler;
+import io.reactivex.netty.protocol.tcp.server.TcpServer;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class TcpClientRule extends ExternalResource {
+
+    private TcpServer<ByteBuf, ByteBuf> server;
+    private TcpClient<ByteBuf, ByteBuf> client;
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                server = TcpServer.newServer();
+                base.evaluate();
+            }
+        };
+    }
+
+    public void startServer(int maxConnections) {
+        server.start(new ConnectionHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(Connection<ByteBuf, ByteBuf> newConnection) {
+                return newConnection.writeAndFlushOnEach(newConnection.getInput());
+            }
+        });
+        createClient(maxConnections);
+    }
+
+    public void startServer(ConnectionHandler<ByteBuf, ByteBuf> handler, int maxConnections) {
+        server.start(handler);
+        createClient(maxConnections);
+    }
+
+    public PooledConnection<ByteBuf, ByteBuf> connect() {
+
+        TestSubscriber<Connection<ByteBuf, ByteBuf>> cSub = new TestSubscriber<>();
+        client.createConnectionRequest().subscribe(cSub);
+
+        cSub.awaitTerminalEvent();
+
+        cSub.assertNoErrors();
+
+        assertThat("No connection received.", cSub.getOnNextEvents(), hasSize(1));
+
+        return  (PooledConnection<ByteBuf, ByteBuf>) cSub.getOnNextEvents().get(0);
+    }
+
+    protected void createClient(int maxConnections) {
+        client = TcpClient.newClient("127.0.0.1", server.getServerPort());
+        if (maxConnections >= 0) {
+            client = client.maxConnections(maxConnections);
+        }
+    }
+
+    public TcpServer<ByteBuf, ByteBuf> getServer() {
+        return server;
+    }
+
+    public TcpClient<ByteBuf, ByteBuf> getClient() {
+        return client;
+    }
+}


### PR DESCRIPTION
The reuse subscriber, in case of reuse was asynchronously sending onNext() but synchronously sending terminal events.
So, the terminal events may arrive earlier than the onNext event. Now, wrapping it over an appropriate subscriber to buffer terminal events if onNext has not yet arrived.

Also, changed ContentWriterImpl to use unsafeSubscribe instead of subscribe (duhhh)
