### PR TITLE
Fixing test flakiness.

### DIFF
--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/HelloSseServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/HelloSseServer.java
@@ -45,7 +45,7 @@ public final class HelloSseServer {
                            .start((req, resp) ->
                                           resp.transformToServerSentEvents()
                                               .writeAndFlushOnEach(Observable.interval(10, TimeUnit.MILLISECONDS)
-                                                                             .onBackpressureDrop()
+                                                                             .onBackpressureBuffer(10)
                                                                              .map(aLong -> withData(
                                                                                      "Interval => " + aLong)))
                            );

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/streaming/StreamingServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/streaming/StreamingServer.java
@@ -41,7 +41,7 @@ public final class StreamingServer {
                            .start((req, resp) ->
                                           resp.writeStringAndFlushOnEach(
                                                   Observable.interval(10, TimeUnit.MILLISECONDS)
-                                                            .onBackpressureDrop()
+                                                            .onBackpressureBuffer(10)
                                                             .map(aLong -> "Interval =>" + aLong)
                                           )
                            );


### PR DESCRIPTION
Servers in these examples were using `onBackpressureDrop()` for infinite streams.
This leads to test flakiness as when an element is dropped, the output becomes indeterminate w.r.t order/presence of items which leads to test failures.

Now, instead using `onBackpressureBuffer()` with a limit of 10 as the clients need 10 items.
