### PR TITLE
Handling content subscription after request/response completion.

### DIFF
--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/internal/UpgradedHttpContentSubscriberEvent.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/internal/UpgradedHttpContentSubscriberEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.reactivex.netty.protocol.http.internal;
+
+import rx.Subscriber;
+
+public class UpgradedHttpContentSubscriberEvent<T> extends HttpContentSubscriberEvent<T> {
+
+    public UpgradedHttpContentSubscriberEvent(Subscriber<? super T> subscriber) {
+        super(subscriber);
+    }
+}

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/ws/WebSocketConnection.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/ws/WebSocketConnection.java
@@ -19,7 +19,7 @@ package io.reactivex.netty.protocol.http.ws;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.reactivex.netty.channel.Connection;
-import io.reactivex.netty.protocol.http.internal.HttpContentSubscriberEvent;
+import io.reactivex.netty.protocol.http.internal.UpgradedHttpContentSubscriberEvent;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
@@ -60,7 +60,7 @@ public final class WebSocketConnection {
             @Override
             public void call(Subscriber<? super WebSocketFrame> subscriber) {
                 delegate.unsafeNettyChannel().pipeline()
-                        .fireUserEventTriggered(new HttpContentSubscriberEvent<>(subscriber));
+                        .fireUserEventTriggered(new UpgradedHttpContentSubscriberEvent<>(subscriber));
             }
         });
         if (untilCloseFrame) {


### PR DESCRIPTION
Today, it is possible to subscribe to HTTP request/response content even after the completion of the request/response.
This would result in either the subscriber never finishing or messing up subscriptions for any subsequent request/response on that connection.

For websocket, it is valid for a content to be subscribed to after the content completes but for non-upgraded requests, it is always expected to subscribe to content after header read and before content completion.

This change adds the check that a content subscription should always arrive after header receive and before content completion.

 For WS, this restriction is relaxed.
