### PR TITLE
Named wire loggers.

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientState.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientState.java
@@ -30,6 +30,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -203,8 +204,12 @@ public class ClientState<W, R> {
     }
 
     public ClientState<W, R> enableWireLogging(final LogLevel wireLoggingLevel) {
+        return enableWireLogging(LoggingHandler.class.getName(), wireLoggingLevel);
+    }
+
+    public ClientState<W, R> enableWireLogging(String name, final LogLevel wireLoggingLevel) {
         return addChannelHandlerFirst(WireLogging.getName(),
-                                      LoggingHandlerFactory.getFactory(wireLoggingLevel));
+                                      LoggingHandlerFactory.getFactory(name, wireLoggingLevel));
     }
 
     public static <WW, RR> ClientState<WW, RR> create(ConnectionProviderFactory<WW, RR> factory,
@@ -254,7 +259,7 @@ public class ClientState<W, R> {
                 ch.pipeline().addLast(ClientChannelActiveBufferingHandler.getName(),
                                       new ChannelActivityBufferingHandler());
             }
-                });
+        });
         return nettyBootstrap;
     }
 

--- a/rxnetty-common/src/main/java/io/reactivex/netty/server/ServerState.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/server/ServerState.java
@@ -157,10 +157,14 @@ public abstract class ServerState<R, W> {
     }
 
     public ServerState<R, W> enableWireLogging(final LogLevel wireLoggingLevel) {
+        return enableWireLogging(LoggingHandler.class.getName(), wireLoggingLevel);
+    }
+
+    public ServerState<R, W> enableWireLogging(final String name, final LogLevel wireLoggingLevel) {
         return addChannelHandlerFirst(HandlerNames.WireLogging.getName(), new Func0<ChannelHandler>() {
             @Override
             public ChannelHandler call() {
-                return new LoggingHandler(wireLoggingLevel);
+                return new LoggingHandler(name, wireLoggingLevel);
             }
         });
     }

--- a/rxnetty-common/src/test/java/io/reactivex/netty/client/ClientStateTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/client/ClientStateTest.java
@@ -246,7 +246,7 @@ public class ClientStateTest {
 
     @Test(timeout = 60000)
     public void testEnableWireLogging() throws Exception {
-        ClientState<String, String> newState = clientStateRule.clientState.enableWireLogging(LogLevel.ERROR);
+        ClientState<String, String> newState = clientStateRule.clientState.enableWireLogging("", LogLevel.ERROR);
 
         clientStateRule.verifyMockPipelineAccessPostCopy();
         assertThat("Client state not copied.", clientStateRule.clientState, is(not(newState)));
@@ -255,8 +255,8 @@ public class ClientStateTest {
         assertThat("Detached pipeline not copied.", clientStateRule.clientState.unsafeDetachedPipeline(),
                    is(not(newState.unsafeDetachedPipeline())));
 
-        Mockito.verify(newState.unsafeDetachedPipeline()).addFirst(HandlerNames.WireLogging.getName(),
-                                                                   LoggingHandlerFactory.getFactory(LogLevel.ERROR));
+        Mockito.verify(newState.unsafeDetachedPipeline())
+               .addFirst(HandlerNames.WireLogging.getName(), LoggingHandlerFactory.getFactory("", LogLevel.ERROR));
 
         Mockito.verifyNoMoreInteractions(newState.unsafeDetachedPipeline());
         Mockito.verifyNoMoreInteractions(clientStateRule.mockPipeline);

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/helloworld/HelloWorldClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/helloworld/HelloWorldClient.java
@@ -56,7 +56,7 @@ import java.nio.charset.Charset;
  *
  * @see HelloWorldServer Default server for this client.
  */
-public class HelloWorldClient {
+public final class HelloWorldClient {
 
     public static void main(String[] args) {
 
@@ -74,7 +74,7 @@ public class HelloWorldClient {
         SocketAddress serverAddress = env.getServerAddress(HelloWorldServer.class, args);
 
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("hello-client", LogLevel.DEBUG)
                   .createGet("/hello")
                   .doOnNext(resp -> logger.info(resp.toString()))
                   .flatMap(resp -> resp.getContent()

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/simple/InterceptingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/simple/InterceptingClient.java
@@ -66,7 +66,7 @@ import static io.reactivex.netty.examples.http.interceptors.simple.InterceptingS
  *
  * @see InterceptingServer Default server for this client.
  */
-public class InterceptingClient {
+public final class InterceptingClient {
 
     public static void main(String[] args) {
 
@@ -84,7 +84,7 @@ public class InterceptingClient {
         SocketAddress serverAddress = env.getServerAddress(InterceptingServer.class, args);
 
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("inter-client", LogLevel.DEBUG)
                   .intercept()
                   .next(provider -> (version, method, uri) -> provider.createRequest(version, method, uri)
                                                                       .addHeader(INTERCEPTOR_HEADER_NAME, "client"))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/simple/InterceptingServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/simple/InterceptingServer.java
@@ -33,7 +33,7 @@ import static rx.Observable.*;
  *
  * This server sends a response with "Hello World" as the content for any request that it receives.
  */
-public class InterceptingServer {
+public final class InterceptingServer {
 
     public static final String INTERCEPTOR_HEADER_NAME = "X-from-interceptor";
 
@@ -44,7 +44,7 @@ public class InterceptingServer {
         HttpServer<ByteBuf, ByteBuf> server;
 
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("inter-server", LogLevel.DEBUG)
                            .start(HttpServerInterceptorChain.startRaw()
                                                             .next(addHeader())
                                                             .end((req, resp) -> resp.writeString(just("Hello World!")))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/transformation/InterceptingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/transformation/InterceptingClient.java
@@ -70,7 +70,7 @@ import java.util.List;
  *
  * @see TransformingInterceptorsServer Default server for this client.
  */
-public class InterceptingClient {
+public final class InterceptingClient {
 
     public static void main(String[] args) {
 
@@ -89,7 +89,7 @@ public class InterceptingClient {
 
         HttpClient.newClient(serverAddress)
                 .<ByteBuf, String>addChannelHandlerLast("line-decoder", HttpContentStringLineDecoder::new)
-                .enableWireLogging(LogLevel.DEBUG)
+                .enableWireLogging("inter-client", LogLevel.DEBUG)
                 .intercept()
                 .<Integer, Integer>nextWithTransform(readWriteInts())
                 .finish()

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/transformation/TransformingInterceptorsServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/interceptors/transformation/TransformingInterceptorsServer.java
@@ -54,7 +54,7 @@ public final class TransformingInterceptorsServer {
 
         server = HttpServer.newServer()
                            .<String, ByteBuf>addChannelHandlerLast("line-decoder", HttpContentStringLineDecoder::new)
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("inter-server", LogLevel.DEBUG)
                            .start(HttpServerInterceptorChain.<String, ByteBuf>start()
                                           .<Integer, Integer>nextWithTransform(readWriteInts())
                                           .end(numberIncrementingHandler()));
@@ -80,7 +80,7 @@ public final class TransformingInterceptorsServer {
                                   response.transformContent(new AllocatingTransformer<Integer, ByteBuf>() {
                                       @Override
                                       public List<ByteBuf> transform(Integer toTransform, ByteBufAllocator allocator) {
-                                          String msg = toTransform.toString() + "\n";
+                                          String msg = toTransform.toString() + '\n';
                                           return singletonList(allocator.buffer()
                                                                         .writeBytes(msg.getBytes())
                                           );

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/loadbalancing/HttpLoadBalancingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/loadbalancing/HttpLoadBalancingClient.java
@@ -65,7 +65,7 @@ public final class HttpLoadBalancingClient {
                                                  .map(Host::new);
 
         HttpClient.newClient(LoadBalancerFactory.create(new EWMABasedP2CStrategy<>()), hosts)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("lb-client", LogLevel.DEBUG)
                   .createGet("/hello")
                   .doOnNext(resp -> logger.info(resp.toString()))
                   .flatMap((HttpClientResponse<ByteBuf> resp) ->

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/perf/PerfHelloWorldClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/perf/PerfHelloWorldClient.java
@@ -30,7 +30,7 @@ import java.nio.charset.Charset;
  * A client to test {@link PerfHelloWorldServer}. This client is provided here only for completeness of the example,
  * otherwise, it is exactly the same as {@link HelloWorldClient}.
  */
-public class PerfHelloWorldClient {
+public final class PerfHelloWorldClient {
 
     public static void main(String[] args) {
 
@@ -48,7 +48,7 @@ public class PerfHelloWorldClient {
         SocketAddress serverAddress = env.getServerAddress(PerfHelloWorldServer.class, args);
 
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("perf-client", LogLevel.DEBUG)
                   .createGet("/hello")
                   .doOnNext(resp -> logger.info(resp.toString()))
                   .flatMap(resp -> resp.getContent()

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/proxy/ProxyClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/proxy/ProxyClient.java
@@ -30,7 +30,7 @@ import java.nio.charset.Charset;
  * A client to test {@link ProxyServer}. This client is provided here only for completeness of the example,
  * otherwise, it is exactly the same as {@link HelloWorldClient}.
  */
-public class ProxyClient {
+public final class ProxyClient {
 
     public static void main(String[] args) {
 
@@ -48,7 +48,7 @@ public class ProxyClient {
         SocketAddress serverAddress = env.getServerAddress(ProxyServer.class, args);
 
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("proxy-client", LogLevel.DEBUG)
                   .createGet("/hello")
                   .doOnNext(resp -> logger.info(resp.toString()))
                   .flatMap(resp -> resp.getContent()

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/proxy/ProxyServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/proxy/ProxyServer.java
@@ -59,7 +59,7 @@ public final class ProxyServer {
 
         /*Starts a new HTTP server on an ephemeral port which acts as a proxy to the target server started above.*/
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("proxy-server", LogLevel.DEBUG)
                            .start((serverReq, serverResp) -> {
                                       /*
                                        * Create a new HTTP request for the target server, using the method and URI from

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/secure/SecureHelloWorldClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/secure/SecureHelloWorldClient.java
@@ -56,7 +56,7 @@ import java.nio.charset.Charset;
  *
  * @see SecureHelloWorldServer Default server for this client.
  */
-public class SecureHelloWorldClient {
+public final class SecureHelloWorldClient {
 
     public static void main(String[] args) {
 
@@ -74,7 +74,7 @@ public class SecureHelloWorldClient {
         SocketAddress serverAddress = env.getServerAddress(SecureHelloWorldServer.class, args);
 
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("inter-client", LogLevel.DEBUG)
                   .unsafeSecure()
                   .createGet("/hello")
                   .doOnNext(resp -> logger.info(resp.toString()))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/secure/SecureHelloWorldServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/secure/SecureHelloWorldServer.java
@@ -37,7 +37,7 @@ public final class SecureHelloWorldServer {
         HttpServer<ByteBuf, ByteBuf> server;
 
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("hello-server", LogLevel.DEBUG)
                            /*Enable HTTPS for demo purpose only, for real apps, use secure() methods instead.*/
                            .unsafeSecure()
                            .start((req, resp) ->

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/HelloSseClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/HelloSseClient.java
@@ -81,7 +81,7 @@ public final class HelloSseClient {
 
         /*Create a new client for the server address*/
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("inter-client", LogLevel.DEBUG)
                   .createGet("/sse")
                   .doOnNext(resp -> logger.info(resp.toString()))
                   .flatMap(HttpClientResponse::getContentAsServerSentEvents)

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/HelloSseServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/sse/HelloSseServer.java
@@ -41,7 +41,7 @@ public final class HelloSseServer {
         HttpServer<ByteBuf, ByteBuf> server;
 
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("sse-server", LogLevel.DEBUG)
                            .start((req, resp) ->
                                           resp.transformToServerSentEvents()
                                               .writeAndFlushOnEach(Observable.interval(10, TimeUnit.MILLISECONDS)

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/streaming/StreamingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/streaming/StreamingClient.java
@@ -64,7 +64,7 @@ import java.nio.charset.Charset;
  *
  * @see StreamingServer Default server for this client.
  */
-public class StreamingClient {
+public final class StreamingClient {
 
     public static void main(String[] args) {
 
@@ -83,7 +83,7 @@ public class StreamingClient {
 
         /*Create a new client for the server address*/
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("streaming-client", LogLevel.DEBUG)
                   /*Creates a GET request with URI "/stream"*/
                   .createGet("/stream")
                   /*Prints the response headers*/

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/streaming/StreamingServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/streaming/StreamingServer.java
@@ -37,7 +37,7 @@ public final class StreamingServer {
         HttpServer<ByteBuf, ByteBuf> server;
 
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("streaming-server", LogLevel.DEBUG)
                            .start((req, resp) ->
                                           resp.writeStringAndFlushOnEach(
                                                   Observable.interval(10, TimeUnit.MILLISECONDS)

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/echo/WebSocketEchoClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/echo/WebSocketEchoClient.java
@@ -62,7 +62,7 @@ import java.nio.charset.Charset;
  *
  * In all the above usages, this client will print the response received from the server.
  */
-public class WebSocketEchoClient {
+public final class WebSocketEchoClient {
 
     public static void main(String[] args) {
 
@@ -79,7 +79,7 @@ public class WebSocketEchoClient {
         Logger logger = env.getLogger();
 
         HttpClient.newClient(socketAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("ws-echo-client", LogLevel.DEBUG)
                   .createGet("/ws")
                   .requestWebSocketUpgrade()
                   .doOnNext(resp -> logger.info(resp.toString()))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/echo/WebSocketEchoServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/echo/WebSocketEchoServer.java
@@ -41,7 +41,7 @@ public final class WebSocketEchoServer {
 
         /*Starts a new HTTP server on an ephemeral port.*/
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("ws-server", LogLevel.DEBUG)
                            .start((req, resp) -> {
                                /*If WebSocket upgrade is requested, then accept the request with an echo handler.*/
                                if (req.isWebSocketUpgradeRequested()) {

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/messaging/MessagingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/messaging/MessagingClient.java
@@ -73,7 +73,7 @@ import java.util.concurrent.TimeUnit;
  * Since, message production is asynchronous, if this client can not connect to the server, it will buffer the messages
  * in memory and wait for the server to come up.
  */
-public class MessagingClient {
+public final class MessagingClient {
 
     public static void main(String[] args) {
 
@@ -94,7 +94,7 @@ public class MessagingClient {
 
         /*Create a new client for the server address*/
         HttpClient.newClient(socketAddress)
-                  .enableWireLogging(LogLevel.DEBUG)
+                  .enableWireLogging("msging-client", LogLevel.DEBUG)
                   .createGet("/ws")
                   .requestWebSocketUpgrade()
                   .doOnNext(resp -> logger.info(resp.toString()))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/messaging/MessagingServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/ws/messaging/MessagingServer.java
@@ -41,7 +41,7 @@ public final class MessagingServer {
 
         /*Starts a new HTTP server on an ephemeral port.*/
         server = HttpServer.newServer()
-                           .enableWireLogging(LogLevel.DEBUG)
+                           .enableWireLogging("msg-server", LogLevel.DEBUG)
                            .start((req, resp) -> {
                                /*If WebSocket upgrade is requested, then accept the request with an echo handler.*/
                                if (req.isWebSocketUpgradeRequested()) {

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/EchoClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/EchoClient.java
@@ -79,7 +79,7 @@ public final class EchoClient {
 
         /*Create a new client for the server address*/
         TcpClient.newClient(serverAddress)
-                 .enableWireLogging(LogLevel.DEBUG)
+                 .enableWireLogging("echo-client", LogLevel.DEBUG)
                  .createConnectionRequest()
                  .flatMap(connection ->
                                   connection.writeString(Observable.just("Hello World!"))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/EchoServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/echo/EchoServer.java
@@ -46,7 +46,7 @@ public final class EchoServer {
 
         /*Starts a new TCP server on an ephemeral port.*/
         server = TcpServer.newServer(0)
-                          .enableWireLogging(LogLevel.DEBUG)
+                          .enableWireLogging("echo-server", LogLevel.DEBUG)
                           .start(connection -> connection
                                   .writeStringAndFlushOnEach(connection.getInput()
                                                                        .map(bb -> bb.toString(Charset.defaultCharset()))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/loadbalancing/TcpLoadBalancingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/loadbalancing/TcpLoadBalancingClient.java
@@ -62,7 +62,7 @@ public final class TcpLoadBalancingClient {
                                                  .map(Host::new);
 
         TcpClient.<ByteBuf, ByteBuf>newClient(LoadBalancerFactory.create(new TcpLoadBalancer<>()), hosts)
-                 .enableWireLogging(LogLevel.DEBUG)
+                 .enableWireLogging("lb-client", LogLevel.DEBUG)
                  .createConnectionRequest()
                  .doOnNext(conn -> logger.info("Using host: " + conn.unsafeNettyChannel().remoteAddress()))
                  .flatMap(connection ->

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/proxy/ProxyClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/proxy/ProxyClient.java
@@ -51,7 +51,7 @@ public final class ProxyClient {
 
         /*Create a new client for the server address*/
         TcpClient.newClient(serverAddress)
-                 .enableWireLogging(LogLevel.DEBUG)
+                 .enableWireLogging("proxy-client", LogLevel.DEBUG)
                  .createConnectionRequest()
                  .flatMap(connection ->
                                   connection.writeString(Observable.just("Hello World!"))

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/proxy/ProxyServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/proxy/ProxyServer.java
@@ -56,7 +56,7 @@ public final class ProxyServer {
 
         /*Starts a new HTTP server on an ephemeral port which acts as a proxy to the target server started above.*/
         server = TcpServer.newServer()
-                          .enableWireLogging(LogLevel.DEBUG)
+                          .enableWireLogging("proxy-server", LogLevel.DEBUG)
                           .start(serverConn ->
                                          serverConn.writeStringAndFlushOnEach(
                                                  connReq.flatMap(clientConn -> {

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/secure/SecureEchoClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/secure/SecureEchoClient.java
@@ -81,7 +81,7 @@ public final class SecureEchoClient {
 
         /*Create a new client for the server address*/
         TcpClient.newClient(serverAddress)
-                 .enableWireLogging(LogLevel.DEBUG)
+                 .enableWireLogging("secure-client", LogLevel.DEBUG)
                  .unsafeSecure()
                  .createConnectionRequest()
                  .flatMap(connection ->

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/secure/SecureEchoServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/secure/SecureEchoServer.java
@@ -43,7 +43,7 @@ public final class SecureEchoServer {
 
         /*Starts a new TCP server on an ephemeral port.*/
         TcpServer<ByteBuf, ByteBuf> server = TcpServer.newServer()
-                                                      .enableWireLogging(LogLevel.DEBUG)
+                                                      .enableWireLogging("echo-server", LogLevel.DEBUG)
                                                       .unsafeSecure()
                                                       .start(connection ->
                                                                      connection.writeStringAndFlushOnEach(

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/streaming/StreamingClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/streaming/StreamingClient.java
@@ -83,7 +83,7 @@ public final class StreamingClient {
 
         /*Create a new client for the server address*/
         TcpClient.newClient(serverAddress)
-                 .enableWireLogging(LogLevel.DEBUG)
+                 .enableWireLogging("streaming-client", LogLevel.DEBUG)
                 .<ByteBuf, String>addChannelHandlerLast("string-decoder", StringLineDecoder::new)
                 .createConnectionRequest()
                 .flatMap(Connection::getInput)

--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/streaming/StreamingServer.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/tcp/streaming/StreamingServer.java
@@ -37,7 +37,7 @@ public final class StreamingServer {
         TcpServer<ByteBuf, ByteBuf> server;
 
         server = TcpServer.newServer()
-                          .enableWireLogging(LogLevel.DEBUG)
+                          .enableWireLogging("streaming-server", LogLevel.DEBUG)
                           .start(connection ->
                                          connection.writeStringAndFlushOnEach(
                                                  Observable.interval(10, TimeUnit.MILLISECONDS)

--- a/rxnetty-examples/src/main/resources/log4j.properties
+++ b/rxnetty-examples/src/main/resources/log4j.properties
@@ -17,4 +17,4 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] (%F:%L) - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%c %d{dd MMM yyyy HH:mm:ss,SSS} %5p [%t] (%F:%L) - %m%n

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/HttpClient.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/HttpClient.java
@@ -277,8 +277,23 @@ public abstract class HttpClient<I, O> extends InterceptingHttpClient<I,O> {
      *                        logging is enabled at this level for {@link LoggingHandler}
      *
      * @return A new {@link HttpClient} instance.
+     *
+     * @deprecated Use {@link #enableWireLogging(String, LogLevel)} instead.
      */
+    @Deprecated
     public abstract HttpClient<I, O> enableWireLogging(LogLevel wireLoggingLevel);
+
+    /**
+     * Creates a new client instances, inheriting all configurations from this client and enabling wire logging at the
+     * passed level for the newly created client instance.
+     *
+     * @param name Name of the logger that can be used to control the logging dynamically.
+     * @param wireLoggingLevel Logging level at which the wire logs will be logged. The wire logging will only be done if
+     *                        logging is enabled at this level for {@link LoggingHandler}
+     *
+     * @return A new {@link HttpClient} instance.
+     */
+    public abstract HttpClient<I, O> enableWireLogging(String name, LogLevel wireLoggingLevel);
 
     /**
      * Creates a new client instance, inheriting all configurations from this client and using the passed

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/HttpClientImpl.java
@@ -237,8 +237,14 @@ public final class HttpClientImpl<I, O> extends HttpClient<I, O> {
     }
 
     @Override
+    @Deprecated
     public HttpClientImpl<I, O> enableWireLogging(LogLevel wireLoggingLevel) {
         return _copy(client.enableWireLogging(wireLoggingLevel), maxRedirects);
+    }
+
+    @Override
+    public HttpClient<I, O> enableWireLogging(String name, LogLevel wireLoggingLevel) {
+        return _copy(client.enableWireLogging(name, wireLoggingLevel), maxRedirects);
     }
 
     @Override

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServer.java
@@ -272,8 +272,23 @@ public abstract class HttpServer<I, O> implements EventSource<HttpServerEventsLi
      * if logging is enabled at this level for {@link io.netty.handler.logging.LoggingHandler}
      *
      * @return A new {@link HttpServer} instance.
+     *
+     * @deprecated Use {@link #enableWireLogging(String, LogLevel)} instead.
      */
+    @Deprecated
     public abstract HttpServer<I, O> enableWireLogging(LogLevel wireLoggingLevel);
+
+    /**
+     * Creates a new client instances, inheriting all configurations from this client and enabling wire logging at the
+     * passed level for the newly created client instance.
+     *
+     * @param name Name of the logger that can be used to control the logging dynamically.
+     * @param wireLoggingLevel Logging level at which the wire logs will be logged. The wire logging will only be done
+     * if logging is enabled at this level for {@link io.netty.handler.logging.LoggingHandler}
+     *
+     * @return A new {@link HttpServer} instance.
+     */
+    public abstract HttpServer<I, O> enableWireLogging(String name, LogLevel wireLoggingLevel);
 
     /**
      * According to the <a href="http://tools.ietf.org/html/rfc2145#section-2.3">specification</a>, an HTTP server must

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerImpl.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerImpl.java
@@ -149,8 +149,14 @@ public final class HttpServerImpl<I, O> extends HttpServer<I, O> {
     }
 
     @Override
+    @Deprecated
     public HttpServer<I, O> enableWireLogging(LogLevel wireLoggingLevel) {
         return _copy(server.enableWireLogging(wireLoggingLevel), eventPublisher);
+    }
+
+    @Override
+    public HttpServer<I, O> enableWireLogging(String name, LogLevel wireLoggingLevel) {
+        return _copy(server.enableWireLogging(name, wireLoggingLevel), eventPublisher);
     }
 
     @Override

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/EventListenerTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/EventListenerTest.java
@@ -54,7 +54,7 @@ public class EventListenerTest {
     @Test(timeout = 60000)
     public void testEventListenerPostCopy() throws Exception {
         HttpClient<ByteBuf, ByteBuf> client = HttpClient.newClient(rule.serverAddress)
-                                                        .enableWireLogging(LogLevel.ERROR);
+                                                        .enableWireLogging("test", LogLevel.ERROR);
 
         assertListenerCalled(client);
     }
@@ -65,18 +65,18 @@ public class EventListenerTest {
 
         MockHttpClientEventsListener listener = subscribe(client);
 
-        client = client.enableWireLogging(LogLevel.DEBUG);
+        client = client.enableWireLogging("test", LogLevel.DEBUG);
 
         connectAndAssertListenerInvocation(client, listener);
     }
 
-    private void assertListenerCalled(HttpClient<ByteBuf, ByteBuf> client) {
+    private static void assertListenerCalled(HttpClient<ByteBuf, ByteBuf> client) {
         MockHttpClientEventsListener listener = subscribe(client);
         connectAndAssertListenerInvocation(client, listener);
     }
 
-    private void connectAndAssertListenerInvocation(HttpClient<ByteBuf, ByteBuf> client,
-                                                    MockHttpClientEventsListener listener) {
+    private static void connectAndAssertListenerInvocation(HttpClient<ByteBuf, ByteBuf> client,
+                                                           MockHttpClientEventsListener listener) {
         TestSubscriber<ByteBuf> subscriber = new TestSubscriber<>();
         client.createGet("")
               .flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>>() {
@@ -95,7 +95,7 @@ public class EventListenerTest {
         assertThat("TCP methods not invoked on the listener.", listener.tcpListenerInvoked, is(true));
     }
 
-    private MockHttpClientEventsListener subscribe(HttpClient<ByteBuf, ByteBuf> client) {
+    private static MockHttpClientEventsListener subscribe(HttpClient<ByteBuf, ByteBuf> client) {
         MockHttpClientEventsListener listener = new MockHttpClientEventsListener();
         client.subscribe(listener);
         return listener;
@@ -110,7 +110,7 @@ public class EventListenerTest {
             return new Statement() {
                 @Override
                 public void evaluate() throws Throwable {
-                    serverAddress = HttpServer.newServer().enableWireLogging(LogLevel.ERROR)
+                    serverAddress = HttpServer.newServer().enableWireLogging("test", LogLevel.ERROR)
                                               .start(new RequestHandler<ByteBuf, ByteBuf>() {
                                                   @Override
                                                   public Observable<Void> handle(HttpServerRequest<ByteBuf> request,

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientRule.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientRule.java
@@ -59,7 +59,7 @@ public class HttpClientRule extends ExternalResource {
             public void evaluate() throws Throwable {
                 channelProvider = new EmbeddedChannelProvider();
                 httpClient = HttpClient.newClient(new InetSocketAddress(0))
-                                       .enableWireLogging(LogLevel.ERROR)
+                                       .enableWireLogging("test", LogLevel.ERROR)
                                        .channelProvider(channelProvider.asFactory());
                 base.evaluate();
             }
@@ -205,7 +205,7 @@ public class HttpClientRule extends ExternalResource {
 
         boolean found = false;
         Object outbound;
-        final String expectedFirstLineStart = method.name().toUpperCase() + " " + uri;
+        final String expectedFirstLineStart = method.name().toUpperCase() + ' ' + uri;
         String data = null;
 
         while ((outbound = getLastCreatedChannel().readOutbound()) != null) {

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/internal/HttpClientRequestImplTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/internal/HttpClientRequestImplTest.java
@@ -706,7 +706,7 @@ public class HttpClientRequestImplTest {
                     Mockito.when(clientMock.pipelineConfigurator(Matchers.<Action1<ChannelPipeline>>anyObject()))
                                            .thenAnswer(returnThisMock);
 
-                    Mockito.when(clientMock.enableWireLogging(Matchers.<LogLevel>anyObject()))
+                    Mockito.when(clientMock.enableWireLogging(anyString(), Matchers.<LogLevel>anyObject()))
                                            .thenAnswer(returnThisMock);
 
                     RequestRule.this.clientMock = clientMock;

--- a/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/client/TcpClient.java
+++ b/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/client/TcpClient.java
@@ -231,8 +231,23 @@ public abstract class TcpClient<W, R> extends InterceptingTcpClient<W,R> {
      *                         logging is enabled at this level for {@link LoggingHandler}
      *
      * @return A new {@link TcpClient} instance.
+     *
+     * @deprecated Use {@link #enableWireLogging(String, LogLevel)} instead.
      */
+    @Deprecated
     public abstract TcpClient<W, R> enableWireLogging(LogLevel wireLoggingLevel);
+
+    /**
+     * Creates a new client instances, inheriting all configurations from this client and enabling wire logging at the
+     * passed level for the newly created client instance.
+     *
+     * @param name Name of the logger that can be used to control the logging dynamically.
+     * @param wireLoggingLevel Logging level at which the wire logs will be logged. The wire logging will only be done if
+     *                         logging is enabled at this level for {@link LoggingHandler}
+     *
+     * @return A new {@link TcpClient} instance.
+     */
+    public abstract TcpClient<W, R> enableWireLogging(String name, LogLevel wireLoggingLevel);
 
     /**
      * Creates a new client instance, inheriting all configurations from this client and using the passed

--- a/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/client/TcpClientImpl.java
+++ b/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/client/TcpClientImpl.java
@@ -146,8 +146,14 @@ public final class TcpClientImpl<W, R> extends TcpClient<W, R> {
     }
 
     @Override
+    @Deprecated
     public TcpClient<W, R> enableWireLogging(LogLevel wireLoggingLevel) {
         return copy(state.enableWireLogging(wireLoggingLevel), eventPublisher);
+    }
+
+    @Override
+    public TcpClient<W, R> enableWireLogging(String name, LogLevel wireLoggingLevel) {
+        return copy(state.enableWireLogging(name, wireLoggingLevel), eventPublisher);
     }
 
     @Override

--- a/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/server/TcpServer.java
+++ b/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/server/TcpServer.java
@@ -278,8 +278,23 @@ public abstract class TcpServer<R, W> implements EventSource<TcpServerEventListe
      *                         logging is enabled at this level for {@link io.netty.handler.logging.LoggingHandler}
      *
      * @return A new {@link TcpServer} instance.
+     *
+     * @deprecated Use {@link #enableWireLogging(String, LogLevel)} instead.
      */
+    @Deprecated
     public abstract TcpServer<R, W> enableWireLogging(LogLevel wireLoggingLevel);
+
+    /**
+     * Creates a new server instances, inheriting all configurations from this server and enabling wire logging at the
+     * passed level for the newly created server instance.
+     *
+     * @param name Name of the logger that can be used to control the logging dynamically.
+     * @param wireLoggingLevel Logging level at which the wire logs will be logged. The wire logging will only be done if
+     *                         logging is enabled at this level for {@link io.netty.handler.logging.LoggingHandler}
+     *
+     * @return A new {@link TcpServer} instance.
+     */
+    public abstract TcpServer<R, W> enableWireLogging(String name, LogLevel wireLoggingLevel);
 
     /**
      * Returns the port at which this server is running.

--- a/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/server/TcpServerImpl.java
+++ b/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/server/TcpServerImpl.java
@@ -148,8 +148,14 @@ public class TcpServerImpl<R, W> extends TcpServer<R, W> {
     }
 
     @Override
+    @Deprecated
     public TcpServer<R, W> enableWireLogging(LogLevel wireLoggingLevel) {
         return copy(state.<W, R>enableWireLogging(wireLoggingLevel));
+    }
+
+    @Override
+    public TcpServer<R, W> enableWireLogging(String name, LogLevel wireLoggingLevel) {
+        return copy(state.<W, R>enableWireLogging(name, wireLoggingLevel));
     }
 
     @Override

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/client/ClientStateTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/client/ClientStateTest.java
@@ -84,7 +84,7 @@ public class ClientStateTest {
                     mockPipeline = Mockito.mock(DetachedChannelPipeline.class, Mockito.RETURNS_MOCKS);
 
                     mockServer = TcpServer.newServer(0)
-                                          .enableWireLogging(LogLevel.ERROR)
+                                          .enableWireLogging("test", LogLevel.ERROR)
                                           .start(new ConnectionHandler<ByteBuf, ByteBuf>() {
                                               @Override
                                               public Observable<Void> handle(

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/EventListenerTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/EventListenerTest.java
@@ -49,7 +49,7 @@ public class EventListenerTest {
     @Test(timeout = 60000)
     public void testEventListenerPostCopy() throws Exception {
         TcpClient<ByteBuf, ByteBuf> client = TcpClient.newClient(rule.serverAddress)
-                                                      .enableWireLogging(LogLevel.ERROR);
+                                                      .enableWireLogging("test", LogLevel.ERROR);
 
         assertListenerCalled(client);
     }
@@ -60,18 +60,18 @@ public class EventListenerTest {
 
         MockTcpClientEventListener listener = subscribe(client);
 
-        client = client.enableWireLogging(LogLevel.DEBUG);
+        client = client.enableWireLogging("test", LogLevel.DEBUG);
 
         connectAndAssertListenerInvocation(client, listener);
     }
 
-    private void assertListenerCalled(TcpClient<ByteBuf, ByteBuf> client) {
+    private static void assertListenerCalled(TcpClient<ByteBuf, ByteBuf> client) {
         MockTcpClientEventListener listener = subscribe(client);
         connectAndAssertListenerInvocation(client, listener);
     }
 
-    private void connectAndAssertListenerInvocation(TcpClient<ByteBuf, ByteBuf> client,
-                                                    MockTcpClientEventListener listener) {
+    private static void connectAndAssertListenerInvocation(TcpClient<ByteBuf, ByteBuf> client,
+                                                           MockTcpClientEventListener listener) {
         TestSubscriber<ByteBuf> subscriber = new TestSubscriber<>();
         client.createConnectionRequest().flatMap(new Func1<Connection<ByteBuf, ByteBuf>, Observable<ByteBuf>>() {
             @Override
@@ -86,7 +86,7 @@ public class EventListenerTest {
         listener.assertMethodsCalled(Event.BytesRead);
     }
 
-    private MockTcpClientEventListener subscribe(TcpClient<ByteBuf, ByteBuf> client) {
+    private static MockTcpClientEventListener subscribe(TcpClient<ByteBuf, ByteBuf> client) {
         MockTcpClientEventListener listener = new MockTcpClientEventListener();
         client.subscribe(listener);
         return listener;

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/TcpClientImplTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/TcpClientImplTest.java
@@ -192,11 +192,11 @@ public class TcpClientImplTest {
         TcpClientImpl<String, String> client = TcpClientImpl._create(state, new TcpClientEventPublisher());
         ClientState<String, String> state = client.getClientState();
         TcpClientImpl<String, String> newClient =
-                (TcpClientImpl<String, String>) client.enableWireLogging(LogLevel.DEBUG);
+                (TcpClientImpl<String, String>) client.enableWireLogging("test", LogLevel.DEBUG);
 
         assertDeepClientCopy(client, newClient);
 
-        verify(state).enableWireLogging(LogLevel.DEBUG);
+        verify(state).enableWireLogging("test", LogLevel.DEBUG);
     }
 
     private static void assertDeepClientCopy(TcpClientImpl<String, String> client,

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/server/UnexpectedConnectionHandlerErrorsTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/server/UnexpectedConnectionHandlerErrorsTest.java
@@ -93,7 +93,7 @@ public class UnexpectedConnectionHandlerErrorsTest {
             return new Statement() {
                 @Override
                 public void evaluate() throws Throwable {
-                    server = TcpServer.newServer(0).enableWireLogging(LogLevel.ERROR);
+                    server = TcpServer.newServer(0).enableWireLogging("test", LogLevel.ERROR);
                     base.evaluate();
                 }
             };
@@ -104,7 +104,7 @@ public class UnexpectedConnectionHandlerErrorsTest {
 
             TcpClient.newClient("127.0.0.1", server.getServerPort())
                      .channelOption(ChannelOption.AUTO_READ, true) /*Else nothing is read from the channel even close*/
-                     .enableWireLogging(LogLevel.ERROR)
+                     .enableWireLogging("test", LogLevel.ERROR)
                      .createConnectionRequest()
                      .subscribe(subscriber);
 


### PR DESCRIPTION
Wire Logging available for all clients and servers is used to debug network traffic.
In an application that contains multiple clients (or servers), it will be useful if these logs can be enabled per client/server instead of the current model of enabling logs for all the clients.

This change deprecates the existing `enableWireLogging` methods and add a replacement to also include the name of the logger.
