### PR TITLE
Fixes #432

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/RequestProcessingOperator.java
@@ -126,7 +126,11 @@ class RequestProcessingOperator<I, O> implements Observable.Operator<HttpClientR
                                 });
                             }
                         });
-                        connection.write(request);
+                        if (connection.getChannel().eventLoop().inEventLoop()) {
+                            connection.write(request);
+                        } else {
+                            connection.writeAndFlush(request);
+                        }
                     }
                 };
         return toReturn;


### PR DESCRIPTION
`HttpClient` writes `HttpClientRequest` object on the channel but does not flush the channel after the write as it is expected to be flushed after content is written.
Since, writes do not wake up the selector (flush does), when the requests are written from outside the eventloop, this write (as a task scheduled on the selector's queue) will only be processed the next time selector wakes up. Although, not functionally incorrect, this induces perceivable latencies.

Now, adding a `flush` whenever the write happens from outside the eventloop.

The following code snippet (modified to java from issue #432) clearly shows perceivable difference in latencies, before and after this change:

``` java

        HttpServer<ByteBuf, ByteBuf> server = RxNetty.createHttpServer(0, (request, response) -> {
            response.setStatus(HttpResponseStatus.OK);
            response.writeString("OK");
            return response.close();
        });

        server.start();

        HttpClientBuilder<ByteBuf, ByteBuf> clientBuilder =
                RxNetty.<ByteBuf, ByteBuf>newHttpClientBuilder("localhost", server.getServerPort());

        HttpClient<ByteBuf, ByteBuf> rxclient = clientBuilder.build();

        List<Long> durations = new ArrayList<>();

        Observable.range(1, 1000)
                  .toBlocking()
                  .forEach(integer -> {
                      long start = System.currentTimeMillis();
                      rxclient.submit(HttpClientRequest.createGet("/"))
                              .flatMap(response -> {
                                  assert response.getStatus().code() == 200;
                                  return response.getContent();
                              })
                              .toBlocking()
                              .singleOrDefault(null);
                      long end = System.currentTimeMillis();
                      durations.add(end - start);
                  });

        System.out.println("Count distinct durations (ms):  ");

        Observable.from(durations)
                  .toSortedList()
                  .flatMap(Observable::from)
                  .groupBy(aLong -> aLong)
                  .<String>flatMap(go -> go.count()
                                           .map(count -> String.valueOf(go.getKey()) + " : " + count))
                  .toBlocking()
                  .forEach(System.out::println);
```
###### Before

```
Count distinct durations (ms):  
0 : 211
1 : 690
2 : 64
3 : 3
4 : 3
1002 : 4
1003 : 3
1004 : 3
1005 : 12
1006 : 5
1007 : 1
186 : 1
```
###### After

```
Count distinct durations (ms):  
0 : 52
1 : 652
33 : 1
2 : 235
3 : 35
4 : 11
5 : 4
6 : 4
7 : 1
10 : 1
12 : 1
13 : 1
16 : 1
379 : 1
```

_Disclaimer: Not that this is a great test but the result is pretty evident for a localized change._
