### PR TITLE
Adding TCP Server interceptors.

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/AbstractDelegatingConnection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/AbstractDelegatingConnection.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.reactivex.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.FileRegion;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.internal.TypeParameterMatcher;
+import io.reactivex.netty.HandlerNames;
+import rx.Observable;
+import rx.annotations.Beta;
+import rx.functions.Action1;
+import rx.functions.Func1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An implementation of {@link Connection} primarily intended to transform read and write types of a connection and
+ * delegate all the other operations to a provided connection implementation.
+ *
+ * <h2>Manipulating writes</h2>
+ *
+ * In order to manipulate writes to the connection, this class provides a {@link Transformer} abstraction that produces
+ * one or more items for every item transformed.
+ *
+ * These transformers are useful when the produced item requires {@link ByteBuf} allocations, for which the
+ * transformation is invoked by passing a {@link ByteBufAllocator}. For transformations that do not need a
+ * {@link ByteBuf} allocation, can be done by overriding the appropriate methods in this class.
+ *
+ * <h2>Manipulating reads</h2>
+ *
+ * Reads can be manipulated by implementing the {@link #getInput()} method.
+ *
+ * @param <R> Type of objects read from the underlying connection.
+ * @param <W> Type of objects written to the underlying connection.
+ * @param <RR> Type of objects read from this connection.
+ * @param <WW> Type of objects written to this connection.
+ */
+@Beta
+public abstract class AbstractDelegatingConnection<R, W, RR, WW> extends Connection<RR, WW> {
+
+    private static final AttributeKey<List<Transformer>> transformerKey =
+            AttributeKey.newInstance("_rxnetty-transformer-1-*-key");
+
+    private final Connection<R, WW> delegate;
+
+    protected AbstractDelegatingConnection(Connection<R, WW> delegate) {
+        super(delegate.unsafeNettyChannel());
+        this.delegate = delegate;
+    }
+
+    protected AbstractDelegatingConnection(Connection<R, W> delegate, final Transformer<WW, W> transformer) {
+        super(delegate.unsafeNettyChannel());
+        this.delegate = delegate.pipelineConfigurator(new Action1<ChannelPipeline>() {
+            @Override
+            public void call(ChannelPipeline pipeline) {
+                final List<Transformer> finalTrans = getTransformersFromChannel(pipeline, transformer, transformerKey);
+                MessageToMessageEncoder<WW> encoder = new MessageToMessageEncoder<WW>() {
+
+                    @Override
+                    protected void encode(ChannelHandlerContext ctx, WW msg, List<Object> out) throws Exception {
+                        List<Object> lastTransform = Collections.singletonList((Object) msg);
+
+                        for (Transformer transformer : finalTrans) {
+                            List<Object> thisTransformResult = null;
+                            for (Object toTransform : lastTransform) {
+                                List<Object> transformed = transform(ctx, toTransform, transformer);
+                                if (null == thisTransformResult) {
+                                    thisTransformResult = new ArrayList<>();
+                                }
+
+                                thisTransformResult.addAll(transformed);
+                            }
+                            lastTransform = null != thisTransformResult ? thisTransformResult : lastTransform;
+                        }
+
+                        out.addAll(lastTransform);
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    private List<Object> transform(ChannelHandlerContext ctx, Object msg, Transformer transformer) {
+                        return transformer.transform(msg, ctx.alloc());
+                    }
+
+                    @Override
+                    public boolean acceptOutboundMessage(Object msg) throws Exception {
+                        return transformer.acceptMessage(msg);
+                    }
+                };
+
+                addOrReplaceEncoder("write-transformer-1-*-dynamic", pipeline, encoder);
+            }
+        });
+    }
+
+    @Override
+    public abstract Observable<RR> getInput();
+
+    @Override
+    public Observable<Void> write(Observable<WW> msgs) {
+        return delegate.write(msgs);
+    }
+
+    @Override
+    public Observable<Void> write(Observable<WW> msgs, Func1<WW, Boolean> flushSelector) {
+        return delegate.write(msgs, flushSelector);
+    }
+
+    @Override
+    public Observable<Void> writeAndFlushOnEach(Observable<WW> msgs) {
+        return delegate.writeAndFlushOnEach(msgs);
+    }
+
+    @Override
+    public Observable<Void> writeBytes(Observable<byte[]> msgs) {
+        return delegate.writeBytes(msgs);
+    }
+
+    @Override
+    public Observable<Void> writeBytes(Observable<byte[]> msgs, Func1<byte[], Boolean> flushSelector) {
+        return delegate.writeBytes(msgs, flushSelector);
+    }
+
+    @Override
+    public Observable<Void> writeBytesAndFlushOnEach(Observable<byte[]> msgs) {
+        return delegate.writeBytesAndFlushOnEach(msgs);
+    }
+
+    @Override
+    public Observable<Void> writeFileRegion(Observable<FileRegion> msgs) {
+        return delegate.writeFileRegion(msgs);
+    }
+
+    @Override
+    public Observable<Void> writeFileRegion(Observable<FileRegion> msgs,
+                                            Func1<FileRegion, Boolean> flushSelector) {
+        return delegate.writeFileRegion(msgs, flushSelector);
+    }
+
+    @Override
+    public Observable<Void> writeFileRegionAndFlushOnEach(Observable<FileRegion> msgs) {
+        return delegate.writeFileRegionAndFlushOnEach(msgs);
+    }
+
+    @Override
+    public Observable<Void> writeString(Observable<String> msgs) {
+        return delegate.writeString(msgs);
+    }
+
+    @Override
+    public Observable<Void> writeString(Observable<String> msgs,
+                                        Func1<String, Boolean> flushSelector) {
+        return delegate.writeString(msgs, flushSelector);
+    }
+
+    @Override
+    public Observable<Void> writeStringAndFlushOnEach(Observable<String> msgs) {
+        return delegate.writeStringAndFlushOnEach(msgs);
+    }
+
+    @Override
+    public void flush() {
+        delegate.flush();
+    }
+
+    @Override
+    public void closeNow() {
+        delegate.closeNow();
+    }
+
+    @Override
+    public Observable<Void> close(boolean flush) {
+        return delegate.close(flush);
+    }
+
+    @Override
+    public Observable<Void> close() {
+        return delegate.close();
+    }
+
+    @Override
+    public ChannelPipeline getChannelPipeline() {
+        return delegate.getChannelPipeline();
+    }
+
+    @Override
+    public MarkAwarePipeline getResettableChannelPipeline() {
+        return delegate.getResettableChannelPipeline();
+    }
+
+    @Override
+    public Observable<Void> ignoreInput() {
+        return delegate.ignoreInput();
+    }
+
+    @Override
+    public Channel unsafeNettyChannel() {
+        return delegate.unsafeNettyChannel();
+    }
+
+    @Override
+    public Observable<Void> closeListener() {
+        return delegate.closeListener();
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerAfter(String baseName, String name,
+                                                                  ChannelHandler handler) {
+        return delegate.addChannelHandlerAfter(baseName, name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerAfter(EventExecutorGroup group,
+                                                                  String baseName, String name,
+                                                                  ChannelHandler handler) {
+        return delegate.addChannelHandlerAfter(group, baseName, name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerBefore(String baseName, String name,
+                                                                   ChannelHandler handler) {
+        return delegate.addChannelHandlerBefore(baseName, name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerBefore(EventExecutorGroup group,
+                                                                   String baseName, String name,
+                                                                   ChannelHandler handler) {
+        return delegate.addChannelHandlerBefore(group, baseName, name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerFirst(EventExecutorGroup group,
+                                                                  String name, ChannelHandler handler) {
+        return delegate.addChannelHandlerFirst(group, name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerFirst(String name, ChannelHandler handler) {
+        return delegate.addChannelHandlerFirst(name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerLast(EventExecutorGroup group,
+                                                               String name, ChannelHandler handler) {
+        return delegate.addChannelHandlerLast(group, name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> addChannelHandlerLast(String name, ChannelHandler handler) {
+        return delegate.addChannelHandlerLast(name, handler);
+    }
+
+    @Override
+    public <RRR, WWW> Connection<RRR, WWW> pipelineConfigurator(Action1<ChannelPipeline> pipelineConfigurator) {
+        return delegate.pipelineConfigurator(pipelineConfigurator);
+    }
+
+    private static void addOrReplaceEncoder(String handlerName, ChannelPipeline pipeline,
+                                            MessageToMessageEncoder<?> encoder) {
+        synchronized (pipeline.channel()) {
+            ChannelHandler existing = pipeline.get(handlerName);
+            if (null == existing) {
+                pipeline.addAfter(HandlerNames.PrimitiveConverter.getName(), handlerName, encoder);
+            } else {
+                pipeline.replace(handlerName, handlerName, encoder);
+            }
+        }
+    }
+
+    private static <T> List<T> getTransformersFromChannel(ChannelPipeline pipeline, T transformer,
+                                                          AttributeKey<List<T>> key) {
+
+        List<T> trans;
+
+        /*Only one AbstractDelegatingConnection instance can modify the attribute to hold the transformers
+         at a time. Once the attribute is set, the transformers list contents do not change*/
+        synchronized (pipeline.channel()) {
+            trans = pipeline.channel().attr(key).get();
+            if (null == trans) {
+                trans = Collections.singletonList(transformer);
+            } else {
+                List<T> newTrans = new ArrayList<>(trans.size() + 1);
+                newTrans.add(transformer);
+                newTrans.addAll(trans);
+                trans = Collections.unmodifiableList(newTrans);
+            }
+
+            pipeline.channel().attr(key).set(trans);
+        }
+
+        return trans;
+    }
+
+    /**
+     * A transformer that produces one or more items for every item transformed.
+     *
+     * @param <X> Type of object to be transformed.
+     * @param <XX> Type of object produced after transformation.
+     */
+    public static abstract class Transformer<X, XX> {
+
+        private final TypeParameterMatcher matcher;
+
+        protected Transformer() {
+            matcher = TypeParameterMatcher.find(this, Transformer.class, "X");
+        }
+
+        protected final boolean acceptMessage(Object msg) {
+            return matcher.match(msg);
+        }
+
+        public abstract List<XX> transform(X toTransform, ByteBufAllocator allocator);
+
+    }
+}

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/Connection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/Connection.java
@@ -19,12 +19,15 @@ package io.reactivex.netty.channel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutorGroup;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
+import rx.functions.Action1;
 import rx.functions.Func1;
 
 /**
@@ -97,6 +100,148 @@ public abstract class Connection<R, W> implements ChannelOperations<W> {
             }
         }).ignoreElements();
     }
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified handler is added at
+     * the first position of the pipeline as specified by {@link ChannelPipeline#addFirst(String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param name Name of the handler.
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerFirst(String name, ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified handler is added at
+     * the first position of the pipeline as specified by
+     * {@link ChannelPipeline#addFirst(EventExecutorGroup, String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param group   the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler} methods
+     * @param name     the name of the handler to append
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerFirst(EventExecutorGroup group, String name,
+                                                                       ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified handler is added at
+     * the last position of the pipeline as specified by {@link ChannelPipeline#addLast(String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param name Name of the handler.
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW>  addChannelHandlerLast(String name, ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified handler is added at
+     * the last position of the pipeline as specified by
+     * {@link ChannelPipeline#addLast(EventExecutorGroup, String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param group   the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler} methods
+     * @param name     the name of the handler to append
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerLast(EventExecutorGroup group, String name,
+                                                                      ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified
+     * handler is added before an existing handler with the passed {@code baseName} in the pipeline as specified by
+     * {@link ChannelPipeline#addBefore(String, String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param baseName  the name of the existing handler
+     * @param name Name of the handler.
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerBefore(String baseName, String name,
+                                                                        ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified
+     * handler is added before an existing handler with the passed {@code baseName} in the pipeline as specified by
+     * {@link ChannelPipeline#addBefore(EventExecutorGroup, String, String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param group   the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}
+     *                 methods
+     * @param baseName  the name of the existing handler
+     * @param name     the name of the handler to append
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerBefore(EventExecutorGroup group, String baseName,
+                                                                        String name, ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified
+     * handler is added after an existing handler with the passed {@code baseName} in the pipeline as specified by
+     * {@link ChannelPipeline#addAfter(String, String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param baseName  the name of the existing handler
+     * @param name Name of the handler.
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerAfter(String baseName, String name,
+                                                                       ChannelHandler handler);
+
+    /**
+     * Adds a {@link ChannelHandler} to {@link ChannelPipeline} for this connection. The specified
+     * handler is added after an existing handler with the passed {@code baseName} in the pipeline as specified by
+     * {@link ChannelPipeline#addAfter(EventExecutorGroup, String, String, ChannelHandler)}
+     *
+     * <em>For better flexibility of pipeline modification, the method {@link #pipelineConfigurator(Action1)} will be
+     * more convenient.</em>
+     *
+     * @param group   the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler} methods
+     * @param baseName  the name of the existing handler
+     * @param name     the name of the handler to append
+     * @param handler Handler instance to add.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> addChannelHandlerAfter(EventExecutorGroup group, String baseName,
+                                                                       String name, ChannelHandler handler);
+
+    /**
+     * Configures the {@link ChannelPipeline} for this channel, using the passed {@code pipelineConfigurator}.
+     *
+     * @param pipelineConfigurator Action to configure {@link ChannelPipeline}.
+     *
+     * @return {@code this}.
+     */
+    public abstract <RR, WW> Connection<RR, WW> pipelineConfigurator(Action1<ChannelPipeline> pipelineConfigurator);
 
     /**
      * Returns the {@link MarkAwarePipeline} for this connection, changes to which can be reverted at any point in time.

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/ConnectionImpl.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/ConnectionImpl.java
@@ -17,10 +17,14 @@
 package io.reactivex.netty.channel;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FileRegion;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.events.ConnectionEventListener;
 import io.reactivex.netty.events.EventPublisher;
 import rx.Observable;
+import rx.functions.Action1;
 import rx.functions.Func1;
 
 /**
@@ -140,5 +144,68 @@ public final class ConnectionImpl<R, W> extends Connection<R, W> {
         final ConnectionImpl<R, W> toReturn = new ConnectionImpl<>(nettyChannel, delegate);
         toReturn.connectCloseToChannelClose();
         return toReturn;
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerFirst(String name, ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addFirst(name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerFirst(EventExecutorGroup group, String name,
+                                                              ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addFirst(group, name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerLast(String name, ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addLast(name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerLast(EventExecutorGroup group, String name,
+                                                             ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addLast(group, name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerBefore(String baseName, String name, ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addBefore(baseName, name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerBefore(EventExecutorGroup group, String baseName, String name,
+                                                               ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addBefore(group, baseName, name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerAfter(String baseName, String name, ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addAfter(baseName, name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerAfter(EventExecutorGroup group, String baseName, String name,
+                                                              ChannelHandler handler) {
+        getResettableChannelPipeline().markIfNotYetMarked().addAfter(group, baseName, name, handler);
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> pipelineConfigurator(Action1<ChannelPipeline> pipelineConfigurator) {
+        pipelineConfigurator.call(getResettableChannelPipeline().markIfNotYetMarked());
+        return cast();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <RR, WW> Connection<RR, WW> cast() {
+        return (Connection<RR, WW>) this;
     }
 }

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnection.java
@@ -17,9 +17,11 @@
 package io.reactivex.netty.client.pool;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FileRegion;
 import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.Connection;
 import io.reactivex.netty.client.ClientConnectionToChannelBridge;
 import io.reactivex.netty.client.ClientConnectionToChannelBridge.ConnectionReuseEvent;
@@ -195,6 +197,59 @@ public class PooledConnection<R, W> extends Connection<R, W> {
     @Override
     public Observable<Void> closeListener() {
         return unpooledDelegate.closeListener();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerAfter(String baseName, String name,
+                                                              ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerAfter(baseName, name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerAfter(EventExecutorGroup group,
+                                                              String baseName, String name,
+                                                              ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerAfter(group, baseName, name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerBefore(String baseName, String name,
+                                                               ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerBefore(baseName, name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerBefore(EventExecutorGroup group,
+                                                               String baseName, String name,
+                                                               ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerBefore(group, baseName, name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerFirst(EventExecutorGroup group,
+                                                              String name, ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerFirst(group, name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerFirst(String name, ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerFirst(name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerLast(EventExecutorGroup group,
+                                                             String name, ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerLast(group, name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerLast(String name, ChannelHandler handler) {
+        return unpooledDelegate.addChannelHandlerLast(name, handler);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> pipelineConfigurator(Action1<ChannelPipeline> pipelineConfigurator) {
+        return unpooledDelegate.pipelineConfigurator(pipelineConfigurator);
     }
 
     /**

--- a/rxnetty-examples/TCP.md
+++ b/rxnetty-examples/TCP.md
@@ -29,5 +29,15 @@ demonstrates how to write failure detection logic to detect unhealthy hosts. Thi
 [Load Balancing Client](src/main/java/io/reactivex/netty/examples/tcp/loadbalancing/TcpLoadBalancingClient.java)
 and a [Load Balancer](src/main/java/io/reactivex/netty/examples/tcp/loadbalancing/TcpLoadBalancer.java)
 
+- __Simple interceptor__: A simple interceptor for TCP server to demonstrate sending an initial hello message before
+the actual connection handling starts. This example constitutes of an 
+[Intercepting Server](src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingServer.java)
+and an [Intercepting Client](src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingClient.java)
+
+- __Interceptors with transformation__: An interceptor for TCP server to demonstrate transformation of input and output
+on a connection. This example constitutes of an 
+[Intercepting Server](src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingServer.java)
+and an [Intercepting Client](src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingClient.java)
+
 
 

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingClient.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.examples.tcp.interceptors.simple;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.examples.AbstractClientExample;
+import io.reactivex.netty.protocol.tcp.client.TcpClient;
+import rx.Observable;
+
+import java.net.SocketAddress;
+import java.nio.charset.Charset;
+
+/**
+ * A client to test {@link InterceptingServer}. This client is provided here only for completeness of the example,
+ * otherwise, it is mostly the same as {@link io.reactivex.netty.examples.tcp.echo.EchoClient}.
+ *
+ * @see InterceptingServer Default server for this client.
+ */
+public final class InterceptingClient extends AbstractClientExample {
+
+    public static void main(String[] args) {
+
+        /*
+         * Retrieves the server address, using the following algorithm:
+         * <ul>
+             <li>If any arguments are passed, then use the first argument as the server port.</li>
+             <li>If available, use the second argument as the server host, else default to localhost</li>
+             <li>Otherwise, start the passed server class and use that address.</li>
+         </ul>
+         */
+        SocketAddress serverAddress = getServerAddress(InterceptingServer.class, args);
+
+        /*Create a new client for the server address*/
+        TcpClient.<ByteBuf, ByteBuf>newClient(serverAddress)
+                /*Create a new connection request, each subscription creates a new connection*/
+                 .createConnectionRequest()
+                /*Upon successful connection, write "Hello World" and listen to input*/
+                 .flatMap(connection ->
+                                  /*Write the message*/
+                                  connection.writeString(Observable.just("Hello World!"))
+                                          /*Since, write returns a Void stream, cast it to ByteBuf to be able to merge
+                                          with the input*/
+                                          .cast(ByteBuf.class)
+                                          /*Upon successful completion of the write, subscribe to the connection input*/
+                                          .concatWith(connection.getInput())
+                 )
+                /*Server sends an initial hello and then echoes*/
+                 .take(2)
+                /*Convert each ByteBuf to a string*/
+                 .map(bb -> bb.toString(Charset.defaultCharset()))
+                /*Block till the response comes to avoid JVM exit.*/
+                 .toBlocking()
+                /*Print each content chunk*/
+                 .forEach(logger::info);
+    }
+}

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/simple/InterceptingServer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.examples.tcp.interceptors.simple;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.reactivex.netty.examples.AbstractServerExample;
+import io.reactivex.netty.examples.tcp.interceptors.transformation.TransformingInterceptorsServer;
+import io.reactivex.netty.protocol.tcp.server.ConnectionHandler;
+import io.reactivex.netty.protocol.tcp.server.TcpServer;
+import io.reactivex.netty.protocol.tcp.server.TcpServerInterceptorChain;
+import io.reactivex.netty.protocol.tcp.server.TcpServerInterceptorChain.Interceptor;
+import rx.Observable;
+
+import java.nio.charset.Charset;
+
+/**
+ * A TCP echo server that echoes all input it receives on any connection, after prepending the input with a fixed
+ * string. <p>
+ *
+ * This example demonstrates the usage of simple server side interceptors which does not do any data transformations.
+ * For interceptors requiring data transformation see {@link TransformingInterceptorsServer}
+ *
+ * This example just aims to demonstrate how to write the simplest TCP server, it is however, not of much use in general
+ * primarily because it reads unstructured data i.e. there are no boundaries that define what constitutes "a message".
+ * In order to define such boundaries, one would typically add a {@link ChannelHandler} that converts the read raw
+ * {@code ByteBuffer} to a structured message.
+ */
+public final class InterceptingServer extends AbstractServerExample {
+
+    public static void main(final String[] args) {
+
+        TcpServer<ByteBuf, ByteBuf> server;
+
+        /*Starts a new TCP server on an ephemeral port.*/
+        server = TcpServer.newServer(0)
+                          /*Starts the server with a connection handler.*/
+                          .start(TcpServerInterceptorChain.startRaw(sendHello())
+                                                          .end(echoHandler()));
+
+        /*Wait for shutdown if not called from the client (passed an arg)*/
+        if (shouldWaitForShutdown(args)) {
+            server.awaitShutdown();
+        }
+
+        /*If not waiting for shutdown, assign the ephemeral port used to a field so that it can be read and used by
+        the caller, if any.*/
+        setServerPort(server.getServerPort());
+    }
+
+    /**
+     * Logs every new connection.
+     *
+     * @return Interceptor for logging new connections.
+     */
+    private static Interceptor<ByteBuf, ByteBuf> sendHello() {
+        return in -> newConnection -> newConnection.writeString(Observable.just("Hello"))
+                                                   .concatWith(in.handle(newConnection));
+    }
+
+    /**
+     * New {@link ConnectionHandler} that echoes all data received.
+     *
+     * @return Connection handler.
+     */
+    private static ConnectionHandler<ByteBuf, ByteBuf> echoHandler() {
+        return conn -> conn.writeStringAndFlushOnEach(
+                conn.getInput().map(msg -> "echo => " + msg.toString(Charset.defaultCharset())));
+    }
+}

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/transformation/InterceptingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/transformation/InterceptingClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.examples.tcp.interceptors.transformation;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.examples.AbstractClientExample;
+import io.reactivex.netty.examples.tcp.interceptors.simple.InterceptingServer;
+import io.reactivex.netty.protocol.tcp.client.TcpClient;
+import rx.Observable;
+
+import java.net.SocketAddress;
+import java.nio.charset.Charset;
+
+/**
+ * A client to test {@link InterceptingServer}. This client is provided here only for completeness of the example,
+ * otherwise, it is exactly the same as {@link io.reactivex.netty.examples.tcp.echo.EchoClient}.
+ *
+ * @see InterceptingServer Default server for this client.
+ */
+public final class InterceptingClient extends AbstractClientExample {
+
+    public static void main(String[] args) {
+
+        /*
+         * Retrieves the server address, using the following algorithm:
+         * <ul>
+             <li>If any arguments are passed, then use the first argument as the server port.</li>
+             <li>If available, use the second argument as the server host, else default to localhost</li>
+             <li>Otherwise, start the passed server class and use that address.</li>
+         </ul>
+         */
+        SocketAddress serverAddress = getServerAddress(TransformingInterceptorsServer.class, args);
+
+        /*Create a new client for the server address*/
+        TcpClient.<ByteBuf, ByteBuf>newClient(serverAddress)
+                /*Create a new connection request, each subscription creates a new connection*/
+                 .createConnectionRequest()
+                /*Upon successful connection, write "Hello World" and listen to input*/
+                 .flatMap(connection ->
+                                  /*Write the message*/
+                                  connection.writeString(Observable.just("1"))
+                                          /*Since, write returns a Void stream, cast it to ByteBuf to be able to merge
+                                          with the input*/
+                                          .cast(ByteBuf.class)
+                                          /*Upon successful completion of the write, subscribe to the connection input*/
+                                          .concatWith(connection.getInput())
+                 )
+                /*Server sends an initial hello and then a number*/
+                 .take(2)
+                /*Convert each ByteBuf to a string*/
+                 .map(bb -> bb.toString(Charset.defaultCharset()))
+                /*Block till the response comes to avoid JVM exit.*/
+                 .toBlocking()
+                /*Print each content chunk*/
+                 .forEach(logger::info);
+    }
+}

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/transformation/TransformingInterceptorsServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/interceptors/transformation/TransformingInterceptorsServer.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.examples.tcp.interceptors.transformation;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import io.reactivex.netty.channel.AbstractDelegatingConnection;
+import io.reactivex.netty.channel.AbstractDelegatingConnection.Transformer;
+import io.reactivex.netty.examples.AbstractServerExample;
+import io.reactivex.netty.examples.tcp.interceptors.simple.InterceptingServer;
+import io.reactivex.netty.protocol.tcp.server.ConnectionHandler;
+import io.reactivex.netty.protocol.tcp.server.TcpServer;
+import io.reactivex.netty.protocol.tcp.server.TcpServerInterceptorChain;
+import io.reactivex.netty.protocol.tcp.server.TcpServerInterceptorChain.Interceptor;
+import io.reactivex.netty.protocol.tcp.server.TcpServerInterceptorChain.TransformingInterceptor;
+import rx.Observable;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A TCP echo server that echoes all input it receives on any connection, after prepending the input with a fixed
+ * string. <p>
+ *
+ * This example demonstrates the usage of server side interceptors which do data transformations.
+ * For interceptors requiring no data transformation see {@link InterceptingServer}
+ *
+ * This example just aims to demonstrate how to write the simplest TCP server, it is however, not of much use in general
+ * primarily because it reads unstructured data i.e. there are no boundaries that define what constitutes "a message".
+ * In order to define such boundaries, one would typically add a {@link ChannelHandler} that converts the read raw
+ * {@code ByteBuffer} to a structured message.
+ */
+public final class TransformingInterceptorsServer extends AbstractServerExample {
+
+    public static void main(final String[] args) {
+
+        TcpServer<ByteBuf, ByteBuf> server;
+
+        /*Starts a new TCP server on an ephemeral port.*/
+        server = TcpServer.newServer(0)
+                          /*Starts the server with a connection handler.*/
+                .start(TcpServerInterceptorChain.startRaw(sendHello())
+                                                .nextWithReadTransform(readStrings())
+                                                .nextWithWriteTransform(writeStrings())
+                                                .nextWithTransform(readAndWriteInts())
+                                                .end(numberIncrementingHandler()));
+
+        /*Wait for shutdown if not called from the client (passed an arg)*/
+        if (shouldWaitForShutdown(args)) {
+            server.awaitShutdown();
+        }
+
+        /*If not waiting for shutdown, assign the ephemeral port used to a field so that it can be read and used by
+        the caller, if any.*/
+        setServerPort(server.getServerPort());
+    }
+
+    /**
+     * Logs every new connection.
+     *
+     * @return Interceptor for logging new connections.
+     */
+    private static Interceptor<ByteBuf, ByteBuf> sendHello() {
+        return in -> newConnection -> newConnection.writeString(Observable.just("Hello"))
+                                                   .concatWith(in.handle(newConnection));
+    }
+
+    /**
+     * Converts read bytes to string.
+     *
+     * @return Interceptor for logging new connections.
+     */
+    private static TransformingInterceptor<ByteBuf, ByteBuf, String, ByteBuf> readStrings() {
+        return in -> newConnection ->
+                in.handle(new AbstractDelegatingConnection<ByteBuf, ByteBuf, String, ByteBuf>(newConnection) {
+                    @Override
+                    public Observable<String> getInput() {
+                        return newConnection.getInput().map(bb -> bb.toString(Charset.defaultCharset()));
+                    }
+                });
+    }
+
+    private static TransformingInterceptor<String, ByteBuf, String, String> writeStrings() {
+        return in -> newConnection ->
+                in.handle(new AbstractDelegatingConnection<String, ByteBuf, String, String>(newConnection,
+                                                                                            transformStringToBytes()) {
+                    @Override
+                    public Observable<String> getInput() {
+                        return newConnection.getInput();
+                    }
+                });
+    }
+
+    private static TransformingInterceptor<String, String, Integer, Integer> readAndWriteInts() {
+        return in -> newConnection ->
+                in.handle(new AbstractDelegatingConnection<String, String, Integer, Integer>(newConnection,
+                                                                                            transformIntegerToString()) {
+                    @Override
+                    public Observable<Integer> getInput() {
+                        return newConnection.getInput().map(String::trim).map(Integer::parseInt);
+                    }
+                });
+    }
+
+    /**
+     * New {@link ConnectionHandler} that echoes all data received.
+     *
+     * @return Connection handler.
+     */
+    private static ConnectionHandler<Integer, Integer> numberIncrementingHandler() {
+        return conn -> conn.writeAndFlushOnEach(conn.getInput().map(anInt -> anInt++));
+    }
+
+    private static Transformer<String, ByteBuf> transformStringToBytes() {
+
+        return new Transformer<String, ByteBuf>() {
+            @Override
+            public List<ByteBuf> transform(String toTransform, ByteBufAllocator allocator) {
+                return Collections.singletonList(allocator.buffer().writeBytes(toTransform.getBytes()));
+            }
+        };
+    }
+
+    private static Transformer<Integer, String> transformIntegerToString() {
+        return new Transformer<Integer, String>() {
+            @Override
+            public List<String> transform(Integer toTransform, ByteBufAllocator allocator) {
+                return Arrays.asList(String.valueOf(toTransform), String.valueOf(++toTransform));
+            }
+        };
+    }
+}

--- a/rxnetty-examples/src/test/java/io/reactivex/netty/examples/tcp/interceptors/simple/SimpleInterceptorTest.java
+++ b/rxnetty-examples/src/test/java/io/reactivex/netty/examples/tcp/interceptors/simple/SimpleInterceptorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.examples.tcp.interceptors.simple;
+
+import org.junit.Test;
+
+import java.util.Queue;
+
+import static io.reactivex.netty.examples.ExamplesTestUtil.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class SimpleInterceptorTest {
+
+    @Test(timeout = 60000)
+    public void testSimpleInterceptor() throws Exception {
+
+        final Queue<String> output = setupClientLogger(InterceptingClient.class);
+
+        InterceptingClient.main(null);
+
+        assertThat("Unexpected number of messages echoed", output, hasSize(2));
+        assertThat("Unexpected number of messages echoed", output, contains("Hello", "echo => Hello World!"));
+    }
+}

--- a/rxnetty-examples/src/test/java/io/reactivex/netty/examples/tcp/interceptors/transformation/TransformingInterceptorTest.java
+++ b/rxnetty-examples/src/test/java/io/reactivex/netty/examples/tcp/interceptors/transformation/TransformingInterceptorTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.examples.tcp.interceptors.transformation;
+
+import org.junit.Test;
+
+import java.util.Queue;
+
+import static io.reactivex.netty.examples.ExamplesTestUtil.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class TransformingInterceptorTest {
+
+    @Test(timeout = 60000)
+    public void testTransformingInterceptor() throws Exception {
+
+        final Queue<String> output = setupClientLogger(InterceptingClient.class);
+
+        InterceptingClient.main(null);
+
+        assertThat("Unexpected number of messages echoed", output, hasSize(2));
+        assertThat("Unexpected number of messages echoed", output, contains("Hello", "23"));
+    }
+}

--- a/rxnetty-examples/src/test/resources/document.txt
+++ b/rxnetty-examples/src/test/resources/document.txt
@@ -1,4 +1,0 @@
-Lets count some words. Lets count some words. Lets count some words. Lets count some words.
-Lets count some words. Lets count some words. Lets count some words. Lets count some words.
-Lets count some words. Lets count some words. Lets count some words. Lets count some words.
-Lets count some words. Lets count some words. Lets count some words. Lets count some words.

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/UnusableConnection.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/UnusableConnection.java
@@ -17,12 +17,16 @@
 package io.reactivex.netty.protocol.http.client.internal;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.concurrent.EventExecutorGroup;
 import io.reactivex.netty.channel.Connection;
 import io.reactivex.netty.channel.events.ConnectionEventListener;
 import io.reactivex.netty.events.EventPublisher;
 import rx.Observable;
+import rx.functions.Action1;
 import rx.functions.Func1;
 
 final class UnusableConnection<R, W> extends Connection<R, W> {
@@ -120,5 +124,59 @@ final class UnusableConnection<R, W> extends Connection<R, W> {
 
     public static Connection<?, ?> create() {
         return new UnusableConnection<>(new EmbeddedChannel(), null, null);
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerFirst(String name, ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerFirst(EventExecutorGroup group, String name,
+                                                              ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerLast(String name, ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerLast(EventExecutorGroup group, String name,
+                                                             ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerBefore(String baseName, String name, ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerBefore(EventExecutorGroup group, String baseName, String name,
+                                                               ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerAfter(String baseName, String name, ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> addChannelHandlerAfter(EventExecutorGroup group, String baseName, String name,
+                                                              ChannelHandler handler) {
+        return cast();
+    }
+
+    @Override
+    public <RR, WW> Connection<RR, WW> pipelineConfigurator(Action1<ChannelPipeline> pipelineConfigurator) {
+        return cast();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <RR, WW> Connection<RR, WW> cast() {
+        return (Connection<RR, WW>) this;
     }
 }

--- a/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/server/TcpServerInterceptorChain.java
+++ b/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/server/TcpServerInterceptorChain.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.protocol.tcp.server;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.channel.AbstractDelegatingConnection;
+import io.reactivex.netty.channel.Connection;
+import rx.annotations.Beta;
+import rx.functions.Func1;
+
+/**
+ * A utility to create an interceptor chain to be used with a {@link TcpServer} to modify behavior of connections
+ * accepted by that server.
+ *
+ * <h2>What are interceptors?</h2>
+ *
+ * Interceptors can be used to achieve use-cases that involve instrumentation related to any behavior of the connection,
+ * they can even be used to short-circuit the rest of the chain or to provide canned responses. In order to achieve such
+ * widely different use-cases, an interceptor is modelled as a simple function that takes one {@link ConnectionHandler}
+ * and returns another {@link ConnectionHandler} instance. With this low level abstraction, any use-case pertaining to
+ * connection instrumentation can be achieved.
+ *
+ * <h2>Interceptor chain anatomy</h2>
+ *
+ <PRE>
+        -------        -------        -------        -------        -------
+       |       |      |       |      |       |      |       |      |       |
+       |       | ---> |       | ---> |       | ---> |       | ---> |       |
+       |       |      |       |      |       |      |       |      |       |
+        -------        -------        -------        -------        -------
+      Interceptor    Interceptor    Interceptor    Interceptor     Connection
+           1              2              3              4           Handler
+ </PRE>
+ *
+ * An interceptor chain always starts with an interceptor and ends with a {@link ConnectionHandler} and any number of
+ * other interceptors can exist between the start and end. <p>
+ *
+ * A chain can be created by using the various {@code start*()} methods available in this class, eg:
+ * {@link #start(Interceptor)}, {@link #startWithTransform(TransformingInterceptor)},
+ * {@link #startWithReadTransform(TransformingInterceptor)}, {@link #startWithWriteTransform(TransformingInterceptor)}.<p>
+ *
+ * After starting a chain, any number of other interceptors can be added by using the various {@code next*()} methods
+ * available in this class, eg: {@link #next(Interceptor)}, {@link #nextWithTransform(TransformingInterceptor)},
+ * {@link #nextWithReadTransform(TransformingInterceptor)} and {@link #nextWithWriteTransform(TransformingInterceptor)}<p>
+ *
+ * After adding the required interceptors, by providing a {@link ConnectionHandler} via the
+ * {@link #end(ConnectionHandler)} method, the chain can be ended and the returned {@link ConnectionHandler} can be used
+ * with any {@link TcpServer}<p>
+ *
+ * So, a typical interaction with this class would look like: <p>
+ *
+ * {@code
+ *    TcpServer.newServer().start(TcpServerInterceptorChain.start(first).next(second).next(third).end(handler))
+ * }
+ *
+ * <h2>Simple Interceptor</h2>
+ *
+ * For interceptors that do not change the types of objects read or written to the underlying connection, the interface
+ * {@link TcpServerInterceptorChain.Interceptor} defines the interceptor contract.
+ *
+ * <h2>Modifying the type of data read/written to the {@link Connection}</h2>
+ *
+ * Sometimes, it is required to change the type of objects read or written to a {@link Connection} instance handled by
+ * a {@link TcpServer}. For such cases, the interface {@link TcpServerInterceptorChain.TransformingInterceptor} defines
+ * the interceptor contract. Since, this included 4 generic arguments to the interceptor, this is not the base type for
+ * all interceptors and should be used only when the types of the {@link Connection} are actually to be changed.
+ *
+ * <h2>Execution order</h2>
+ *
+ <PRE>
+      -------        -------         -------        -------        -------        -------        -------
+     |       |      |       |       |       |      |       |      |       |      |       |      |       |
+     |       | ---> |       | --->  |       | ---> |       | ---> |       | ---> |       | ---> |       |
+     |       |      |       |       |       |      |       |      |       |      |       |      |       |
+      -------        -------         -------        -------        -------        -------        -------
+       Tcp         Connection      Interceptor    Interceptor    Interceptor    Interceptor     Connection
+      Server         Handler           1              2              3              4             Handler
+                   (Internal)                                                                     (User)
+ </PRE>
+ *
+ * The above diagram depicts the execution order of interceptors. The first connection handler (internal) is created by
+ * this class and as is returned by {@link #end(ConnectionHandler)} method by providing a {@link ConnectionHandler} that
+ * does the actual processing of the connection. {@link TcpServer} with which this interceptor chain is used, will
+ * invoke the internal connection handler provided by this class. <p>
+ *
+ * The interceptors are invoked in the order that they are added to this chain.
+ *
+ * @param <R> The type of objects read from a connection to {@link TcpServer} with which this interceptor chain will be
+ * used.
+ * @param <W> The type of objects written to a connection to {@link TcpServer} with which this interceptor chain will be
+ * used.
+ * @param <RR> The type of objects read from a connection to {@link TcpServer} after applying this interceptor chain.
+ * @param <WW> The type of objects written to a connection to {@link TcpServer} after applying this interceptor chain.
+ *
+ * @see AbstractDelegatingConnection
+ */
+@Beta
+public final class TcpServerInterceptorChain<R, W, RR, WW> {
+
+    private final TransformingInterceptor<R, W, RR, WW> interceptor;
+
+    private TcpServerInterceptorChain(TransformingInterceptor<R, W, RR, WW> interceptor) {
+        this.interceptor = interceptor;
+    }
+
+    /**
+     * Add the next interceptor to this chain.
+     *
+     * @param next Next interceptor to add.
+     *
+     * @return A new interceptor chain with the interceptors current existing and the passed interceptor added to the
+     * end.
+     */
+    public TcpServerInterceptorChain<R, W, RR, WW> next(final Interceptor<RR, WW> next) {
+        return new TcpServerInterceptorChain<>(new TransformingInterceptor<R, W, RR, WW>() {
+            @Override
+            public ConnectionHandler<R, W> call(ConnectionHandler<RR, WW> handler) {
+                return interceptor.call(next.call(handler));
+            }
+        });
+    }
+
+    /**
+     * Add the next interceptor to this chain, which changes the type of objects read from the connections processed by
+     * the associated {@link TcpServer}.
+     *
+     * @param next Next interceptor to add.
+     *
+     * @return A new interceptor chain with the interceptors current existing and the passed interceptor added to the
+     * end.
+     */
+    public <RRR> TcpServerInterceptorChain<R, W, RRR, WW> nextWithReadTransform(final TransformingInterceptor<RR, WW, RRR, WW> next) {
+        return new TcpServerInterceptorChain<>(new TransformingInterceptor<R, W, RRR, WW>() {
+            @Override
+            public ConnectionHandler<R, W> call(ConnectionHandler<RRR, WW> handler) {
+                return interceptor.call(next.call(handler));
+            }
+        });
+    }
+
+    /**
+     * Add the next interceptor to this chain, which changes the type of objects written to the connections processed by
+     * the associated {@link TcpServer}.
+     *
+     * @param next Next interceptor to add.
+     *
+     * @return A new interceptor chain with the interceptors current existing and the passed interceptor added to the
+     * end.
+     */
+    public <WWW> TcpServerInterceptorChain<R, W, RR, WWW> nextWithWriteTransform(final TransformingInterceptor<RR, WW, RR, WWW> next) {
+        return new TcpServerInterceptorChain<>(new TransformingInterceptor<R, W, RR, WWW>() {
+            @Override
+            public ConnectionHandler<R, W> call(ConnectionHandler<RR, WWW> handler) {
+                return interceptor.call(next.call(handler));
+            }
+        });
+    }
+
+    /**
+     * Add the next interceptor to this chain, which changes the type of objects read and written from/to the
+     * connections processed by the associated {@link TcpServer}.
+     *
+     * @param next Next interceptor to add.
+     *
+     * @return A new interceptor chain with the interceptors current existing and the passed interceptor added to the
+     * end.
+     */
+    public <RRR, WWW> TcpServerInterceptorChain<R, W, RRR, WWW> nextWithTransform(final TransformingInterceptor<RR, WW, RRR, WWW> next) {
+        return new TcpServerInterceptorChain<>(new TransformingInterceptor<R, W, RRR, WWW>() {
+            @Override
+            public ConnectionHandler<R, W> call(ConnectionHandler<RRR, WWW> handler) {
+                return interceptor.call(next.call(handler));
+            }
+        });
+    }
+
+    /**
+     * Terminates this chain with the passed {@link ConnectionHandler} and returns a {@link ConnectionHandler} to be
+     * used by a {@link TcpServer}
+     *
+     * @param handler Connection handler to use.
+     *
+     * @return A connection handler that wires the interceptor chain, to be used with {@link TcpServer} instead of
+     * directly using the passed {@code handler}
+     */
+    public ConnectionHandler<R, W> end(ConnectionHandler<RR, WW> handler) {
+        return interceptor.call(handler);
+    }
+
+    /**
+     * One of the methods to start creating the interceptor chain. The other start methods can be used for starting with
+     * interceptors that modify the type of Objects read/written from/to the connections processed by the associated
+     * {@link TcpServer}.
+     *
+     * @param start The starting interceptor for this chain.
+     *
+     * @param <R> The type of objects read from a connection to {@link TcpServer} with which this interceptor chain will
+     * be used.
+     * @param <W> The type of objects written to a connection to {@link TcpServer} with which this interceptor chain
+     * will be used.
+     *
+     * @return A new interceptor chain.
+     */
+    public static <R, W> TcpServerInterceptorChain<R, W, R, W> start(final Interceptor<R, W> start) {
+        return new TcpServerInterceptorChain<>(new TransformingInterceptor<R, W, R, W>() {
+            @Override
+            public ConnectionHandler<R, W> call(ConnectionHandler<R, W> handler) {
+                return start.call(handler);
+            }
+        });
+    }
+
+    /**
+     * One of the methods to start creating the interceptor chain. The other start methods can be used for starting with
+     * interceptors that modify the type of Objects read/written from/to the connections processed by the associated
+     * {@link TcpServer}.
+     *
+     * @param start The starting interceptor for this chain.
+     *
+     * @return A new interceptor chain.
+     */
+    public static TcpServerInterceptorChain<ByteBuf, ByteBuf, ByteBuf, ByteBuf> startRaw(final Interceptor<ByteBuf, ByteBuf> start) {
+        return new TcpServerInterceptorChain<>(new TransformingInterceptor<ByteBuf, ByteBuf, ByteBuf, ByteBuf>() {
+            @Override
+            public ConnectionHandler<ByteBuf, ByteBuf> call(ConnectionHandler<ByteBuf, ByteBuf> handler) {
+                return start.call(handler);
+            }
+        });
+    }
+
+    /**
+     * One of the methods to start creating the interceptor chain for converting the type of objects read from the
+     * connections processed by the associated {@link TcpServer}. For converting the type of objects written, use
+     * {@link #startWithWriteTransform(TransformingInterceptor)} and for converting both read and write types, use
+     * {@link #startWithTransform(TransformingInterceptor)}
+     *
+     * @param start The starting interceptor for this chain.
+     *
+     * @param <R> The type of objects read from a connection to {@link TcpServer} before applying this interceptor
+     * chain.
+     * @param <W> The type of objects written to a connection to {@link TcpServer} with which this interceptor chain
+     * will be used.
+     * @param <RR> The type of objects read from a connection to {@link TcpServer} after applying this interceptor
+     * chain.
+     *
+     * @return A new interceptor chain.
+     */
+    public static <R, W, RR> TcpServerInterceptorChain<R, W, RR, W> startWithReadTransform(TransformingInterceptor<R, W, RR, W> start) {
+        return new TcpServerInterceptorChain<>(start);
+    }
+
+    /**
+     * One of the methods to start creating the interceptor chain for converting the type of objects written to the
+     * connections processed by the associated {@link TcpServer}. For converting the type of objects read, use
+     * {@link #startWithReadTransform(TransformingInterceptor)} and for converting both read and write types, use
+     * {@link #startWithTransform(TransformingInterceptor)}
+     *
+     * @param start The starting interceptor for this chain.
+     *
+     * @param <R> The type of objects read from a connection to {@link TcpServer} with which this interceptor chain
+     * will be used.
+     * @param <W> The type of objects written to a connection to {@link TcpServer} before applying this interceptor
+     * chain.
+     * @param <WW> The type of objects written to a connection to {@link TcpServer} after applying this interceptor
+     * chain.
+     *
+     * @return A new interceptor chain.
+     */
+    public static <R, W, WW> TcpServerInterceptorChain<R, W, R, WW> startWithWriteTransform(TransformingInterceptor<R, W, R, WW> start) {
+        return new TcpServerInterceptorChain<>(start);
+    }
+
+    /**
+     * One of the methods to start creating the interceptor chain for converting the type of objects read and written
+     * from/to the connections processed by the associated {@link TcpServer}. For converting the type of objects read,
+     * use {@link #startWithReadTransform(TransformingInterceptor)} and for converting type of objects written, use
+     * {@link #startWithWriteTransform(TransformingInterceptor)}
+     *
+     * @param start The starting interceptor for this chain.
+     *
+     * @param <R> The type of objects read from a connection to {@link TcpServer} before applying this interceptor
+     * chain.
+     * @param <W> The type of objects written to a connection to {@link TcpServer} with which this interceptor chain
+     * will be used.
+     * @param <RR> The type of objects read from a connection to {@link TcpServer} after applying this interceptor
+     * chain.
+     * @param <WW> The type of objects written to a connection to {@link TcpServer} after applying this interceptor
+     * chain.
+     *
+     * @return A new interceptor chain.
+     */
+    public static <R, W, RR, WW> TcpServerInterceptorChain<R, W, RR, WW> startWithTransform(TransformingInterceptor<R, W, RR, WW> start) {
+        return new TcpServerInterceptorChain<>(start);
+    }
+
+    /**
+     * An interceptor that preserves the type of objects read and written to the connection.
+     *
+     * @param <R> Type of objects read from the connection handled by this interceptor.
+     * @param <W> Type of objects written to the connection handled by this interceptor.
+     */
+    public interface Interceptor<R, W> extends Func1<ConnectionHandler<R, W>, ConnectionHandler<R, W>> {
+
+    }
+
+    /**
+     * An interceptor that changes the type of objects read and written to the connection.
+     *
+     * @param <R> Type of objects read from the connection before applying this interceptor.
+     * @param <W> Type of objects written to the connection before applying this interceptor.
+     * @param <RR> Type of objects read from the connection after applying this interceptor.
+     * @param <WW> Type of objects written to the connection after applying this interceptor.
+     */
+    public interface TransformingInterceptor<R, W, RR, WW>
+            extends Func1<ConnectionHandler<RR, WW>, ConnectionHandler<R, W>> {
+
+    }
+}


### PR DESCRIPTION
Provides a new abstraction of `TcpServerInterceptorChain` that creates a chain starting with an interceptor and ending on a `ConnectionHandler`.  Any number of interceptors can be added in between. Javadoc on this class, copied below, explains the usage and design in detail:

```
What are interceptors?
Interceptors can be used to achieve use-cases that involve instrumentation related to any behavior of the connection, they can even be used to short-circuit the rest of the chain or to provide canned responses. In order to achieve such widely different use-cases, an interceptor is modelled as a simple function that takes one ConnectionHandler and returns another ConnectionHandler instance. With this low level abstraction, any use-case pertaining to connection instrumentation can be achieved.
Interceptor chain anatomy
        -------        -------        -------        -------        -------
       |       |      |       |      |       |      |       |      |       |
       |       | ---> |       | ---> |       | ---> |       | ---> |       |
       |       |      |       |      |       |      |       |      |       |
        -------        -------        -------        -------        -------
      Interceptor    Interceptor    Interceptor    Interceptor     Connection
           1              2              3              4           Handler

An interceptor chain always starts with an interceptor and ends with a ConnectionHandler and any number of other interceptors can exist between the start and end.
A chain can be created by using the various start*() methods available in this class, eg: start(TcpServerInterceptorChain.Interceptor), startWithTransform(TcpServerInterceptorChain.TransformingInterceptor), startWithReadTransform(TcpServerInterceptorChain.TransformingInterceptor), startWithWriteTransform(TcpServerInterceptorChain.TransformingInterceptor).
After starting a chain, any number of other interceptors can be added by using the various next*() methods available in this class, eg: next(TcpServerInterceptorChain.Interceptor), nextWithTransform(TcpServerInterceptorChain.TransformingInterceptor), nextWithReadTransform(TcpServerInterceptorChain.TransformingInterceptor) and nextWithWriteTransform(TcpServerInterceptorChain.TransformingInterceptor)
After adding the required interceptors, by providing a ConnectionHandler via the end(ConnectionHandler) method, the chain can be ended and the returned ConnectionHandler can be used with any TcpServer
So, a typical interaction with this class would look like:
TcpServer.newServer().start(TcpServerInterceptorChain.start(first).next(second).next(third).end(handler)) 
Simple Interceptor
For interceptors that do not change the types of objects read or written to the underlying connection, the interface TcpServerInterceptorChain.Interceptor defines the interceptor contract.
Modifying the type of data read/written to the Connection
Sometimes, it is required to change the type of objects read or written to a Connection instance handled by a TcpServer. For such cases, the interface TcpServerInterceptorChain.TransformingInterceptor defines the interceptor contract. Since, this included 4 generic arguments to the interceptor, this is not the base type for all interceptors and should be used only when the types of the Connection are actually to be changed.
Execution order
      -------        -------         -------        -------        -------        -------        -------
     |       |      |       |       |       |      |       |      |       |      |       |      |       |
     |       | ---> |       | --->  |       | ---> |       | ---> |       | ---> |       | ---> |       |
     |       |      |       |       |       |      |       |      |       |      |       |      |       |
      -------        -------         -------        -------        -------        -------        -------
       Tcp         Connection      Interceptor    Interceptor    Interceptor    Interceptor     Connection
      Server         Handler           1              2              3              4             Handler
                   (Internal)                                                                     (User)

The above diagram depicts the execution order of interceptors. The first connection handler (internal) is created by this class and as is returned by end(ConnectionHandler) method by providing a ConnectionHandler that does the actual processing of the connection. TcpServer with which this interceptor chain is used, will invoke the internal connection handler provided by this class.
The interceptors are invoked in the order that they are added to this chain.
```

Also added are two examples of how these interceptors are used.
