### PR TITLE
Potential Fix for Memory Leak Issue #466

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequiredConfigurator.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/ClientRequiredConfigurator.java
@@ -15,6 +15,8 @@
  */
 package io.reactivex.netty.protocol.http.client;
 
+import java.util.concurrent.TimeUnit;
+
 import io.netty.channel.ChannelPipeline;
 import io.reactivex.netty.client.ClientMetricsEvent;
 import io.reactivex.netty.metrics.MetricEventsSubject;
@@ -30,9 +32,18 @@ import io.reactivex.netty.pipeline.PipelineConfigurator;
 class ClientRequiredConfigurator<I, O> implements PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> {
 
     private final MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject;
+    private final long responseSubscriptionTimeout;
+    private final TimeUnit responseSubscriptionTimeoutUnit;
 
     public ClientRequiredConfigurator(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject) {
+        this(eventsSubject, 0, TimeUnit.MILLISECONDS);
+    }
+
+    public ClientRequiredConfigurator(MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject,
+        long responseSubscriptionTimeout, TimeUnit responseSubscriptionTimeoutUnit) {
         this.eventsSubject = eventsSubject;
+        this.responseSubscriptionTimeout = responseSubscriptionTimeout;
+        this.responseSubscriptionTimeoutUnit = responseSubscriptionTimeoutUnit;
     }
 
     @Override
@@ -40,7 +51,8 @@ class ClientRequiredConfigurator<I, O> implements PipelineConfigurator<HttpClien
         ClientRequestResponseConverter converter = pipeline.get(ClientRequestResponseConverter.class);
         if (null == converter) {
             pipeline.addLast(HttpClientPipelineConfigurator.REQUEST_RESPONSE_CONVERTER_HANDLER_NAME,
-                             new ClientRequestResponseConverter(eventsSubject));
+                             new ClientRequestResponseConverter(eventsSubject, responseSubscriptionTimeout,
+                                 responseSubscriptionTimeoutUnit));
         }
     }
 }

--- a/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -16,6 +16,8 @@
 
 package io.reactivex.netty.protocol.http.client;
 
+import java.util.concurrent.TimeUnit;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
@@ -107,9 +109,16 @@ public class HttpClientImpl<I, O> extends RxClientImpl<HttpClientRequest<I>, Htt
     protected PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> adaptPipelineConfigurator(
             PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> pipelineConfigurator,
             ClientConfig clientConfig, MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject) {
+        long responseSubscriptionTimeoutMs = 0;
+        if (clientConfig instanceof HttpClientConfig) {
+            HttpClientConfig httpClientConfig = (HttpClientConfig) clientConfig;
+            responseSubscriptionTimeoutMs = httpClientConfig.getResponseSubscriptionTimeoutMs();
+        }
         PipelineConfigurator<HttpClientResponse<O>, HttpClientRequest<I>> configurator =
                 new PipelineConfiguratorComposite<HttpClientResponse<O>, HttpClientRequest<I>>(pipelineConfigurator,
-                                                     new ClientRequiredConfigurator<I, O>(eventsSubject));
+                                                     new ClientRequiredConfigurator<I, O>(
+                                                         eventsSubject, responseSubscriptionTimeoutMs,
+                                                         TimeUnit.MILLISECONDS));
         return super.adaptPipelineConfigurator(configurator, clientConfig, eventsSubject);
     }
 


### PR DESCRIPTION
If a response subscription timeout is configured, pass this timeout into the ClientRequestResponseConverter so that it can create a UnicastContentSubject with a timeout. This fix addresses issue #466
