### PR TITLE
Fixes #402 (Remove listener on unsubscribe)

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/AbstractConnectionToChannelBridge.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/AbstractConnectionToChannelBridge.java
@@ -265,7 +265,7 @@ public abstract class AbstractConnectionToChannelBridge<R, W> extends Backpressu
 
     private void newConnectionInputSubscriber(final Channel channel, final Subscriber<? super R> subscriber,
                                               final Connection<R, W> connection) {
-        final Subscriber<? super R> connInputSub = null == readProducer? null : readProducer.subscriber;
+        final Subscriber<? super R> connInputSub = null == readProducer ? null : readProducer.subscriber;
         if (isValidToEmit(connInputSub)) {
             /*Allow only once concurrent input subscriber but allow concatenated subscribers*/
             subscriber.onError(ONLY_ONE_CONN_INPUT_SUB_ALLOWED);

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/ChannelOperations.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/ChannelOperations.java
@@ -263,4 +263,11 @@ public interface ChannelOperations<W> {
      * {@code Observable}
      */
     void closeNow();
+
+    /**
+     * Returns an {@link Observable} that completes when this connection is closed.
+     *
+     * @return An {@link Observable} that completes when this connection is closed.
+     */
+    Observable<Void> closeListener();
 }

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/Connection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/Connection.java
@@ -128,26 +128,6 @@ public abstract class Connection<R, W> implements ChannelOperations<W> {
         return nettyChannel;
     }
 
-    /**
-     * Returns an {@link Observable} that completes when this connection is closed.
-     *
-     * @return An {@link Observable} that completes when this connection is closed.
-     */
-    public Observable<Void> closeListener() {
-        return Observable.create(new OnSubscribe<Void>() {
-            @Override
-            public void call(final Subscriber<? super Void> subscriber) {
-                nettyChannel.closeFuture()
-                            .addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) throws Exception {
-                                    subscriber.onCompleted();
-                                }
-                            });
-            }
-        });
-    }
-
     /*
      * In order to make sure that the connection is correctly initialized, the listener needs to be added post
      * constructor. Otherwise, there is a race-condition of the channel closed before the connection is completely

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/ConnectionImpl.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/ConnectionImpl.java
@@ -123,6 +123,11 @@ public final class ConnectionImpl<R, W> extends Connection<R, W> {
         delegate.closeNow();
     }
 
+    @Override
+    public Observable<Void> closeListener() {
+        return delegate.closeListener();
+    }
+
     public static <R, W> ConnectionImpl<R, W> create(Channel nettyChannel, ConnectionEventListener eventListener,
                                                      EventPublisher eventPublisher) {
         final ConnectionImpl<R, W> toReturn = new ConnectionImpl<>(nettyChannel, eventListener, eventPublisher);

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/SubscriberToChannelFutureBridge.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/SubscriberToChannelFutureBridge.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * A bridge to connect a {@link Subscriber} to a {@link ChannelFuture} so that when the {@code subscriber} is
+ * unsubscribed, the listener will get removed from the {@code future}. Failure to do so for futures that are long
+ * living, eg: {@link Channel#closeFuture()} will lead to a memory leak where the attached listener will be in the
+ * listener queue of the future till the channel closes.
+ *
+ * In order to bridge the future and subscriber, {@link #bridge(ChannelFuture, Subscriber)} must be called.
+ */
+public abstract class SubscriberToChannelFutureBridge implements ChannelFutureListener {
+
+    @Override
+    public final void operationComplete(ChannelFuture future) throws Exception {
+        if (future.isSuccess()) {
+            doOnSuccess(future);
+        } else {
+            doOnFailure(future, future.cause());
+        }
+    }
+
+    protected abstract void doOnSuccess(ChannelFuture future);
+
+    protected abstract void doOnFailure(ChannelFuture future, Throwable cause);
+
+    /**
+     * Bridges the passed subscriber and future, which means the following:
+     *
+     * <ul>
+     <li>Add this listener to the passed future.</li>
+     <li>Add a callback to the subscriber, such that on unsubscribe this listener is removed from the future.</li>
+     </ul>
+     *
+     * @param future Future to bridge.
+     * @param subscriber Subscriber to connect to the future.
+     */
+    public void bridge(final ChannelFuture future, Subscriber<?> subscriber) {
+        future.addListener(this);
+        subscriber.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                future.removeListener(SubscriberToChannelFutureBridge.this);
+            }
+        }));
+    }
+}

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnection.java
@@ -192,6 +192,11 @@ public class PooledConnection<R, W> extends Connection<R, W> {
         });
     }
 
+    @Override
+    public Observable<Void> closeListener() {
+        return unpooledDelegate.closeListener();
+    }
+
     /**
      * Discards this connection, to be called when this connection will never be used again.
      *

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/DefaultChannelOperationsTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/DefaultChannelOperationsTest.java
@@ -240,6 +240,23 @@ public class DefaultChannelOperationsTest {
         channelOpRule.verifyOutboundMessages(expected);
     }
 
+    @Test(timeout = 60000)
+    public void testCloseListener() throws Exception {
+        Observable<Void> closeListener = channelOpRule.channelOperations.closeListener();
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        closeListener.subscribe(subscriber);
+
+        subscriber.assertNoTerminalEvent();
+
+        subscriber.unsubscribe();
+
+        subscriber.assertNoTerminalEvent();
+
+        channelOpRule.channel.close().sync();
+
+        subscriber.assertNoTerminalEvent();
+    }
+
     public static class ChannelOpRule extends ExternalResource {
 
         private DefaultChannelOperations<ByteBuf> channelOperations;

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/SubscriberToChannelFutureBridgeTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/SubscriberToChannelFutureBridgeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.channel.ChannelFuture;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockito.Mockito;
+import rx.observers.TestSubscriber;
+
+public class SubscriberToChannelFutureBridgeTest {
+
+    @Rule
+    public final BridgeRule rule = new BridgeRule();
+
+    @Test(timeout = 60000)
+    public void testBridge() throws Exception {
+
+        rule.subscriber.unsubscribe();
+
+        Mockito.verify(rule.future).addListener(rule.bridge);
+        Mockito.verify(rule.future).removeListener(rule.bridge);
+    }
+
+    @Test(timeout = 60000)
+    public void testSuccess() throws Exception {
+        rule.completeFuture();
+        rule.subscriber.assertTerminalEvent();
+        rule.subscriber.assertNoErrors();
+    }
+
+    @Test(timeout = 60000)
+    public void testError() throws Exception {
+        rule.failFuture();
+        rule.subscriber.assertTerminalEvent();
+        rule.subscriber.assertError(IllegalStateException.class);
+    }
+
+    public static class BridgeRule extends ExternalResource {
+
+        public TestSubscriber<Void> subscriber;
+        public SubscriberToChannelFutureBridge bridge;
+        private ChannelFuture future;
+        private volatile boolean futureTerminated;
+
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    subscriber = new TestSubscriber<>();
+                    bridge = new SubscriberToChannelFutureBridge() {
+
+                        @Override
+                        protected void doOnSuccess(ChannelFuture future) {
+                            subscriber.onCompleted();
+                        }
+
+                        @Override
+                        protected void doOnFailure(ChannelFuture future, Throwable cause) {
+                            subscriber.onError(cause);
+                        }
+                    };
+
+                    future = Mockito.mock(ChannelFuture.class);
+
+                    bridge.bridge(future, subscriber);
+                    base.evaluate();
+                }
+            };
+        }
+
+        public void completeFuture() throws Exception {
+            if (futureTerminated) {
+                throw new IllegalStateException("Channel future is already terminated");
+            }
+            futureTerminated = true;
+            Mockito.when(future.isSuccess()).thenReturn(true);
+            bridge.operationComplete(future);
+        }
+
+        public void failFuture() throws Exception {
+            if (futureTerminated) {
+                throw new IllegalStateException("Channel future is already terminated");
+            }
+            futureTerminated = true;
+            Mockito.when(future.isSuccess()).thenReturn(false);
+            Mockito.when(future.cause()).thenReturn(new IllegalStateException("Force terminate"));
+            bridge.operationComplete(future);
+        }
+    }
+
+}

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/UnusableConnection.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/UnusableConnection.java
@@ -113,6 +113,11 @@ final class UnusableConnection<R, W> extends Connection<R, W> {
         throw new IllegalStateException("Connection is not usable.");
     }
 
+    @Override
+    public Observable<Void> closeListener() {
+        throw new IllegalStateException("Connection is not usable.");
+    }
+
     public static Connection<?, ?> create() {
         return new UnusableConnection<>(new EmbeddedChannel(), null, null);
     }


### PR DESCRIPTION
In multiple places there was a listener added to netty's `closeFuture()` to listen for close events. However, on unsubscription of the subscriber that triggeredd the attachment of the listener, the listener was not removed.
