### PR TITLE
Added server latency and total request processing times to HttpClientEventListener

### DIFF
--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/loadbalancing/HttpLoadBalancer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/loadbalancing/HttpLoadBalancer.java
@@ -22,6 +22,7 @@ import io.reactivex.netty.protocol.tcp.client.ConnectionProvider;
 import rx.Observable;
 
 import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is an implementation of {@link RoundRobinLoadBalancer} for HTTP clients.
@@ -41,7 +42,7 @@ public class HttpLoadBalancer<W, R> extends RoundRobinLoadBalancer<W, R> {
     private HttpLoadBalancer(Observable<SocketAddress> hosts, ConnectionFactory<W, R> connectionFactory) {
         super(hosts, connectionFactory, removeAction -> new HttpClientEventsListener() {
             @Override
-            public void onResponseHeadersReceived(int responseCode) {
+            public void onResponseHeadersReceived(int responseCode, long duration, TimeUnit timeUnit) {
                 if (503 == responseCode) {
                     /*Remove the host from the active list, if we get a 503 response*/
                     removeAction.call();

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisher.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisher.java
@@ -65,11 +65,12 @@ public final class HttpClientEventPublisher extends HttpClientEventsListener
                 }
             };
 
-    private static final Action2<HttpClientEventsListener, Integer> RESP_HEADER_RECIEVED_ACTION =
-            new Action2<HttpClientEventsListener, Integer>() {
+    private static final Action4<HttpClientEventsListener, Long, TimeUnit, Integer> RESP_HEADER_RECIEVED_ACTION =
+            new Action4<HttpClientEventsListener, Long, TimeUnit, Integer>() {
                 @Override
-                public void call(HttpClientEventsListener listener, Integer responseCode) {
-                    listener.onResponseHeadersReceived(responseCode);
+                public void call(HttpClientEventsListener listener, Long duration, TimeUnit timeUnit,
+                                 Integer responseCode) {
+                    listener.onResponseHeadersReceived(responseCode, duration, timeUnit);
                 }
             };
 
@@ -139,8 +140,8 @@ public final class HttpClientEventPublisher extends HttpClientEventsListener
     }
 
     @Override
-    public void onResponseHeadersReceived(final int responseCode) {
-        listeners.invokeListeners(RESP_HEADER_RECIEVED_ACTION, responseCode);
+    public void onResponseHeadersReceived(final int responseCode, long duration, TimeUnit timeUnit) {
+        listeners.invokeListeners(RESP_HEADER_RECIEVED_ACTION, duration, timeUnit, responseCode);
     }
 
     @Override

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListener.java
@@ -58,9 +58,11 @@ public abstract class HttpClientEventsListener extends TcpClientEventListener {
      * Event when the response headers are received.
      *
      * @param responseCode The HTTP response code.
+     * @param duration The time between the request write completion and response header recieve.
+     * @param timeUnit Timeunit for the duration.
      */
     @SuppressWarnings("unused")
-    public void onResponseHeadersReceived(int responseCode) {}
+    public void onResponseHeadersReceived(int responseCode, long duration, TimeUnit timeUnit) {}
 
     /**
      * Event whenever an HTTP response content is received (an HTTP response can have multiple content chunks, in which
@@ -86,9 +88,9 @@ public abstract class HttpClientEventsListener extends TcpClientEventListener {
     public void onResponseFailed(Throwable throwable) {}
 
     /**
-     * Event when the entire request processing (request submitted to response failed/complete) is completed.
+     * Event when the entire request processing (request header write to response failed/complete) is completed.
      *
-     * @param duration Time taken from submission of request to completion.
+     * @param duration Time taken from start of write of request to response receive completion.
      * @param timeUnit Time unit for the duration.
      */
     @SuppressWarnings("unused")

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/SafeHttpClientEventsListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/SafeHttpClientEventsListener.java
@@ -67,9 +67,9 @@ final class SafeHttpClientEventsListener extends HttpClientEventsListener implem
     }
 
     @Override
-    public void onResponseHeadersReceived(int responseCode) {
+    public void onResponseHeadersReceived(int responseCode, long duration, TimeUnit timeUnit) {
         if (!completed.get()) {
-            delegate.onResponseHeadersReceived(responseCode);
+            delegate.onResponseHeadersReceived(responseCode, duration, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/internal/AbstractHttpConnectionBridge.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/internal/AbstractHttpConnectionBridge.java
@@ -93,6 +93,7 @@ public abstract class AbstractHttpConnectionBridge<C> extends ChannelDuplexHandl
         Object msgToWrite = msg;
 
         if (isOutboundHeader(msg)) {
+            /*Reset on every header write, when we support pipelining, this should be a queue.*/
             headerWriteStartTimeMillis = Clock.newStartTimeMillis();
             HttpMessage httpMsg = (HttpMessage) msg;
             if (!HttpHeaderUtil.isContentLengthSet(httpMsg) && !HttpVersion.HTTP_1_0.equals(httpMsg.protocolVersion())) {
@@ -185,6 +186,10 @@ public abstract class AbstractHttpConnectionBridge<C> extends ChannelDuplexHandl
 
     protected void onNewContentSubscriber(ConnectionInputSubscriber inputSubscriber, Subscriber<? super C> newSub) {
         // No Op.
+    }
+
+    protected long getHeaderWriteStartTimeMillis() {
+        return headerWriteStartTimeMillis;
     }
 
     private void processNextItemInEventloop(Object nextItem, ConnectionInputSubscriber connectionInputSubscriber) {

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisherTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventPublisherTest.java
@@ -68,10 +68,12 @@ public class HttpClientEventPublisherTest {
 
     @Test(timeout = 60000)
     public void testOnResponseHeadersReceived() throws Exception {
-        rule.publisher.onResponseHeadersReceived(200);
+        rule.publisher.onResponseHeadersReceived(200, 1, MILLISECONDS);
         rule.listener.assertMethodCalled(HttpEvent.ResHeadersReceived);
 
         assertThat("Listener not called with response code.", rule.listener.getResponseCode(), is(200));
+        assertThat("Listener not called with duration.", rule.listener.getDuration(), is(1L));
+        assertThat("Listener not called with time unit.", rule.listener.getTimeUnit(), is(MILLISECONDS));
     }
 
     @Test(timeout = 60000)

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListenerImpl.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListenerImpl.java
@@ -69,8 +69,10 @@ public class HttpClientEventsListenerImpl extends HttpClientEventsListener {
     }
 
     @Override
-    public void onResponseHeadersReceived(int responseCode) {
+    public void onResponseHeadersReceived(int responseCode, long duration, TimeUnit timeUnit) {
         this.responseCode = responseCode;
+        this.duration = duration;
+        this.timeUnit = timeUnit;
         methodsCalled.add(HttpEvent.ResHeadersReceived);
     }
 


### PR DESCRIPTION
It is useful for clients to get server side latency per request which is the duration between request write completion and response recieve start.
Added this duration to responseHeaderReceived() callback.

requestProcessingComplete() was not called, fixed it now. It now gives the duration between start of header write and completion of response.
