### PR TITLE
Fixes #496 - Marks netty-transport-native-epoll dependency as optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@
  */
 buildscript {
     repositories { jcenter() }
-    dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.+' }
+    dependencies {
+        classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.+'
+        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
+    }
 }
 
 description = 'RxNetty: Reactive Extensions for Netty'
@@ -24,6 +27,7 @@ description = 'RxNetty: Reactive Extensions for Netty'
 apply plugin: 'rxjava-project'
 
 configure(subprojects) {
+    apply plugin: 'nebula.optional-base'
     apply plugin: 'rxjava-project'
     apply plugin: 'java'
 

--- a/rxnetty-common/build.gradle
+++ b/rxnetty-common/build.gradle
@@ -20,6 +20,6 @@ plugins {
 
 dependencies {
     compile "io.netty:netty-handler:${netty_version}"
-    compile "io.netty:netty-transport-native-epoll:${netty_version}"
+    compile "io.netty:netty-transport-native-epoll:${netty_version}", optional
     compile "org.slf4j:slf4j-api:${slf4j_version}"
 }


### PR DESCRIPTION
The dependency `io.netty:netty-transport-native-epoll` is now optional and is not transitively included in the classpath of RxNetty's users

To enable Netty's native support, the user should explicitly add two dependencies:
- The one now marked as optional:
  `compile group:"io.netty", name:"netty-transport-native-epoll", version:"${netty_version}"`
- and one to get the binary specific to the OS:
  `compile group:"io.netty", name:"netty-transport-native-epoll", version:"${netty_version}", classifier: 'linux-x86_64`'

See #259 for more on how to active native support
