### PR TITLE
Moving all timeunits from millis to nanos.

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/events/Clock.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/events/Clock.java
@@ -38,52 +38,52 @@ public class Clock {
      * The value returned by all static methods in this class, viz.,
      * <ul>
      <li>{@link #newStartTime(TimeUnit)}</li>
-     <li>{@link #newStartTimeMillis()}</li>
-     <li>{@link #onEndMillis(long)}</li>
+     <li>{@link #newStartTimeNanos()}</li>
+     <li>{@link #onEndNanos(long)}</li>
      <li>{@link #onEnd(long, TimeUnit)}</li>
      </ul>
      * after calling {@link RxNetty#disableEventPublishing()}
      */
     public static final long SYSTEM_TIME_DISABLED_TIME = -1;
 
-    private final long startTimeMillis = System.currentTimeMillis();
-    private long endTimeMillis = -1;
-    private long durationMillis = -1;
+    private final long startTimeNanos = System.nanoTime();
+    private long endTimeNanos = -1;
+    private long durationNanos = -1;
 
     /**
      * Stops this clock. This method is idempotent, so, after invoking this method, the duration of the clock is
      * immutable. Hence, you can call this method multiple times with no side-effects.
      *
-     * @return The duration in milliseconds for which the clock was running.
+     * @return The duration in nanoseconds for which the clock was running.
      */
     public long stop() {
-        if (-1 != endTimeMillis) {
-            endTimeMillis = System.currentTimeMillis();
-            durationMillis = endTimeMillis - startTimeMillis;
+        if (-1 != endTimeNanos) {
+            endTimeNanos = System.nanoTime();
+            durationNanos = endTimeNanos - startTimeNanos;
         }
-        return durationMillis;
+        return durationNanos;
     }
 
-    public long getStartTimeMillis() {
-        return startTimeMillis;
+    public long getStartTimeNanos() {
+        return startTimeNanos;
     }
 
     public long getStartTime(TimeUnit targetUnit) {
-        return targetUnit.convert(startTimeMillis, TimeUnit.MILLISECONDS);
+        return targetUnit.convert(startTimeNanos, TimeUnit.NANOSECONDS);
     }
 
     /**
-     * Returns the duration for which this clock was running in milliseconds.
+     * Returns the duration for which this clock was running in nanoseconds.
      *
-     * @return The duration for which this clock was running in milliseconds.
+     * @return The duration for which this clock was running in nanoseconds.
      *
      * @throws IllegalStateException If the clock is not yet stopped.
      */
-    public long getDurationInMillis() {
+    public long getDurationInNanos() {
         if (isRunning()) {
             throw new IllegalStateException("The clock is not yet stopped.");
         }
-        return durationMillis;
+        return durationNanos;
     }
 
     /**
@@ -97,15 +97,15 @@ public class Clock {
         if (isRunning()) {
             throw new IllegalStateException("The clock is not yet stopped.");
         }
-        return targetUnit.convert(durationMillis, TimeUnit.MILLISECONDS);
+        return targetUnit.convert(durationNanos, TimeUnit.NANOSECONDS);
     }
 
     public boolean isRunning() {
-        return -1 != durationMillis;
+        return -1 != durationNanos;
     }
 
-    public static long newStartTimeMillis() {
-        return RxNetty.isEventPublishingDisabled() ? SYSTEM_TIME_DISABLED_TIME : System.currentTimeMillis();
+    public static long newStartTimeNanos() {
+        return RxNetty.isEventPublishingDisabled() ? SYSTEM_TIME_DISABLED_TIME : System.nanoTime();
     }
 
     public static long newStartTime(TimeUnit timeUnit) {
@@ -113,27 +113,27 @@ public class Clock {
             return SYSTEM_TIME_DISABLED_TIME;
         }
 
-        if (TimeUnit.MILLISECONDS == timeUnit) {
-            return newStartTimeMillis();
+        if (TimeUnit.NANOSECONDS == timeUnit) {
+            return newStartTimeNanos();
         }
-        return timeUnit.convert(newStartTimeMillis(), TimeUnit.MILLISECONDS);
+        return timeUnit.convert(newStartTimeNanos(), TimeUnit.NANOSECONDS);
     }
 
     public static long onEnd(long startTime, TimeUnit timeUnit) {
         if (RxNetty.isEventPublishingDisabled() ) {
             return SYSTEM_TIME_DISABLED_TIME;
         }
-        if (TimeUnit.MILLISECONDS == timeUnit) {
-            return onEndMillis(startTime);
+        if (TimeUnit.NANOSECONDS == timeUnit) {
+            return onEndNanos(startTime);
         }
-        long startTimeMillis = TimeUnit.MILLISECONDS.convert(startTime, timeUnit);
-        return timeUnit.convert(onEndMillis(startTimeMillis), TimeUnit.MILLISECONDS);
+        long startTimeNanos = TimeUnit.NANOSECONDS.convert(startTime, timeUnit);
+        return timeUnit.convert(onEndNanos(startTimeNanos), TimeUnit.NANOSECONDS);
     }
 
-    public static long onEndMillis(long startTimeMillis) {
+    public static long onEndNanos(long startTimeNanos) {
         if (RxNetty.isEventPublishingDisabled() ) {
             return SYSTEM_TIME_DISABLED_TIME;
         }
-        return System.currentTimeMillis() - startTimeMillis;
+        return System.nanoTime() - startTimeNanos;
     }
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/SafeHttpClientEventsListener.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/events/SafeHttpClientEventsListener.java
@@ -69,7 +69,7 @@ final class SafeHttpClientEventsListener extends HttpClientEventsListener implem
     @Override
     public void onResponseHeadersReceived(int responseCode, long duration, TimeUnit timeUnit) {
         if (!completed.get()) {
-            delegate.onResponseHeadersReceived(responseCode, duration, TimeUnit.MILLISECONDS);
+            delegate.onResponseHeadersReceived(responseCode, duration, timeUnit);
         }
     }
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/internal/HttpClientRequestImpl.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/internal/HttpClientRequestImpl.java
@@ -525,7 +525,7 @@ public final class HttpClientRequestImpl<I, O> extends HttpClientRequest<I, O> {
 
         @Override
         public Subscriber<? super Void> call(final Subscriber<? super Void> o) {
-            final long startTimeMillis = eventPublisher.publishingEnabled() ? Clock.newStartTimeMillis() : -1;
+            final long startTimeNanos = eventPublisher.publishingEnabled() ? Clock.newStartTimeNanos() : -1;
             if (eventPublisher.publishingEnabled()) {
                 eventsListener.onRequestSubmitted();
             }
@@ -533,7 +533,7 @@ public final class HttpClientRequestImpl<I, O> extends HttpClientRequest<I, O> {
                 @Override
                 public void onCompleted() {
                     if (eventPublisher.publishingEnabled()) {
-                        eventsListener.onRequestWriteComplete(Clock.onEndMillis(startTimeMillis), MILLISECONDS);
+                        eventsListener.onRequestWriteComplete(Clock.onEndNanos(startTimeNanos), NANOSECONDS);
                     }
                     o.onCompleted();
                 }
@@ -541,7 +541,7 @@ public final class HttpClientRequestImpl<I, O> extends HttpClientRequest<I, O> {
                 @Override
                 public void onError(Throwable e) {
                     if (eventPublisher.publishingEnabled()) {
-                        eventsListener.onRequestWriteFailed(Clock.onEndMillis(startTimeMillis), MILLISECONDS, e);
+                        eventsListener.onRequestWriteFailed(Clock.onEndNanos(startTimeNanos), NANOSECONDS, e);
                     }
                     o.onError(e);
                 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerImpl.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerImpl.java
@@ -287,7 +287,7 @@ public final class HttpServerImpl<I, O> extends HttpServer<I, O> {
                     @Override
                     public void onNext(HttpServerRequest<I> request) {
 
-                        final long startMillis = eventPublisher.publishingEnabled() ? newStartTimeMillis() : -1;
+                        final long startNanos = eventPublisher.publishingEnabled() ? newStartTimeNanos() : -1;
 
                         if (eventPublisher.publishingEnabled()) {
                             eventPublisher.onNewRequestReceived();
@@ -295,7 +295,7 @@ public final class HttpServerImpl<I, O> extends HttpServer<I, O> {
 
                         final HttpServerResponse<O> response = newResponse(request);
 
-                        final Subscription processingSubscription = handleRequest(request, startMillis, response)
+                        final Subscription processingSubscription = handleRequest(request, startNanos, response)
                                                                         .doOnTerminate( new Action0() {
                                                                             @Override
                                                                             public void call() {
@@ -321,7 +321,7 @@ public final class HttpServerImpl<I, O> extends HttpServer<I, O> {
             }
 
             @SuppressWarnings("unchecked")
-            private Observable<Void> handleRequest(HttpServerRequest<I> request, final long startTimeMillis,
+            private Observable<Void> handleRequest(HttpServerRequest<I> request, final long startTimeNanos,
                                                    final HttpServerResponse<O> response) {
                 Observable<Void> requestHandlingResult = null;
                 try {
@@ -352,15 +352,15 @@ public final class HttpServerImpl<I, O> extends HttpServer<I, O> {
                         public Subscriber<? super Void> call(final Subscriber<? super Void> o) {
 
                             if (eventPublisher.publishingEnabled()) {
-                                eventPublisher.onRequestHandlingStart(onEndMillis(startTimeMillis), MILLISECONDS);
+                                eventPublisher.onRequestHandlingStart(onEndNanos(startTimeNanos), NANOSECONDS);
                             }
 
                             return new Subscriber<Void>(o) {
                                 @Override
                                 public void onCompleted() {
                                     if (eventPublisher.publishingEnabled()) {
-                                        eventPublisher.onRequestHandlingSuccess(onEndMillis(startTimeMillis),
-                                                                                MILLISECONDS);
+                                        eventPublisher.onRequestHandlingSuccess(onEndNanos(startTimeNanos),
+                                                                                NANOSECONDS);
                                     }
                                     o.onCompleted();
                                 }
@@ -368,8 +368,8 @@ public final class HttpServerImpl<I, O> extends HttpServer<I, O> {
                                 @Override
                                 public void onError(Throwable e) {
                                     if (eventPublisher.publishingEnabled()) {
-                                        eventPublisher.onRequestHandlingFailed(onEndMillis(startTimeMillis),
-                                                                               MILLISECONDS, e);
+                                        eventPublisher.onRequestHandlingFailed(onEndNanos(startTimeNanos),
+                                                                               NANOSECONDS, e);
                                     }
                                     logger.error("Unexpected error processing a request.", e);
                                     o.onError(e);

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerToConnectionBridge.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerToConnectionBridge.java
@@ -52,7 +52,7 @@ public class HttpServerToConnectionBridge<C> extends AbstractHttpConnectionBridg
     }
 
     @Override
-    protected void beforeOutboundHeaderWrite(HttpMessage httpMsg, ChannelPromise promise, final long startTimeMillis) {
+    protected void beforeOutboundHeaderWrite(HttpMessage httpMsg, ChannelPromise promise, final long startTimeNanos) {
         HttpResponse response = (HttpResponse) httpMsg;
         if (eventPublisher.publishingEnabled()) {
             eventPublisher.onResponseWriteStart();
@@ -62,7 +62,7 @@ public class HttpServerToConnectionBridge<C> extends AbstractHttpConnectionBridg
 
     @Override
     protected void onOutboundLastContentWrite(LastHttpContent msg, ChannelPromise promise,
-                                              final long headerWriteStartTime) {
+                                              final long headerWriteStartTimeNanos) {
         final int _responseCode = lastSeenResponseCode;
 
         if (eventPublisher.publishingEnabled()) {
@@ -70,11 +70,11 @@ public class HttpServerToConnectionBridge<C> extends AbstractHttpConnectionBridg
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
                     if (eventPublisher.publishingEnabled()) {
-                        long endMillis = Clock.onEndMillis(headerWriteStartTime);
+                        long endNanos = Clock.onEndNanos(headerWriteStartTimeNanos);
                         if (future.isSuccess()) {
-                            eventPublisher.onResponseWriteSuccess(endMillis, MILLISECONDS, _responseCode);
+                            eventPublisher.onResponseWriteSuccess(endNanos, NANOSECONDS, _responseCode);
                         } else {
-                            eventPublisher.onResponseWriteFailed(endMillis, MILLISECONDS, future.cause());
+                            eventPublisher.onResponseWriteFailed(endNanos, NANOSECONDS, future.cause());
                         }
                     }
                 }
@@ -152,9 +152,9 @@ public class HttpServerToConnectionBridge<C> extends AbstractHttpConnectionBridg
     }
 
     @Override
-    protected void onContentReceiveComplete(long receiveStartTimeMillis) {
+    protected void onContentReceiveComplete(long receiveStartTimeNanos) {
         if (eventPublisher.publishingEnabled()) {
-            eventPublisher.onRequestReceiveComplete(Clock.onEndMillis(receiveStartTimeMillis), MILLISECONDS);
+            eventPublisher.onRequestReceiveComplete(Clock.onEndNanos(receiveStartTimeNanos), NANOSECONDS);
         }
     }
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/client/ClientConnectionToChannelBridge.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/client/ClientConnectionToChannelBridge.java
@@ -71,7 +71,7 @@ public class ClientConnectionToChannelBridge<R, W> extends AbstractConnectionToC
     private EventPublisher eventPublisher;
     private TcpClientEventListener eventListener;
     private final boolean isSecure;
-    private long connectStartTimeMillis;
+    private long connectStartTimeNanos;
 
     private ClientConnectionToChannelBridge(boolean isSecure) {
         super(HANDLER_NAME, CONNECTION_EVENT_LISTENER, EVENT_PUBLISHER);
@@ -140,7 +140,7 @@ public class ClientConnectionToChannelBridge<R, W> extends AbstractConnectionToC
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
                         ChannelPromise promise) throws Exception {
 
-        connectStartTimeMillis = Clock.newStartTimeMillis();
+        connectStartTimeNanos = Clock.newStartTimeNanos();
 
         if (eventPublisher.publishingEnabled()) {
             eventListener.onConnectStart();
@@ -149,11 +149,11 @@ public class ClientConnectionToChannelBridge<R, W> extends AbstractConnectionToC
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
                     if (eventPublisher.publishingEnabled()) {
-                        long endTimeMillis = Clock.onEndMillis(connectStartTimeMillis);
+                        long endTimeNanos = Clock.onEndNanos(connectStartTimeNanos);
                         if (!future.isSuccess()) {
-                            eventListener.onConnectFailed(endTimeMillis, MILLISECONDS, future.cause());
+                            eventListener.onConnectFailed(endTimeNanos, NANOSECONDS, future.cause());
                         } else {
-                            eventListener.onConnectSuccess(endTimeMillis, MILLISECONDS);
+                            eventListener.onConnectSuccess(endTimeNanos, NANOSECONDS);
                         }
                     }
                 }
@@ -217,7 +217,7 @@ public class ClientConnectionToChannelBridge<R, W> extends AbstractConnectionToC
     @SuppressWarnings("unchecked")
     private void onConnectFailedEvent(ConnectionCreationFailedEvent event) {
         if (eventPublisher.publishingEnabled()) {
-            eventListener.onConnectFailed(connectStartTimeMillis, MILLISECONDS, event.getThrowable());
+            eventListener.onConnectFailed(connectStartTimeNanos, NANOSECONDS, event.getThrowable());
         }
     }
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/server/ServerConnectionToChannelBridge.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/tcp/server/ServerConnectionToChannelBridge.java
@@ -97,14 +97,14 @@ public class ServerConnectionToChannelBridge<R, W> extends AbstractConnectionToC
 
         @Override
         public void onNext(final Connection<R, W> connection) {
-            final long startTimeMillis = eventPublisher.publishingEnabled() ? Clock.newStartTimeMillis() : -1;
+            final long startTimeNanos = eventPublisher.publishingEnabled() ? Clock.newStartTimeNanos() : -1;
             if (eventPublisher.publishingEnabled()) {
                 eventPublisher.onNewClientConnected();
             }
             Observable<Void> handledObservable;
             try {
                 if (eventPublisher.publishingEnabled()) {
-                    eventPublisher.onConnectionHandlingStart(Clock.onEndMillis(startTimeMillis), MILLISECONDS);
+                    eventPublisher.onConnectionHandlingStart(Clock.onEndNanos(startTimeNanos), NANOSECONDS);
                 }
                 handledObservable = connectionHandler.handle(connection);
             } catch (Throwable throwable) {
@@ -119,7 +119,7 @@ public class ServerConnectionToChannelBridge<R, W> extends AbstractConnectionToC
                 @Override
                 public void onCompleted() {
                     if (eventPublisher.publishingEnabled()) {
-                        eventPublisher.onConnectionHandlingSuccess(Clock.onEndMillis(startTimeMillis), MILLISECONDS);
+                        eventPublisher.onConnectionHandlingSuccess(Clock.onEndNanos(startTimeNanos), NANOSECONDS);
                     }
                     connection.closeNow();
                 }
@@ -128,7 +128,7 @@ public class ServerConnectionToChannelBridge<R, W> extends AbstractConnectionToC
                 public void onError(Throwable e) {
                     if (!(e instanceof ClosedChannelException)) {
                         if (eventPublisher.publishingEnabled()) {
-                            eventPublisher.onConnectionHandlingFailed(Clock.onEndMillis(startTimeMillis), MILLISECONDS,
+                            eventPublisher.onConnectionHandlingFailed(Clock.onEndNanos(startTimeNanos), NANOSECONDS,
                                                                       e);
                         }
                         /*Since, this is always reading input for new requests, it will always get a closed channel

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/internal/AbstractHttpConnectionBridgeTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/internal/AbstractHttpConnectionBridgeTest.java
@@ -585,18 +585,18 @@ public class AbstractHttpConnectionBridgeTest {
         }
 
         @Override
-        protected void onContentReceiveComplete(long receiveStartTimeMillis) {
+        protected void onContentReceiveComplete(long receiveStartTimeNanos) {
             // No Op
         }
 
         @Override
-        protected void beforeOutboundHeaderWrite(HttpMessage httpMsg, ChannelPromise promise, long startTimeMillis) {
+        protected void beforeOutboundHeaderWrite(HttpMessage httpMsg, ChannelPromise promise, long startTimeNanos) {
             // No Op
         }
 
         @Override
         protected void onOutboundLastContentWrite(LastHttpContent msg, ChannelPromise promise,
-                                                  long headerWriteStartTime) {
+                                                  long headerWriteStartTimeNanos) {
             // No Op
         }
 


### PR DESCRIPTION
Today all durations reported to Eventlisteners are milliseconds. This change will make it possible for more finer grained insights, if required.
