### PR TITLE
Adding auto-release and replayable options for content.

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/AutoReleaseOperator.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/AutoReleaseOperator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.util.ReferenceCountUtil;
+import rx.Observable.Operator;
+import rx.Subscriber;
+
+class AutoReleaseOperator<T> implements Operator<T, T> {
+
+    @Override
+    public Subscriber<? super T> call(final Subscriber<? super T> subscriber) {
+        return new Subscriber<T>(subscriber) {
+            @Override
+            public void onCompleted() {
+                subscriber.onCompleted();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                subscriber.onError(e);
+            }
+
+            @Override
+            public void onNext(T t) {
+                try {
+                    subscriber.onNext(t);
+                } finally {
+                    ReferenceCountUtil.release(t);
+                }
+            }
+        };
+    }
+}

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/Connection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/Connection.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.ReferenceCountUtil;
 import rx.Observable;
-import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Func1;
 
@@ -68,12 +67,11 @@ public abstract class Connection<R, W> implements ChannelOperations<W> {
      *
      * @return The stream of data that is read from the connection.
      */
-    public Observable<R> getInput() {
-        return Observable.create(new OnSubscribe<R>() {
+    public ContentSource<R> getInput() {
+        return new ContentSource<>(nettyChannel, new Func1<Subscriber<? super R>, Object>() {
             @Override
-            public void call(Subscriber<? super R> subscriber) {
-                nettyChannel.pipeline()
-                            .fireUserEventTriggered(new ConnectionInputSubscriberEvent<>(subscriber, Connection.this));
+            public Object call(Subscriber<? super R> subscriber) {
+                return new ConnectionInputSubscriberEvent<>(subscriber, Connection.this);
             }
         });
     }

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/ContentSource.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/ContentSource.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.Channel;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+
+/**
+ * A source for any content/data read from a channel.
+ *
+ * <h2>Managing {@link ByteBuf} lifecycle.</h2>
+ *
+ * If this source emits {@link ByteBuf} or a {@link ByteBufHolder}, using {@link #autoRelease()} will release the buffer
+ * after emitting it from this source.
+ *
+ * <h2>Replaying content</h2>
+ *
+ * Since, the content read from a channel is not re-readable, this also provides a {@link #replayable()} function that
+ * produces a source which can be subscribed multiple times to replay the same data. This is specially useful if the
+ * content read from one channel is written on to another with an option to retry.
+ *
+ * @param <T>
+ */
+public final class ContentSource<T> extends Observable<T> {
+
+    public ContentSource(final Channel channel, final Func1<Subscriber<? super T>, Object> subscriptionEventFactory) {
+        super(new OnSubscribe<T>() {
+            @Override
+            public void call(Subscriber<? super T> subscriber) {
+                channel.pipeline()
+                       .fireUserEventTriggered(subscriptionEventFactory.call(subscriber));
+            }
+        });
+    }
+
+    public ContentSource(final Throwable error) {
+        super(new OnSubscribe<T>() {
+            @Override
+            public void call(Subscriber<? super T> subscriber) {
+                subscriber.onError(error);
+            }
+        });
+    }
+
+    /**
+     * If this source emits {@link ByteBuf} or {@link ByteBufHolder} then using this operator will release the buffer
+     * after it is emitted from this source.
+     *
+     * @return A new instance of the stream with auto-release enabled.
+     */
+    public Observable<T> autoRelease() {
+        return this.lift(new AutoReleaseOperator<T>());
+    }
+
+    /**
+     * This provides a replayable content source that only subscribes once to the actual content and then caches it,
+     * till {@link DisposableContentSource#dispose()} is called.
+     *
+     * @return A new replayable content source.
+     */
+    public DisposableContentSource<T> replayable() {
+        return DisposableContentSource.createNew(this);
+    }
+}

--- a/rxnetty-common/src/main/java/io/reactivex/netty/channel/DisposableContentSource.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/channel/DisposableContentSource.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.ReferenceCountUtil;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action1;
+import rx.observables.ConnectableObservable;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Similar to {@link ContentSource} but supports multicast to multiple subscriptions. This source, subscribes upstream
+ * once and then caches the content, till the time {@link #dispose()} is called.
+ *
+ * <h2>Managing {@link ByteBuf} lifecycle.</h2>
+ *
+ * If this source emits {@link ByteBuf} or a {@link ByteBufHolder}, using {@link #autoRelease()} will release the buffer
+ * after emitting it from this source.
+ *
+ * Every subscriber to this source must manage it's own lifecycle of the items it receives i.e. the buffers must be
+ * released by every subscriber post processing.
+ *
+ * <h2>Disposing the source</h2>
+ *
+ * It is mandatory to call {@link #dispose()} on this source when no more subscriptions are required. Failure to do so,
+ * will cause a buffer leak as this source, caches the contents till disposed.
+ *
+ * Typically, {@link #dispose()} can be called as an {@link Subscriber#unsubscribe()} action.
+ *
+ * @param <T> Type of objects emitted by this source.
+ */
+public final class DisposableContentSource<T> extends Observable<T> {
+
+    private final OnSubscribeImpl<T> onSubscribe;
+
+    private DisposableContentSource(final OnSubscribeImpl<T> onSubscribe) {
+        super(onSubscribe);
+        this.onSubscribe = onSubscribe;
+    }
+
+    /**
+     * If this source emits {@link ByteBuf} or {@link ByteBufHolder} then using this operator will release the buffer
+     * after it is emitted from this source.
+     *
+     * @return A new instance of the stream with auto-release enabled.
+     */
+    public Observable<T> autoRelease() {
+        return this.lift(new AutoReleaseOperator<T>());
+    }
+
+    /**
+     * Disposes this source.
+     */
+    public void dispose() {
+        if (onSubscribe.disposed.compareAndSet(false, true)) {
+            for (Object chunk : onSubscribe.chunks) {
+                ReferenceCountUtil.release(chunk);
+            }
+            onSubscribe.chunks.clear();
+        }
+    }
+
+    static <X> DisposableContentSource<X> createNew(Observable<X> source) {
+        final ArrayList<X> chunks = new ArrayList<>();
+        ConnectableObservable<X> replay = source.doOnNext(new Action1<X>() {
+            @Override
+            public void call(X x) {
+                chunks.add(x);
+            }
+        }).replay();
+        return new DisposableContentSource<>(new OnSubscribeImpl<X>(replay, chunks));
+    }
+
+    private static class OnSubscribeImpl<T> implements OnSubscribe<T> {
+
+        private final ConnectableObservable<T> source;
+        private final ArrayList<T> chunks;
+        private boolean subscribed;
+        private final AtomicBoolean disposed = new AtomicBoolean();
+
+        public OnSubscribeImpl(ConnectableObservable<T> source, ArrayList<T> chunks) {
+            this.source = source;
+            this.chunks = chunks;
+        }
+
+        @Override
+        public void call(Subscriber<? super T> subscriber) {
+
+            if (disposed.get()) {
+                subscriber.onError(new IllegalStateException("Content source is already disposed."));
+            }
+
+            boolean connectNow = false;
+
+            synchronized (this) {
+                if (!subscribed) {
+                    connectNow = true;
+                    subscribed = true;
+                }
+            }
+
+            source.doOnNext(new Action1<T>() {
+                @Override
+                public void call(T msg) {
+                    ReferenceCountUtil.retain(msg);
+                }
+            }).unsafeSubscribe(subscriber);
+
+            if (connectNow) {
+                source.connect();
+            }
+        }
+    }
+}

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/ContentSourceRule.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/ContentSourceRule.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Func1;
+import rx.observers.TestSubscriber;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+
+public class ContentSourceRule extends ExternalResource implements Func1<Subscriber<? super ByteBuf>, Object> {
+
+    private ByteBuf data;
+    private EmbeddedChannel channel;
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                data = Unpooled.buffer().writeBytes("Hello".getBytes());
+                channel = new EmbeddedChannel(new ChannelDuplexHandler() {
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                        if (evt instanceof SourceEvent) {
+                            SourceEvent sourceEvent = (SourceEvent) evt;
+                            sourceEvent.subscriber.onNext(data);
+                            sourceEvent.subscriber.onCompleted();
+                        }
+                        super.userEventTriggered(ctx, evt);
+                    }
+                });
+                base.evaluate();
+            }
+        };
+    }
+
+    public EmbeddedChannel getChannel() {
+        return channel;
+    }
+
+    public ByteBuf getData() {
+        return data;
+    }
+
+    public TestSubscriber<ByteBuf> subscribe(Observable<ByteBuf> source, int expectedRefCnt) {
+        TestSubscriber<ByteBuf> subscriber = new TestSubscriber<>();
+        source.subscribe(subscriber);
+        subscriber.awaitTerminalEvent();
+        subscriber.assertValue(data);
+
+        ByteBuf data = subscriber.getOnNextEvents().get(0);
+
+        assertThat("Unexpected ref count of data", data.refCnt(), is(expectedRefCnt));
+        return subscriber;
+    }
+
+    @Override
+    public Object call(Subscriber<? super ByteBuf> subscriber) {
+        return new SourceEvent(subscriber);
+    }
+
+    public static class SourceEvent {
+
+        private final Subscriber<? super ByteBuf> subscriber;
+
+        public SourceEvent(Subscriber<? super ByteBuf> subscriber) {
+            this.subscriber = subscriber;
+        }
+
+        public Subscriber<?> getSubscriber() {
+            return subscriber;
+        }
+    }
+}

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/ContentSourceTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/ContentSourceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.Rule;
+import org.junit.Test;
+import rx.observers.TestSubscriber;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+
+public class ContentSourceTest {
+
+    @Rule
+    public final ContentSourceRule sourceRule = new ContentSourceRule();
+
+    @Test(timeout = 60000)
+    public void testNoAutoRelease() throws Exception {
+        ContentSource<ByteBuf> source = new ContentSource<>(sourceRule.getChannel(), sourceRule);
+        sourceRule.subscribe(source, 1);
+    }
+
+    @Test(timeout = 60000)
+    public void testAutoRelease() throws Exception {
+        ContentSource<ByteBuf> source = new ContentSource<>(sourceRule.getChannel(), sourceRule);
+        sourceRule.subscribe(source.autoRelease(), 0);
+    }
+
+    @Test(timeout = 60000)
+    public void testReplayable() throws Exception {
+        DisposableContentSource<ByteBuf> disposable = new ContentSource<>(sourceRule.getChannel(), sourceRule).replayable();
+        sourceRule.subscribe(disposable.autoRelease(), 1);
+        sourceRule.subscribe(disposable.autoRelease(), 1);
+
+        assertThat("Unexpected ref count before dispose.", sourceRule.getData().refCnt(), is(1));
+
+        disposable.dispose();
+
+        assertThat("Unexpected ref count after dispose.", sourceRule.getData().refCnt(), is(0));
+    }
+
+    @Test(timeout = 60000)
+    public void testSubscribePostDispose() throws Exception {
+        DisposableContentSource<ByteBuf> disposable = new ContentSource<>(sourceRule.getChannel(), sourceRule).replayable();
+        sourceRule.subscribe(disposable.autoRelease(), 1);
+        disposable.dispose();
+
+        TestSubscriber<ByteBuf> subscriber = new TestSubscriber<>();
+        disposable.subscribe(subscriber);
+        subscriber.awaitTerminalEvent();
+        subscriber.assertError(IllegalStateException.class);
+    }
+}

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientResponse.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientResponse.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.reactivex.netty.channel.Connection;
+import io.reactivex.netty.channel.ContentSource;
 import io.reactivex.netty.protocol.http.internal.HttpMessageFormatter;
 import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
 import rx.Observable;
@@ -363,7 +364,7 @@ public abstract class HttpClientResponse<T> {
      *
      * @return Stream of content as {@link ServerSentEvent} messages.
      */
-    public abstract Observable<ServerSentEvent> getContentAsServerSentEvents();
+    public abstract ContentSource<ServerSentEvent> getContentAsServerSentEvents();
 
     /**
      * Returns the content as a stream. There can only be one {@link Subscriber} to the returned {@link Observable}, any
@@ -371,7 +372,7 @@ public abstract class HttpClientResponse<T> {
      *
      * @return Stream of content.
      */
-    public abstract Observable<T> getContent();
+    public abstract ContentSource<T> getContent();
 
     /**
      * Marks the content to be discarded. This means that the content can not be read from this response from now.

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/HttpClientResponseImpl.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/HttpClientResponseImpl.java
@@ -19,15 +19,16 @@ package io.reactivex.netty.protocol.http.client.internal;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.util.ReferenceCountUtil;
 import io.reactivex.netty.channel.Connection;
+import io.reactivex.netty.channel.ContentSource;
 import io.reactivex.netty.protocol.http.CookiesHolder;
 import io.reactivex.netty.protocol.http.HttpHandlerNames;
 import io.reactivex.netty.protocol.http.client.HttpClientResponse;
@@ -37,7 +38,6 @@ import io.reactivex.netty.protocol.http.sse.client.ServerSentEventDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
-import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Func1;
 
@@ -244,7 +244,7 @@ public final class HttpClientResponseImpl<T> extends HttpClientResponse<T> {
     }
 
     @Override
-    public Observable<ServerSentEvent> getContentAsServerSentEvents() {
+    public ContentSource<ServerSentEvent> getContentAsServerSentEvents() {
         if (containsHeader(CONTENT_TYPE, "text/event-stream", false)) {
             ChannelPipeline pipeline = unsafeNettyChannel().pipeline();
             ChannelHandlerContext decoderCtx = pipeline.context(HttpResponseDecoder.class);
@@ -255,20 +255,20 @@ public final class HttpClientResponseImpl<T> extends HttpClientResponse<T> {
             return _contentObservable();
         }
 
-        return Observable.error(new IllegalStateException("Response is not a server sent event response."));
+        return new ContentSource<>(new IllegalStateException("Response is not a server sent event response."));
     }
 
     @Override
-    public Observable<T> getContent() {
+    public ContentSource<T> getContent() {
         return _contentObservable();
     }
 
-    protected <X> Observable<X> _contentObservable() {
-        return Observable.create(new OnSubscribe<X>() {
+    protected <X> ContentSource<X> _contentObservable() {
+
+        return new ContentSource<>(unsafeNettyChannel(), new Func1<Subscriber<? super X>, Object>() {
             @Override
-            public void call(Subscriber<? super X> subscriber) {
-                unsafeNettyChannel().pipeline()
-                                    .fireUserEventTriggered(new HttpContentSubscriberEvent<>(subscriber));
+            public Object call(Subscriber<? super X> subscriber) {
+                return new HttpContentSubscriberEvent<>(subscriber);
             }
         });
     }

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerRequest.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerRequest.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.Cookie;
+import io.reactivex.netty.channel.ContentSource;
 import io.reactivex.netty.protocol.http.internal.HttpMessageFormatter;
 import rx.Observable;
 import rx.Subscriber;
@@ -390,7 +391,7 @@ public abstract class HttpServerRequest<T> {
      *
      * @return Stream of content.
      */
-    public abstract Observable<T> getContent();
+    public abstract ContentSource<T> getContent();
 
     /**
      * Subscribes to the content and discards.

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerRequestImpl.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerRequestImpl.java
@@ -18,18 +18,18 @@ package io.reactivex.netty.protocol.http.server;
 
 import io.netty.channel.Channel;
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.util.ReferenceCountUtil;
+import io.reactivex.netty.channel.ContentSource;
 import io.reactivex.netty.protocol.http.CookiesHolder;
 import io.reactivex.netty.protocol.http.internal.HttpContentSubscriberEvent;
 import io.reactivex.netty.protocol.http.ws.server.WebSocketHandshaker;
 import rx.Observable;
-import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Func1;
 
@@ -254,12 +254,12 @@ public class HttpServerRequestImpl<T> extends HttpServerRequest<T> {
     }
 
     @Override
-    public Observable<T> getContent() {
-        return Observable.create(new OnSubscribe<T>() {
+    public ContentSource<T> getContent() {
+
+        return new ContentSource<T>(nettyChannel, new Func1<Subscriber<? super T>, Object>() {
             @Override
-            public void call(Subscriber<? super T> subscriber) {
-                nettyChannel.pipeline()
-                            .fireUserEventTriggered(new HttpContentSubscriberEvent<>(subscriber));
+            public Object call(Subscriber<? super T> subscriber) {
+                return new HttpContentSubscriberEvent<>(subscriber);
             }
         });
     }

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/ws/client/internal/WebSocketResponseImpl.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/ws/client/internal/WebSocketResponseImpl.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.reactivex.netty.channel.Connection;
+import io.reactivex.netty.channel.ContentSource;
 import io.reactivex.netty.client.ClientConnectionToChannelBridge;
 import io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
@@ -226,12 +227,12 @@ public final class WebSocketResponseImpl<T> extends WebSocketResponse<T> {
     }
 
     @Override
-    public Observable<ServerSentEvent> getContentAsServerSentEvents() {
+    public ContentSource<ServerSentEvent> getContentAsServerSentEvents() {
         return delegate.getContentAsServerSentEvents();
     }
 
     @Override
-    public Observable<T> getContent() {
+    public ContentSource<T> getContent() {
         return delegate.getContent();
     }
 


### PR DESCRIPTION
- In absence of asynchronous processing, auto-release of content buffers is the correct thing to do. `.autoRelease()` makes it possible to do it will less effort.
- Content (HTTP and Connection input) can only be read once, but in some cases, it may be required to subscribe to it twice i.e. for retries. The associated overhead of doing that is the management of the lifecycle of `ByteBuf`. `.replayable()` provides a way to multi-subscribe to the content, with a need to `dispose()` after use.
