### PR TITLE
Check for success/failure on websocket handshake completion (fixes #452)

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
@@ -80,9 +80,7 @@ public class WebSocketClient<I extends WebSocketFrame, O extends WebSocketFrame>
                         handler.addHandshakeFinishedListener(new ChannelFutureListener() {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
-                                if (future.isCancelled()) {
-                                    originalSubscriber.unsubscribe();
-                                } else if (future.isSuccess()) {
+                                if (future.isSuccess()) {
                                     originalSubscriber.onNext(connection);
                                     originalSubscriber.onCompleted();
                                 } else {

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/websocket/WebSocketClient.java
@@ -80,8 +80,14 @@ public class WebSocketClient<I extends WebSocketFrame, O extends WebSocketFrame>
                         handler.addHandshakeFinishedListener(new ChannelFutureListener() {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
-                                originalSubscriber.onNext(connection);
-                                originalSubscriber.onCompleted();
+                                if (future.isCancelled()) {
+                                    originalSubscriber.unsubscribe();
+                                } else if (future.isSuccess()) {
+                                    originalSubscriber.onNext(connection);
+                                    originalSubscriber.onCompleted();
+                                } else {
+                                    originalSubscriber.onError(future.cause());
+                                }
                             }
                         });
                     } else {


### PR DESCRIPTION
This fixes the issue where the WebSocket client fails to signal error on handshake failure.
