### PR TITLE
fix bug removing MetricEventsListener

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/metrics/MetricEventsSubject.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/metrics/MetricEventsSubject.java
@@ -130,7 +130,12 @@ public class MetricEventsSubject<E extends MetricsEvent<?>> implements MetricEve
         Subscription subscription = Subscriptions.create(new Action0() {
             @Override
             public void call() {
-                listeners.remove(listener);
+                for (SafeListener safeListener : listeners) {
+                    if (safeListener.delegate == listener) {
+                        listeners.remove(safeListener);
+                        break;
+                    }
+                }
             }
         });
         listeners.add(new SafeListener<E>(listener, subscription));


### PR DESCRIPTION
A type mismatch is preventing MetricEventsSubject.subscribe from removing a listener.

fixes #427 
