### PR TITLE
Adding a facility to emit custom events on EventListener.

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/channel/events/ConnectionEventListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/channel/events/ConnectionEventListener.java
@@ -108,6 +108,18 @@ public abstract class ConnectionEventListener implements EventListener {
     public void onConnectionCloseFailed(long duration, TimeUnit timeUnit, Throwable throwable) {}
 
     @Override
+    public void onCustomEvent(Object event) { }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) { }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) { }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) { }
+
+    @Override
     public void onCompleted() { }
 
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/channel/events/ConnectionEventPublisher.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/channel/events/ConnectionEventPublisher.java
@@ -24,6 +24,7 @@ import rx.functions.Action1;
 import rx.functions.Action2;
 import rx.functions.Action3;
 import rx.functions.Action4;
+import rx.functions.Action5;
 
 import java.util.concurrent.TimeUnit;
 
@@ -108,6 +109,35 @@ public final class ConnectionEventPublisher<T extends ConnectionEventListener> e
                 }
             };
 
+    private final Action2<T, Object> customEventAction = new Action2<T, Object>() {
+        @Override
+        public void call(T l, Object event) {
+            l.onCustomEvent(event);
+        }
+    };
+
+    private final Action3<T, Throwable, Object> customEventErrorAction = new Action3<T, Throwable, Object>() {
+        @Override
+        public void call(T l, Throwable throwable, Object event) {
+            l.onCustomEvent(event, throwable);
+        }
+    };
+
+    private final Action4<T, Long, TimeUnit, Object> customEventDurationAction = new Action4<T, Long, TimeUnit, Object>() {
+        @Override
+        public void call(T l, Long duration, TimeUnit timeUnit, Object event) {
+            l.onCustomEvent(event, duration, timeUnit);
+        }
+    };
+
+    private final Action5<T, Long, TimeUnit, Throwable, Object> customEventDurationErrAction =
+            new Action5<T, Long, TimeUnit, Throwable, Object>() {
+        @Override
+        public void call(T l, Long duration, TimeUnit timeUnit, Throwable throwable, Object event) {
+            l.onCustomEvent(event, duration, timeUnit, throwable);
+        }
+    };
+
     private final ListenersHolder<T> listeners;
 
     public ConnectionEventPublisher() {
@@ -166,6 +196,26 @@ public final class ConnectionEventPublisher<T extends ConnectionEventListener> e
     @Override
     public void onConnectionCloseFailed(final long duration, final TimeUnit timeUnit, final Throwable throwable) {
         listeners.invokeListeners(closeFailedAction, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event) {
+        listeners.invokeListeners(customEventAction, event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        listeners.invokeListeners(customEventDurationAction, duration, timeUnit, event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        listeners.invokeListeners(customEventDurationErrAction, duration, timeUnit, throwable, event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        listeners.invokeListeners(customEventErrorAction, throwable, event);
     }
 
     @Override

--- a/rxnetty/src/main/java/io/reactivex/netty/events/EventListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/events/EventListener.java
@@ -15,6 +15,8 @@
  */
 package io.reactivex.netty.events;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A listener to subscribe to events published by an {@link EventSource}
  */
@@ -25,4 +27,78 @@ public interface EventListener {
      */
     void onCompleted();
 
+    /**
+     * Typically specific instances on {@link EventListener} will provide events that are fired by RxNetty, however,
+     * there may be cases, where a user would want to emit custom events. eg: Creating a custom protocol on top of an
+     * existing protocol like TCP, would perhaps require some additional events. In such a case, this callback can be
+     * utilized.
+     *
+     * @param event Event published.
+     *
+     * @see #onCustomEvent(Object, long, TimeUnit)
+     * @see #onCustomEvent(Object, Throwable)
+     * @see #onCustomEvent(Object, long, TimeUnit, Throwable)
+     */
+    void onCustomEvent(Object event);
+
+    /**
+     * Typically specific instances on {@link EventListener} will provide events that are fired by RxNetty, however,
+     * there may be cases, where a user would want to emit custom events. eg: Creating a custom protocol on top of an
+     * existing protocol like TCP, would perhaps require some additional events. In such a case, this callback can be
+     * utilized.
+     *
+     * One should use this overload as opposed to {@link #onCustomEvent(Object)} if the custom event need not be created
+     * per invocation but has to be associated with a duration. This is a simple optimization to reduce event creation
+     * overhead.
+     *
+     * @param event Event published.
+     * @param duration Duration associated with this event. The semantics of this duration is totally upto the published
+     * event.
+     * @param timeUnit Timeunit for the duration.
+     *
+     * @see #onCustomEvent(Object, long, TimeUnit)
+     * @see #onCustomEvent(Object, Throwable)
+     * @see #onCustomEvent(Object, long, TimeUnit, Throwable)
+     */
+    void onCustomEvent(Object event, long duration, TimeUnit timeUnit);
+
+    /**
+     * Typically specific instances on {@link EventListener} will provide events that are fired by RxNetty, however,
+     * there may be cases, where a user would want to emit custom events. eg: Creating a custom protocol on top of an
+     * existing protocol like TCP, would perhaps require some additional events. In such a case, this callback can be
+     * utilized.
+     *
+     * One should use this overload as opposed to {@link #onCustomEvent(Object)} if the custom event need not be created
+     * per invocation but has to be associated with an error. This is a simple optimization to reduce event creation
+     * overhead.
+     *
+     * @param event Event published.
+     *
+     * @see #onCustomEvent(Object, long, TimeUnit)
+     * @see #onCustomEvent(Object, Throwable)
+     * @see #onCustomEvent(Object, long, TimeUnit, Throwable)
+     */
+    void onCustomEvent(Object event, Throwable throwable);
+
+    /**
+     * Typically specific instances on {@link EventListener} will provide events that are fired by RxNetty, however,
+     * there may be cases, where a user would want to emit custom events. eg: Creating a custom protocol on top of an
+     * existing protocol like TCP, would perhaps require some additional events. In such a case, this callback can be
+     * utilized.
+     *
+     * One should use this overload as opposed to {@link #onCustomEvent(Object)} if the custom event need not be created
+     * per invocation but has to be associated with a duration and an error. This is a simple optimization to reduce
+     * event creation overhead.
+     *
+     * @param event Event published.
+     * @param duration Duration associated with this event. The semantics of this duration is totally upto the published
+     * event.
+     * @param timeUnit Timeunit for the duration.
+     * @param throwable Error associated with the event.
+     *
+     * @see #onCustomEvent(Object, long, TimeUnit)
+     * @see #onCustomEvent(Object, Throwable)
+     * @see #onCustomEvent(Object, long, TimeUnit, Throwable)
+     */
+    void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable);
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisher.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisher.java
@@ -273,6 +273,26 @@ public final class HttpClientEventPublisher extends HttpClientEventsListener
     }
 
     @Override
+    public void onCustomEvent(Object event) {
+        tcpDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, throwable);
+    }
+
+    @Override
     public boolean publishingEnabled() {
         return listeners.publishingEnabled();
     }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/SafeHttpClientEventsListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/SafeHttpClientEventsListener.java
@@ -39,155 +39,243 @@ final class SafeHttpClientEventsListener extends HttpClientEventsListener implem
 
     @Override
     public void onRequestSubmitted() {
-        delegate.onRequestSubmitted();
+        if (!completed.get()) {
+            delegate.onRequestSubmitted();
+        }
     }
 
     @Override
     public void onRequestWriteStart() {
-        delegate.onRequestWriteStart();
+        if (!completed.get()) {
+            delegate.onRequestWriteStart();
+        }
     }
 
     @Override
     public void onRequestWriteComplete(long duration, TimeUnit timeUnit) {
-        delegate.onRequestWriteComplete(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onRequestWriteComplete(duration, timeUnit);
+        }
     }
 
     @Override
     public void onRequestWriteFailed(long duration, TimeUnit timeUnit,
                                      Throwable throwable) {
-        delegate.onRequestWriteFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onRequestWriteFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onResponseHeadersReceived(int responseCode) {
-        delegate.onResponseHeadersReceived(responseCode);
+        if (!completed.get()) {
+            delegate.onResponseHeadersReceived(responseCode);
+        }
     }
 
     @Override
     public void onResponseContentReceived() {
-        delegate.onResponseContentReceived();
+        if (!completed.get()) {
+            delegate.onResponseContentReceived();
+        }
     }
 
     @Override
     public void onResponseReceiveComplete(long duration, TimeUnit timeUnit) {
-        delegate.onResponseReceiveComplete(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onResponseReceiveComplete(duration, timeUnit);
+        }
     }
 
     @Override
     public void onResponseFailed(Throwable throwable) {
-        delegate.onResponseFailed(throwable);
+        if (!completed.get()) {
+            delegate.onResponseFailed(throwable);
+        }
     }
 
     @Override
     public void onRequestProcessingComplete(long duration, TimeUnit timeUnit) {
-        delegate.onRequestProcessingComplete(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onRequestProcessingComplete(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectStart() {
-        delegate.onConnectStart();
+        if (!completed.get()) {
+            delegate.onConnectStart();
+        }
     }
 
     @Override
     public void onConnectSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onConnectFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onPoolReleaseStart() {
-        delegate.onPoolReleaseStart();
+        if (!completed.get()) {
+            delegate.onPoolReleaseStart();
+        }
     }
 
     @Override
     public void onPoolReleaseSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onPoolReleaseSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onPoolReleaseSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onPoolReleaseFailed(long duration, TimeUnit timeUnit,
                                     Throwable throwable) {
-        delegate.onPoolReleaseFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onPoolReleaseFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onPooledConnectionEviction() {
-        delegate.onPooledConnectionEviction();
+        if (!completed.get()) {
+            delegate.onPooledConnectionEviction();
+        }
     }
 
     @Override
     public void onPooledConnectionReuse() {
-        delegate.onPooledConnectionReuse();
+        if (!completed.get()) {
+            delegate.onPooledConnectionReuse();
+        }
     }
 
     @Override
     public void onPoolAcquireStart() {
-        delegate.onPoolAcquireStart();
+        if (!completed.get()) {
+            delegate.onPoolAcquireStart();
+        }
     }
 
     @Override
     public void onPoolAcquireSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onPoolAcquireSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onPoolAcquireSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onPoolAcquireFailed(long duration, TimeUnit timeUnit,
                                     Throwable throwable) {
-        delegate.onPoolAcquireFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onPoolAcquireFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onByteRead(long bytesRead) {
-        delegate.onByteRead(bytesRead);
+        if (!completed.get()) {
+            delegate.onByteRead(bytesRead);
+        }
     }
 
     @Override
     public void onFlushStart() {
-        delegate.onFlushStart();
+        if (!completed.get()) {
+            delegate.onFlushStart();
+        }
     }
 
     @Override
     public void onFlushSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onFlushSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onFlushSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onFlushFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onFlushFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onWriteStart() {
-        delegate.onWriteStart();
+        if (!completed.get()) {
+            delegate.onWriteStart();
+        }
     }
 
     @Override
     public void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
-        delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        if (!completed.get()) {
+            delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        }
     }
 
     @Override
     public void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onWriteFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onWriteFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onConnectionCloseStart() {
-        delegate.onConnectionCloseStart();
+        if (!completed.get()) {
+            delegate.onConnectionCloseStart();
+        }
     }
 
     @Override
     public void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionCloseSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionCloseSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionCloseFailed(long duration, TimeUnit timeUnit,
                                         Throwable throwable) {
-        delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, throwable);
+        }
     }
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/events/HttpServerEventPublisher.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/events/HttpServerEventPublisher.java
@@ -239,6 +239,26 @@ public final class HttpServerEventPublisher extends HttpServerEventsListener
     }
 
     @Override
+    public void onCustomEvent(Object event) {
+        tcpDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, throwable);
+    }
+
+    @Override
     public void onNewClientConnected() {
         tcpDelegate.onNewClientConnected();
     }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/events/SafeHttpServerEventsListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/events/SafeHttpServerEventsListener.java
@@ -38,125 +38,201 @@ final class SafeHttpServerEventsListener extends HttpServerEventsListener implem
 
     @Override
     public void onNewRequestReceived() {
-        delegate.onNewRequestReceived();
+        if (!completed.get()) {
+            delegate.onNewRequestReceived();
+        }
     }
 
     @Override
     public void onRequestHandlingStart(long duration, TimeUnit timeUnit) {
-        delegate.onRequestHandlingStart(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onRequestHandlingStart(duration, timeUnit);
+        }
     }
 
     @Override
     public void onRequestHandlingSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onRequestHandlingSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onRequestHandlingSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onRequestHandlingFailed(long duration, TimeUnit timeUnit,
                                         Throwable throwable) {
-        delegate.onRequestHandlingFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onRequestHandlingFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onRequestHeadersReceived() {
-        delegate.onRequestHeadersReceived();
+        if (!completed.get()) {
+            delegate.onRequestHeadersReceived();
+        }
     }
 
     @Override
     public void onRequestContentReceived() {
-        delegate.onRequestContentReceived();
+        if (!completed.get()) {
+            delegate.onRequestContentReceived();
+        }
     }
 
     @Override
     public void onRequestReceiveComplete(long duration, TimeUnit timeUnit) {
-        delegate.onRequestReceiveComplete(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onRequestReceiveComplete(duration, timeUnit);
+        }
     }
 
     @Override
     public void onResponseWriteStart() {
-        delegate.onResponseWriteStart();
+        if (!completed.get()) {
+            delegate.onResponseWriteStart();
+        }
     }
 
     @Override
     public void onResponseWriteSuccess(long duration, TimeUnit timeUnit, int responseCode) {
-        delegate.onResponseWriteSuccess(duration, timeUnit, responseCode);
+        if (!completed.get()) {
+            delegate.onResponseWriteSuccess(duration, timeUnit, responseCode);
+        }
     }
 
     @Override
     public void onResponseWriteFailed(long duration, TimeUnit timeUnit,
                                       Throwable throwable) {
-        delegate.onResponseWriteFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onResponseWriteFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onNewClientConnected() {
-        delegate.onNewClientConnected();
+        if (!completed.get()) {
+            delegate.onNewClientConnected();
+        }
     }
 
     @Override
     public void onConnectionHandlingStart(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionHandlingStart(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionHandlingStart(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionHandlingSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionHandlingSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionHandlingSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionHandlingFailed(long duration, TimeUnit timeUnit,
                                            Throwable throwable) {
-        delegate.onConnectionHandlingFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectionHandlingFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onByteRead(long bytesRead) {
-        delegate.onByteRead(bytesRead);
+        if (!completed.get()) {
+            delegate.onByteRead(bytesRead);
+        }
     }
 
     @Override
     public void onFlushStart() {
-        delegate.onFlushStart();
+        if (!completed.get()) {
+            delegate.onFlushStart();
+        }
     }
 
     @Override
     public void onFlushSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onFlushSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onFlushSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onFlushFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onFlushFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onWriteStart() {
-        delegate.onWriteStart();
+        if (!completed.get()) {
+            delegate.onWriteStart();
+        }
     }
 
     @Override
     public void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
-        delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        if (!completed.get()) {
+            delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        }
     }
 
     @Override
     public void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onWriteFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onWriteFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onConnectionCloseStart() {
-        delegate.onConnectionCloseStart();
+        if (!completed.get()) {
+            delegate.onConnectionCloseStart();
+        }
     }
 
     @Override
     public void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionCloseSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionCloseSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionCloseFailed(long duration, TimeUnit timeUnit,
                                         Throwable throwable) {
-        delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, throwable);
+        }
     }
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/client/events/SafeTcpClientEventListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/client/events/SafeTcpClientEventListener.java
@@ -38,109 +38,179 @@ final class SafeTcpClientEventListener extends TcpClientEventListener implements
 
     @Override
     public void onConnectStart() {
-        delegate.onConnectStart();
+        if (!completed.get()) {
+            delegate.onConnectStart();
+        }
     }
 
     @Override
     public void onConnectSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onConnectFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onPoolReleaseStart() {
-        delegate.onPoolReleaseStart();
+        if (!completed.get()) {
+            delegate.onPoolReleaseStart();
+        }
     }
 
     @Override
     public void onPoolReleaseSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onPoolReleaseSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onPoolReleaseSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onPoolReleaseFailed(long duration, TimeUnit timeUnit,
                                     Throwable throwable) {
-        delegate.onPoolReleaseFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onPoolReleaseFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onPooledConnectionEviction() {
-        delegate.onPooledConnectionEviction();
+        if (!completed.get()) {
+            delegate.onPooledConnectionEviction();
+        }
     }
 
     @Override
     public void onPooledConnectionReuse() {
-        delegate.onPooledConnectionReuse();
+        if (!completed.get()) {
+            delegate.onPooledConnectionReuse();
+        }
     }
 
     @Override
     public void onPoolAcquireStart() {
-        delegate.onPoolAcquireStart();
+        if (!completed.get()) {
+            delegate.onPoolAcquireStart();
+        }
     }
 
     @Override
     public void onPoolAcquireSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onPoolAcquireSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onPoolAcquireSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onPoolAcquireFailed(long duration, TimeUnit timeUnit,
                                     Throwable throwable) {
-        delegate.onPoolAcquireFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onPoolAcquireFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onByteRead(long bytesRead) {
-        delegate.onByteRead(bytesRead);
+        if (!completed.get()) {
+            delegate.onByteRead(bytesRead);
+        }
     }
 
     @Override
     public void onFlushStart() {
-        delegate.onFlushStart();
+        if (!completed.get()) {
+            delegate.onFlushStart();
+        }
     }
 
     @Override
     public void onFlushSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onFlushSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onFlushSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onFlushFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onFlushFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onWriteStart() {
-        delegate.onWriteStart();
+        if (!completed.get()) {
+            delegate.onWriteStart();
+        }
     }
 
     @Override
     public void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
-        delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        if (!completed.get()) {
+            delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        }
     }
 
     @Override
     public void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onWriteFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onWriteFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onConnectionCloseStart() {
-        delegate.onConnectionCloseStart();
+        if (!completed.get()) {
+            delegate.onConnectionCloseStart();
+        }
     }
 
     @Override
     public void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionCloseSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionCloseSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionCloseFailed(long duration, TimeUnit timeUnit,
                                         Throwable throwable) {
-        delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, throwable);
+        }
     }
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventPublisher.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventPublisher.java
@@ -233,6 +233,26 @@ public final class TcpClientEventPublisher extends TcpClientEventListener
     }
 
     @Override
+    public void onCustomEvent(Object event) {
+        connDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        connDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        connDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        connDelegate.onCustomEvent(event, throwable);
+    }
+
+    @Override
     public Subscription subscribe(TcpClientEventListener listener) {
         if (!SafeEventListener.class.isAssignableFrom(listener.getClass())) {
             listener = new SafeTcpClientEventListener(listener);

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/server/events/SafeTcpServerEventListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/server/events/SafeTcpServerEventListener.java
@@ -38,73 +38,129 @@ final class SafeTcpServerEventListener extends TcpServerEventListener implements
 
     @Override
     public void onNewClientConnected() {
-        delegate.onNewClientConnected();
+        if (!completed.get()) {
+            delegate.onNewClientConnected();
+        }
     }
 
     @Override
     public void onConnectionHandlingStart(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionHandlingStart(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionHandlingStart(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionHandlingSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionHandlingSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionHandlingSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionHandlingFailed(long duration, TimeUnit timeUnit,
                                            Throwable throwable) {
-        delegate.onConnectionHandlingFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectionHandlingFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onByteRead(long bytesRead) {
-        delegate.onByteRead(bytesRead);
+        if (!completed.get()) {
+            delegate.onByteRead(bytesRead);
+        }
     }
 
     @Override
     public void onFlushStart() {
-        delegate.onFlushStart();
+        if (!completed.get()) {
+            delegate.onFlushStart();
+        }
     }
 
     @Override
     public void onFlushSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onFlushSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onFlushSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onFlushFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onFlushFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onFlushFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onWriteStart() {
-        delegate.onWriteStart();
+        if (!completed.get()) {
+            delegate.onWriteStart();
+        }
     }
 
     @Override
     public void onWriteSuccess(long duration, TimeUnit timeUnit, long bytesWritten) {
-        delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        if (!completed.get()) {
+            delegate.onWriteSuccess(duration, timeUnit, bytesWritten);
+        }
     }
 
     @Override
     public void onWriteFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
-        delegate.onWriteFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onWriteFailed(duration, timeUnit, throwable);
+        }
     }
 
     @Override
     public void onConnectionCloseStart() {
-        delegate.onConnectionCloseStart();
+        if (!completed.get()) {
+            delegate.onConnectionCloseStart();
+        }
     }
 
     @Override
     public void onConnectionCloseSuccess(long duration, TimeUnit timeUnit) {
-        delegate.onConnectionCloseSuccess(duration, timeUnit);
+        if (!completed.get()) {
+            delegate.onConnectionCloseSuccess(duration, timeUnit);
+        }
     }
 
     @Override
     public void onConnectionCloseFailed(long duration, TimeUnit timeUnit,
                                         Throwable throwable) {
-        delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        if (!completed.get()) {
+            delegate.onConnectionCloseFailed(duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, duration, timeUnit, throwable);
+        }
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        if (!completed.get()) {
+            delegate.onCustomEvent(event, throwable);
+        }
     }
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/server/events/TcpServerEventPublisher.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/server/events/TcpServerEventPublisher.java
@@ -150,6 +150,26 @@ public final class TcpServerEventPublisher extends TcpServerEventListener
     }
 
     @Override
+    public void onCustomEvent(Object event) {
+        connDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        connDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        connDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        connDelegate.onCustomEvent(event, throwable);
+    }
+
+    @Override
     public boolean publishingEnabled() {
         return listeners.publishingEnabled();
     }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisherTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisherTest.java
@@ -256,6 +256,30 @@ public class HttpClientEventPublisherTest {
     }
 
     @Test(timeout = 60000)
+    public void testOnCustomEvent() throws Exception {
+        rule.publisher.onCustomEvent("Hello");
+        rule.listener.getTcpDelegate().assertMethodsCalled(Event.CustomEvent); // Test for TCP should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", new NullPointerException());
+        rule.listener.getTcpDelegate().assertMethodsCalled(Event.CustomEventWithError); // Test for TCP should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithDuration() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, MINUTES);
+        rule.listener.getTcpDelegate().assertMethodsCalled(Event.CustomEventWithDuration); // Test for TCP should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithDurationAndError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, MINUTES, new NullPointerException());
+        rule.listener.getTcpDelegate().assertMethodsCalled(Event.CustomEventWithDurationAndError); // Test for TCP should verify rest
+    }
+
+    @Test(timeout = 60000)
     public void testPublishingEnabled() throws Exception {
         assertThat("Publishing not enabled.", rule.publisher.publishingEnabled(), is(true));
     }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListenerImpl.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListenerImpl.java
@@ -224,6 +224,26 @@ public class HttpClientEventsListenerImpl extends HttpClientEventsListener {
     }
 
     @Override
+    public void onCustomEvent(Object event) {
+        tcpDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, throwable);
+    }
+
+    @Override
     public void onCompleted() {
         tcpDelegate.onCompleted();
     }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/events/HttpServerEventPublisherTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/events/HttpServerEventPublisherTest.java
@@ -224,6 +224,30 @@ public class HttpServerEventPublisherTest {
     }
 
     @Test(timeout = 60000)
+    public void testOnCustomEvent() throws Exception {
+        rule.publisher.onCustomEvent("Hello");
+        rule.listener.getTcpDelegate().getConnDelegate().assertMethodsCalled(Event.CustomEvent);
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", new NullPointerException());
+        rule.listener.getTcpDelegate().getConnDelegate().assertMethodsCalled(Event.CustomEventWithError);
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithDuration() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, TimeUnit.MINUTES);
+        rule.listener.getTcpDelegate().getConnDelegate().assertMethodsCalled(Event.CustomEventWithDuration);
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithDurationAndError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, TimeUnit.MINUTES, new NullPointerException());
+        rule.listener.getTcpDelegate().getConnDelegate().assertMethodsCalled(Event.CustomEventWithDurationAndError);
+    }
+
+    @Test(timeout = 60000)
     public void testPublishingEnabled() throws Exception {
         assertThat("Publishing not enabled.", rule.publisher.publishingEnabled(), is(true));
     }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/events/HttpServerEventsListenerImpl.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/events/HttpServerEventsListenerImpl.java
@@ -209,4 +209,24 @@ public class HttpServerEventsListenerImpl extends HttpServerEventsListener {
     public void onFlushStart() {
         tcpDelegate.onFlushStart();
     }
+
+    @Override
+    public void onCustomEvent(Object event) {
+        tcpDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        tcpDelegate.onCustomEvent(event, throwable);
+    }
 }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventListenerImpl.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventListenerImpl.java
@@ -161,6 +161,26 @@ public class TcpClientEventListenerImpl extends TcpClientEventListener {
     }
 
     @Override
+    public void onCustomEvent(Object event) {
+        delegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        delegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        delegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        delegate.onCustomEvent(event, throwable);
+    }
+
+    @Override
     public void onCompleted() {
         delegate.onCompleted();
     }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventPublisherTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventPublisherTest.java
@@ -213,6 +213,30 @@ public class TcpClientEventPublisherTest {
     }
 
     @Test(timeout = 60000)
+    public void testCustomEvent() throws Exception {
+        rule.publisher.onCustomEvent("Hello");
+        rule.listener.assertMethodsCalled(Event.CustomEvent); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testCustomEventWithError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", new NullPointerException());
+        rule.listener.assertMethodsCalled(Event.CustomEventWithError); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testCustomEventWithDuration() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, TimeUnit.MINUTES);
+        rule.listener.assertMethodsCalled(Event.CustomEventWithDuration); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testCustomEventWithDurationAndError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, TimeUnit.MINUTES, new NullPointerException());
+        rule.listener.assertMethodsCalled(Event.CustomEventWithDurationAndError); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
     public void testCopy() throws Exception {
         TcpClientEventPublisher copy = rule.publisher.copy();
 

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/server/events/TcpServerEventListenerImpl.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/server/events/TcpServerEventListenerImpl.java
@@ -136,6 +136,26 @@ public class TcpServerEventListenerImpl extends TcpServerEventListener {
         connDelegate.onByteRead(bytesRead);
     }
 
+    @Override
+    public void onCustomEvent(Object event) {
+        connDelegate.onCustomEvent(event);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit) {
+        connDelegate.onCustomEvent(event, duration, timeUnit);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, long duration, TimeUnit timeUnit, Throwable throwable) {
+        connDelegate.onCustomEvent(event, duration, timeUnit, throwable);
+    }
+
+    @Override
+    public void onCustomEvent(Object event, Throwable throwable) {
+        connDelegate.onCustomEvent(event, throwable);
+    }
+
     public void assertMethodsCalled(ServerEvent... events) {
         assertThat("Unexpected methods called count.", methodsCalled, hasSize(events.length));
         assertThat("Unexpected methods called.", methodsCalled, contains(events));

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/server/events/TcpServerEventPublisherTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/tcp/server/events/TcpServerEventPublisherTest.java
@@ -143,6 +143,30 @@ public class TcpServerEventPublisherTest {
     }
 
     @Test(timeout = 60000)
+    public void testOnCustomEvent() throws Exception {
+        rule.publisher.onCustomEvent("Hello");
+        rule.listener.getConnDelegate().assertMethodsCalled(Event.CustomEvent); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", new NullPointerException());
+        rule.listener.getConnDelegate().assertMethodsCalled(Event.CustomEventWithError); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithDuration() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, MINUTES);
+        rule.listener.getConnDelegate().assertMethodsCalled(Event.CustomEventWithDuration); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
+    public void testOnCustomEventWithDurationError() throws Exception {
+        rule.publisher.onCustomEvent("Hello", 1, MINUTES, new NullPointerException());
+        rule.listener.getConnDelegate().assertMethodsCalled(Event.CustomEventWithDurationAndError); // Test for Connection publisher should verify rest
+    }
+
+    @Test(timeout = 60000)
     public void testPublishingEnabled() throws Exception {
         assertThat("Publishing not enabled.", rule.publisher.publishingEnabled(), is(true));
     }


### PR DESCRIPTION
Currently protocol specific listeners only provide pre-defined events. In cases, when someone is building a custom protocol over an existing protocol (TCP, HTTP), there would be a need of custom events that can be tapped for metrics, feedback to `ConnectionProvider`s etc.

This change adds 4 variants of `onCustomEvent` methods to `EventListener` (Common class for all listeners) with an ability to emit a custom event with duration and error. The intent of these overloads is that it will allow the actual event class to be a constant (to avoid object allocation overhead) for common usecases of emitting events with duration and error.

RxNetty would not emit any events as custom, it will always be emitted by user code.
