### PR TITLE
Fixing (maybe) the failing test.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 buildscript {
     repositories { jcenter() }
@@ -36,5 +37,11 @@ configure(subprojects) {
         testCompile "org.hamcrest:hamcrest-library:1.3"
         testCompile "org.mockito:mockito-core:1.+"
         testRuntime "org.slf4j:slf4j-log4j12:${slf4j_version}"
+    }
+
+    test {
+        testLogging {
+            showStandardStreams = true
+        }
     }
 }

--- a/rxnetty-examples/build.gradle
+++ b/rxnetty-examples/build.gradle
@@ -26,9 +26,3 @@ dependencies {
     compile "io.reactivex:rxjava-string:1.0.0"
     compile "org.slf4j:slf4j-log4j12:${slf4j_version}"
 }
-
-test {
-    testLogging {
-        showStandardStreams = true
-    }
-}

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/client/ClientStateTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/client/ClientStateTest.java
@@ -55,7 +55,7 @@ public class ClientStateTest {
     @Test(timeout = 60000)
     public void testChannelOption() throws Exception {
         ClientState<String, String> newState = clientStateRule.clientState
-                .channelOption(ChannelOption.MAX_MESSAGES_PER_READ, 100);
+                .channelOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, 100);
 
         assertThat("Client state not copied.", clientStateRule.clientState, is(not(newState)));
         assertThat("Options not copied.", clientStateRule.clientState.unsafeChannelOptions(),
@@ -66,10 +66,10 @@ public class ClientStateTest {
         ClientState<String, String> oldState = clientStateRule.updateState(newState);
 
         Channel channel = clientStateRule.connect();
-        assertThat("Channel option not set in the channel.", channel.config().getMaxMessagesPerRead(), is(100));
+        assertThat("Channel option not set in the channel.", channel.config().getConnectTimeoutMillis(), is(100));
 
         Channel oldStateChannel = clientStateRule.connect(oldState);
-        assertThat("Channel option updated in the old state.", oldStateChannel.config().getMaxMessagesPerRead(),
+        assertThat("Channel option updated in the old state.", oldStateChannel.config().getConnectTimeoutMillis(),
                    is(not(100)));
     }
 


### PR DESCRIPTION
I have not spend enough time on why this test was failing when "max messages per read" option was used but using a different option does not seem to show the same behavior.
