### PR TITLE
update 0.4.x to netty 4.1.0-Beta6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-netty_version=4.0.27.Final
+netty_version=4.1.0.Beta6
 slf4j_version=1.7.6

--- a/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextAwareEventLoopGroup.java
+++ b/rxnetty-contexts/src/main/java/io/reactivex/netty/contexts/ContextAwareEventLoopGroup.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +70,11 @@ public class ContextAwareEventLoopGroup implements EventLoopGroup {
     @Override
     public Iterator<EventExecutor> iterator() {
         return delegate.iterator();
+    }
+
+    @Override
+    public <E extends EventExecutor> Set<E> children() {
+        return delegate.children();
     }
 
     @Override

--- a/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/NoOpChannelHandlerContext.java
+++ b/rxnetty-contexts/src/test/java/io/reactivex/netty/contexts/NoOpChannelHandlerContext.java
@@ -138,6 +138,11 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
     }
 
     @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return attributeMap.hasAttr(key);
+    }
+
+    @Override
     public ChannelFuture bind(SocketAddress localAddress) {
         return failedPromise;
     }

--- a/rxnetty/build.gradle
+++ b/rxnetty/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile "io.netty:netty-codec-http:${netty_version}"
+    compile "io.netty:netty-handler:${netty_version}"
     compile "io.netty:netty-transport-native-epoll:${netty_version}"
     compile "org.slf4j:slf4j-api:${slf4j_version}"
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponse.java
@@ -247,14 +247,19 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
 
         @Override
         public FullHttpResponse copy() {
-            DefaultFullHttpResponse copy = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content.copy());
+            return copy(content.copy());
+        }
+
+        @Override
+        public FullHttpResponse copy(ByteBuf newContent) {
+            DefaultFullHttpResponse copy = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), newContent);
             copy.headers().set(headers());
             copy.trailingHeaders().set(trailingHeaders());
             return copy;
         }
 
         @Override
-        public HttpContent duplicate() {
+        public FullHttpResponse duplicate() {
             DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(),
                                                                       content.duplicate());
             dup.headers().set(headers());
@@ -271,6 +276,18 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
         @Override
         public FullHttpResponse retain() {
             content.retain();
+            return this;
+        }
+
+        @Override
+        public FullHttpResponse touch() {
+            content.touch();
+            return this;
+        }
+
+        @Override
+        public FullHttpResponse touch(Object hint) {
+            content.touch(hint);
             return this;
         }
 
@@ -293,12 +310,22 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
 
         @Override
         public HttpResponseStatus getStatus() {
-            return headers.getStatus();
+            return headers.status();
+        }
+
+        @Override
+        public HttpResponseStatus status() {
+            return headers.status();
         }
 
         @Override
         public HttpVersion getProtocolVersion() {
-            return headers.getProtocolVersion();
+            return headers.protocolVersion();
+        }
+
+        @Override
+        public HttpVersion protocolVersion() {
+            return headers.protocolVersion();
         }
 
         @Override
@@ -313,6 +340,11 @@ public class HttpServerResponse<T> extends DefaultChannelWriter<T> {
 
         @Override
         public DecoderResult getDecoderResult() {
+            return DecoderResult.SUCCESS;
+        }
+
+        @Override
+        public DecoderResult decoderResult() {
             return DecoderResult.SUCCESS;
         }
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/ServerSentEvent.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/sse/ServerSentEvent.java
@@ -151,6 +151,30 @@ public class ServerSentEvent implements ByteBufHolder {
     }
 
     @Override
+    public ByteBufHolder touch() {
+        if(hasEventId()) {
+            eventId.touch();
+        }
+        if(hasEventType()) {
+            eventType.touch();
+        }
+        data.touch();
+        return this;
+    }
+
+    @Override
+    public ByteBufHolder touch(Object hint) {
+        if(hasEventId()) {
+            eventId.touch(hint);
+        }
+        if(hasEventType()) {
+            eventType.touch(hint);
+        }
+        data.touch(hint);
+        return this;
+    }
+
+    @Override
     public ByteBufHolder retain() {
         if(hasEventId()) {
             eventId.retain();

--- a/rxnetty/src/test/java/io/reactivex/netty/NoOpChannelHandlerContext.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/NoOpChannelHandlerContext.java
@@ -137,6 +137,11 @@ public class NoOpChannelHandlerContext implements ChannelHandlerContext {
     }
 
     @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return attributeMap.hasAttr(key);
+    }
+
+    @Override
     public ChannelFuture bind(SocketAddress localAddress) {
         return completedPromise;
     }

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/CookieTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/client/CookieTest.java
@@ -80,7 +80,7 @@ public class CookieTest {
         Assert.assertEquals("Unexpected number of cookies.", 1, decodeCookies.size());
         Cookie decodedCookie = decodeCookies.iterator().next();
         Assert.assertEquals("Unexpected cookie name.", cookie1Name, decodedCookie.getName());
-        Assert.assertEquals("Unexpected cookie path.", cookie1Path, decodedCookie.getPath());
-        Assert.assertEquals("Unexpected cookie domain.", cookie1Domain, decodedCookie.getDomain());
+        Assert.assertNull("Unexpected cookie path.", decodedCookie.getPath());
+        Assert.assertNull("Unexpected cookie domain.", decodedCookie.getDomain());
     }
 }


### PR DESCRIPTION
Main goal is to allow the same version of netty to be used
with both 0.4.x and 0.5.x branches.
