### PR TITLE
SSE now works with preceding channel handlers such as SSL

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SSEInboundHandler.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SSEInboundHandler.java
@@ -75,7 +75,7 @@ public class SSEInboundHandler extends SimpleChannelInboundHandler<Object> {
 
             ChannelPipeline pipeline = ctx.channel().pipeline();
             if (!HttpHeaders.isTransferEncodingChunked((HttpResponse) msg)) {
-                pipeline.addFirst(SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
+                pipeline.addBefore(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
                 /*
                  * If there are buffered messages in the previous handler at the time this message is read, we would
                  * not be able to convert the content into an SseEvent. For this reason, we also add the decoder after

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SSEInboundHandler.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SSEInboundHandler.java
@@ -74,18 +74,7 @@ public class SSEInboundHandler extends SimpleChannelInboundHandler<Object> {
             ctx.channel().attr(ClientRequestResponseConverter.DISCARD_CONNECTION).set(true); // SSE traffic should always discard connection on close.
 
             ChannelPipeline pipeline = ctx.channel().pipeline();
-            if (!HttpHeaders.isTransferEncodingChunked((HttpResponse) msg)) {
-                pipeline.addBefore(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
-                /*
-                 * If there are buffered messages in the previous handler at the time this message is read, we would
-                 * not be able to convert the content into an SseEvent. For this reason, we also add the decoder after
-                 * this handler, so that we can handle the buffered messages.
-                 * See the class level javadoc for more details.
-                 */
-                pipeline.addAfter(NAME, SSE_DECODER_POST_INBOUND_HANDLER, new ServerSentEventDecoder());
-            } else {
-                pipeline.addAfter(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
-            }
+            pipeline.addAfter(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
             ctx.fireChannelRead(msg);
         } else if (msg instanceof LastHttpContent) {
             LastHttpContent lastHttpContent = (LastHttpContent) msg;

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SseChannelHandler.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SseChannelHandler.java
@@ -70,7 +70,7 @@ public class SseChannelHandler extends SimpleChannelInboundHandler<Object> {
 
             ChannelPipeline pipeline = ctx.channel().pipeline();
             if (!HttpHeaders.isTransferEncodingChunked((HttpResponse) msg)) {
-                pipeline.addFirst(SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
+                pipeline.addBefore(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
                 /*
                  * If there are buffered messages in the previous handler at the time this message is read, we would
                  * not be able to convert the content into an SseEvent. For this reason, we also add the decoder after

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SseChannelHandler.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/SseChannelHandler.java
@@ -69,18 +69,7 @@ public class SseChannelHandler extends SimpleChannelInboundHandler<Object> {
             ctx.channel().attr(ClientRequestResponseConverter.DISCARD_CONNECTION).set(true); // SSE traffic should always discard connection on close.
 
             ChannelPipeline pipeline = ctx.channel().pipeline();
-            if (!HttpHeaders.isTransferEncodingChunked((HttpResponse) msg)) {
-                pipeline.addBefore(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
-                /*
-                 * If there are buffered messages in the previous handler at the time this message is read, we would
-                 * not be able to convert the content into an SseEvent. For this reason, we also add the decoder after
-                 * this handler, so that we can handle the buffered messages.
-                 * See the class level javadoc for more details.
-                 */
-                pipeline.addAfter(NAME, SSE_DECODER_POST_INBOUND_HANDLER, new ServerSentEventDecoder());
-            } else {
-                pipeline.addAfter(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
-            }
+            pipeline.addAfter(NAME, SSE_DECODER_HANDLER_NAME, new ServerSentEventDecoder());
             ctx.fireChannelRead(msg);
         } else if (msg instanceof LastHttpContent) {
             LastHttpContent lastHttpContent = (LastHttpContent) msg;


### PR DESCRIPTION
Previously it was not possible to connect to a SSE server that also used SSL (https). The reason is that `SSEInboundHandler` / `SseChannelHandler` added the `ServerSentEventDecoder` before the SSL decoder handler in the pipeline chain which made `ServerSentEventDecoder` operate on encrypted data. This pull requests corrects this by not adding the `ServerSentEventDecoder` first in the pipeline.
