### PR TITLE
Eager subscriptions to WS connection input in WSHandler causes upgrade failures

### DIFF
--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/ws/server/Ws7To13UpgradeHandler.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/ws/server/Ws7To13UpgradeHandler.java
@@ -42,6 +42,7 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
+import rx.functions.Func0;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpHeaderValues.*;
@@ -88,7 +89,12 @@ public final class Ws7To13UpgradeHandler extends ChannelDuplexHandler {
                                    pipeline.remove(HttpServerEncoder.getName());
                                }
                            })
-                           .concatWith(wsUpEvt.handler.handle(new WebSocketConnection(wsConn)))
+                           .concatWith(Observable.defer(new Func0<Observable<Void>>() {
+                               @Override
+                               public Observable<Void> call() {
+                                   return wsUpEvt.handler.handle(new WebSocketConnection(wsConn));
+                               }
+                           }))
                            .concatWith(Observable.create(new OnSubscribe<Void>() {
                                @Override
                                public void call(Subscriber<? super Void> sub) {

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/ws/server/WSEagerInputSubscriptionHandlerTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/ws/server/WSEagerInputSubscriptionHandlerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.protocol.http.ws.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+import io.reactivex.netty.protocol.http.ws.WebSocketConnection;
+import io.reactivex.netty.protocol.http.ws.client.WebSocketResponse;
+import org.junit.Test;
+import rx.Observable;
+import rx.functions.Func1;
+import rx.observers.TestSubscriber;
+
+public class WSEagerInputSubscriptionHandlerTest {
+
+    @Test(timeout = 60000)
+    public void testHandlerSubscribesEagerly() throws Exception {
+        HttpServer<ByteBuf, ByteBuf> server =
+                HttpServer.newServer()
+                          .start(new RequestHandler<ByteBuf, ByteBuf>() {
+                              @Override
+                              public Observable<Void> handle(HttpServerRequest<ByteBuf> request,
+                                                             HttpServerResponse<ByteBuf> response) {
+                                  if (request.isWebSocketUpgradeRequested()) {
+                                      return response.acceptWebSocketUpgrade(
+                                              new WebSocketHandler() {
+                                                  @Override
+                                                  public Observable<Void> handle(WebSocketConnection wsConnection) {
+                                                      wsConnection.getInput().subscribe();
+                                                      return Observable.never();
+                                                  }
+                                              });
+                                  } else {
+                                      return response.setStatus(HttpResponseStatus.NOT_FOUND);
+                                  }
+                              }
+                          });
+
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        HttpClient.newClient(server.getServerAddress())
+                  .createGet("/ws")
+                  .requestWebSocketUpgrade()
+                  .flatMap(new Func1<WebSocketResponse<ByteBuf>, Observable<Void>>() {
+                      @Override
+                      public Observable<Void> call(WebSocketResponse<ByteBuf> wsResp) {
+                          if (wsResp.isUpgraded()) {
+                              return Observable.empty();
+                          }
+                          return Observable.error(new IllegalStateException("WebSocket upgrade not accepted."));
+                      }
+                  })
+                  .subscribe(subscriber);
+
+        subscriber.awaitTerminalEvent();
+        subscriber.assertNoErrors();
+    }
+}


### PR DESCRIPTION
`WebSocketHandler.handle()` was called before WS upgrade. This is usually not an issue because the `handle()` processing should be lazy (start only on subscription). However, for any `WebSocketHandler` that does an eager subscription to `WebSocketConnection.getInput()`, the HTTP upgrade request content will be sent to that subscriber. This will cause the following issues:
- WebSocketHandler receives illegal content (not a WS frame)
- When WS upgrade handler discards content, the subscription will be buffered (to sequence pipelined requests) till the `WebSocketConnection.getInput()` unsubscribes. This will cause `request.discardContent()` not complete till the other subscriber unsubscribes, which will delay the sent of upgrade response.
  
  This change, defers the call to `WebSocketHandler.handle()` till subscription, which happens after the upgrade response is sent.
