### PR TITLE
Fixes #419

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequestResponseConverter.java
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package io.reactivex.netty.protocol.http.client;
@@ -276,7 +277,7 @@ public class ClientRequestResponseConverter extends ChannelDuplexHandler {
             public void onError(Throwable e) {
                 eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_CONTENT_SOURCE_ERROR, e);
                 promise.tryFailure(e);
-                rxRequest.onWriteComplete();
+                rxRequest.onWriteFailed(e);
             }
 
             @Override

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientRequest.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package io.reactivex.netty.protocol.http.client;
@@ -29,6 +30,7 @@ import io.reactivex.netty.channel.ByteTransformer;
 import io.reactivex.netty.channel.ContentTransformer;
 import rx.Observable;
 import rx.functions.Action0;
+import rx.functions.Action1;
 import rx.functions.Func1;
 
 import java.nio.charset.Charset;
@@ -44,6 +46,7 @@ public class HttpClientRequest<T> {
     private Observable<ByteBuf> rawContentSource;
     private String absoluteUri;
     private Action0 onWriteCompleteAction;
+    private Action1<Throwable> onWriteFailedAction;
 
     HttpClientRequest(HttpRequest nettyRequest) {
         this.nettyRequest = nettyRequest;
@@ -196,9 +199,19 @@ public class HttpClientRequest<T> {
         this.onWriteCompleteAction = onWriteCompleteAction;
     }
 
+    void doOnWriteFailed(Action1<Throwable> onWriteFailedAction) {
+        this.onWriteFailedAction = onWriteFailedAction;
+    }
+
     void onWriteComplete() {
         if (null != onWriteCompleteAction) {
             onWriteCompleteAction.call();
+        }
+    }
+
+    void onWriteFailed(Throwable throwable) {
+        if (null != onWriteFailedAction) {
+            onWriteFailedAction.call(throwable);
         }
     }
 

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2015 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package io.reactivex.netty.protocol.http.client;
@@ -89,6 +90,16 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
                                              }
                                          })
                                          .subscribe(child)); //subscribe the child for response.
+
+                        request.doOnWriteFailed(new Action1<Throwable>() {
+                            @Override
+                            public void call(Throwable throwable) {
+                                eventsSubject.onEvent(HttpClientMetricsEvent.REQUEST_WRITE_FAILED,
+                                                      Clock.onEndMillis(startTimeMillis), throwable);
+                                child.onError(throwable);
+                            }
+                        });
+
                         request.doOnWriteComplete(new Action0() {
                             @Override
                             public void call() {


### PR DESCRIPTION
If `HttpClientRequest` is created with a content source that emits an error. The error was not propagated to the `Observable` returned by `client.submit()`.
