### PR TITLE
Make the domain name resolver configurable

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientState.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientState.java
@@ -222,7 +222,8 @@ public class ClientState<W, R> extends ConnectionFactory<W, R> {
     /*Visible for testing*/ Bootstrap newBootstrap(ListenersHolder<ClientEventListener> listeners) {
         final Bootstrap nettyBootstrap = new Bootstrap().group(rawConnectionProvider.getEventLoopGroup())
                                                         .channel(rawConnectionProvider.getChannelClass())
-                                                        .option(ChannelOption.AUTO_READ, false);// by default do not read content unless asked.
+                                                        .option(ChannelOption.AUTO_READ, false)// by default do not read content unless asked.
+                                                        .resolver(rawConnectionProvider.getNameResolver());
 
         for (Entry<ChannelOption<?>, Object> optionEntry : options.entrySet()) {
             // Type is just for safety for user of ClientState, internally in Bootstrap, types are thrown on the floor.


### PR DESCRIPTION
When a Bootstrap is created, the resolver is given by the ConnectionProvider.
The ConnectionProvider.forHost(SocketAddress) now has a second argument: NameResolverGroup
In case a proxy connection is required, create a client giving the ConnectionProvider as:
ConnectionProvider.forHost(InetSocketAddress.createUnresolved("proxied host", proxied port), NoopNameResolverGroup.INSTANCE).
