### PR TITLE
Empty body for zero length payloads

### DIFF
--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/RawRequest.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/RawRequest.java
@@ -166,6 +166,12 @@ public final class RawRequest<I, O> {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public Observable asObservable(Connection<?, ?> connection) {
+        HttpRequest headers = this.headers;
+        if (null == content) {
+            headers = _copyHeaders();
+            headers.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        }
+
         Observable toReturn = Observable.just(headers);
 
         if (null != content) {

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponseImpl.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/server/HttpServerResponseImpl.java
@@ -52,7 +52,7 @@ public final class HttpServerResponseImpl<C> extends HttpServerResponse<C> {
         super(new OnSubscribe<Void>() {
             @Override
             public void call(Subscriber<? super Void> subscriber) {
-                state.sendHeaders().write(Observable.<C>empty()).unsafeSubscribe(subscriber);
+                state.sendHeaders().unsafeSubscribe(subscriber);
             }
         });
         this.state = state;

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientTest.java
@@ -276,97 +276,35 @@ public class HttpClientTest {
 
     @Test(timeout = 60000)
     public void testRequestWithNoContentLengthHeaderOrContentReturnsEmptyBody() {
-        serverRule.startServer();
-
-        serverRule.assertRequestEquals(
-            new Func1<HttpClient<ByteBuf, ByteBuf>, Observable<HttpClientResponse<ByteBuf>>>() {
-                @Override
-                public Observable<HttpClientResponse<ByteBuf>> call(HttpClient<ByteBuf, ByteBuf> client) {
-                    return client.createGet("/");
-                }
-            },
-            "GET / HTTP/1.1\r\n" +
-                "content-length: 0\r\n" +
-                "host: " + serverRule.getServerAddress().toString().replaceFirst("^/", "") + "\r\n" +
-                "\r\n");
+        clientRule.sendRequest(clientRule.getHttpClient().createGet("/"));
+        clientRule.assertEmptyBodyWithContentLengthZero();
     }
 
     @Test(timeout = 60000)
     public void testRequestWithNoContentLengthHeaderAndContentReturnsContentChunkAndSingleEmptyChunk() {
-        serverRule.startServer();
-
-        serverRule.assertRequestEquals(
-            new Func1<HttpClient<ByteBuf, ByteBuf>, Observable<HttpClientResponse<ByteBuf>>>() {
-                @Override
-                public Observable<HttpClientResponse<ByteBuf>> call(HttpClient<ByteBuf, ByteBuf> client) {
-                    return client.createGet("/")
-                            .writeStringContent(Observable.just("Hello"));
-                }
-            },
-            "GET / HTTP/1.1\r\n" +
-                "transfer-encoding: chunked\r\n" +
-                "host: " + serverRule.getServerAddress().toString().replaceFirst("^/", "") + "\r\n" +
-                "\r\n" +
-                "5\r\n" +
-                "Hello\r\n" +
-                "0\r\n" +
-                "\r\n");
+        clientRule.sendRequest(clientRule.getHttpClient().createGet("/")
+                .writeStringContent(Observable.just("Hello")));
+        clientRule.assertChunks("Hello");
     }
 
     @Test(timeout = 60000)
     public void testRequestWithContentLengthReturnsRawBody() {
-        serverRule.startServer();
-
-        serverRule.assertRequestEquals(
-            new Func1<HttpClient<ByteBuf, ByteBuf>, Observable<HttpClientResponse<ByteBuf>>>() {
-                @Override
-                public Observable<HttpClientResponse<ByteBuf>> call(HttpClient<ByteBuf, ByteBuf> client) {
-                    return client.createGet("/")
-                            .setHeader(HttpHeaderNames.CONTENT_LENGTH, 5)
-                            .writeStringContent(Observable.just("Hello"));
-                }
-            },
-            "GET / HTTP/1.1\r\n" +
-                "content-length: 5\r\n" +
-                "host: " + serverRule.getServerAddress().toString().replaceFirst("^/", "") + "\r\n" +
-                "\r\n" +
-                "Hello");
+        clientRule.sendRequest(clientRule.getHttpClient().createGet("/")
+                .setHeader(HttpHeaderNames.CONTENT_LENGTH, 5)
+                .writeStringContent(Observable.just("Hello")));
+        clientRule.assertBodyWithContentLength(5, "Hello");
     }
 
     @Test(timeout = 60000)
     public void testRequestWithZeroContentLengthReturnsEmptyBody() {
-        serverRule.startServer();
-
-        serverRule.assertRequestEquals(
-            new Func1<HttpClient<ByteBuf, ByteBuf>, Observable<HttpClientResponse<ByteBuf>>>() {
-                @Override
-                public Observable<HttpClientResponse<ByteBuf>> call(HttpClient<ByteBuf, ByteBuf> client) {
-                    return client.createGet("/")
-                        .setHeader(HttpHeaderNames.CONTENT_LENGTH, 0);
-                }
-            },
-            "GET / HTTP/1.1\r\n" +
-            "content-length: 0\r\n" +
-            "host: " + serverRule.getServerAddress().toString().replaceFirst("^/", "") + "\r\n" +
-            "\r\n");
+        clientRule.sendRequest(clientRule.getHttpClient().createGet("/").setHeader(HttpHeaderNames.CONTENT_LENGTH, 0));
+        clientRule.assertEmptyBodyWithContentLengthZero();
     }
 
     @Test(timeout = 60000)
     public void testRequestWithOnlyPositiveContentLengthReturnsEmptyBody() {
-        serverRule.startServer();
-
-        serverRule.assertRequestEquals(
-            new Func1<HttpClient<ByteBuf, ByteBuf>, Observable<HttpClientResponse<ByteBuf>>>() {
-                @Override
-                public Observable<HttpClientResponse<ByteBuf>> call(HttpClient<ByteBuf, ByteBuf> client) {
-                    return client.createGet("/")
-                        .setHeader(HttpHeaderNames.CONTENT_LENGTH, 5);
-                }
-            },
-            "GET / HTTP/1.1\r\n" +
-            "content-length: 0\r\n" +
-            "host: " + serverRule.getServerAddress().toString().replaceFirst("^/", "") + "\r\n" +
-            "\r\n");
+        clientRule.sendRequest(clientRule.getHttpClient().createGet("/").setHeader(HttpHeaderNames.CONTENT_LENGTH, 5));
+        clientRule.assertEmptyBodyWithContentLengthZero();
     }
 
     protected void startServerThatNeverReplies() {

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
@@ -37,10 +37,7 @@ public class HttpServerTest {
             }
         });
 
-        serverRule.assertResponseEquals(
-                "HTTP/1.1 400 Bad Request\r\n" +
-                "content-length: 0\r\n" +
-                "\r\n");
+        serverRule.assertEmptyBodyWithContentLengthZero();
     }
 
     @Test(timeout = 60000)
@@ -53,10 +50,7 @@ public class HttpServerTest {
             }
         });
 
-        serverRule.assertResponseEquals(
-                "HTTP/1.1 400 Bad Request\r\n" +
-                "content-length: 0\r\n" +
-                "\r\n");
+        serverRule.assertEmptyBodyWithContentLengthZero();
     }
 
     @Test(timeout = 60000)
@@ -69,14 +63,7 @@ public class HttpServerTest {
             }
         });
 
-        serverRule.assertResponseEquals(
-                "HTTP/1.1 200 OK\r\n" +
-                "transfer-encoding: chunked\r\n" +
-                "\r\n" +
-                "5\r\n" +
-                "Hello\r\n" +
-                "0\r\n" +
-                "\r\n");
+        serverRule.assertChunks("Hello");
     }
 
     @Test(timeout = 60000)
@@ -90,11 +77,7 @@ public class HttpServerTest {
             }
         });
 
-        serverRule.assertResponseEquals(
-                "HTTP/1.1 400 Bad Request\r\n" +
-                "content-length: 5\r\n" +
-                "\r\n" +
-                "Hello");
+        serverRule.assertBodyWithContentLength(5, "Hello");
     }
 
     @Test(timeout = 60000)
@@ -107,10 +90,7 @@ public class HttpServerTest {
             }
         });
 
-        serverRule.assertResponseEquals(
-                "HTTP/1.1 400 Bad Request\r\n" +
-                        "content-length: 0\r\n" +
-                        "\r\n");
+        serverRule.assertEmptyBodyWithContentLengthZero();
     }
 
     @Test(timeout = 60000)
@@ -123,9 +103,6 @@ public class HttpServerTest {
             }
         });
 
-        serverRule.assertResponseEquals(
-                "HTTP/1.1 400 Bad Request\r\n" +
-                "content-length: 0\r\n" +
-                "\r\n");
+        serverRule.assertEmptyBodyWithContentLengthZero();
     }
 }

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/server/HttpServerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.reactivex.netty.protocol.http.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Rule;
+import org.junit.Test;
+import rx.Observable;
+
+public class HttpServerTest {
+
+    @Rule
+    public final HttpServerRule serverRule = new HttpServerRule();
+
+    @Test(timeout = 60000)
+    public void testResponseWithNoContentLengthHeaderOrContentReturnsEmptyBody() throws Exception {
+        serverRule.startServer(new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return response.setStatus(HttpResponseStatus.BAD_REQUEST);
+            }
+        });
+
+        serverRule.assertResponseEquals(
+                "HTTP/1.1 400 Bad Request\r\n" +
+                "content-length: 0\r\n" +
+                "\r\n");
+    }
+
+    @Test(timeout = 60000)
+    public void testResponseWithNoContentLengthHeaderAndSendHeadersReturnsEmptyBody() throws Exception {
+        serverRule.startServer(new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return response.setStatus(HttpResponseStatus.BAD_REQUEST)
+                        .sendHeaders();
+            }
+        });
+
+        serverRule.assertResponseEquals(
+                "HTTP/1.1 400 Bad Request\r\n" +
+                "content-length: 0\r\n" +
+                "\r\n");
+    }
+
+    @Test(timeout = 60000)
+    public void testResponseWithNoContentLengthHeaderAndContentReturnsContentChunkAndSingleEmptyChunk() throws Exception {
+        serverRule.startServer(new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return response.sendHeaders()
+                        .writeString(Observable.just("Hello"));
+            }
+        });
+
+        serverRule.assertResponseEquals(
+                "HTTP/1.1 200 OK\r\n" +
+                "transfer-encoding: chunked\r\n" +
+                "\r\n" +
+                "5\r\n" +
+                "Hello\r\n" +
+                "0\r\n" +
+                "\r\n");
+    }
+
+    @Test(timeout = 60000)
+    public void testResponseWithContentLengthReturnsRawBody() throws Exception {
+        serverRule.startServer(new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return response.setStatus(HttpResponseStatus.BAD_REQUEST)
+                        .setHeader(HttpHeaderNames.CONTENT_LENGTH, 5)
+                        .writeString(Observable.just("Hello"));
+            }
+        });
+
+        serverRule.assertResponseEquals(
+                "HTTP/1.1 400 Bad Request\r\n" +
+                "content-length: 5\r\n" +
+                "\r\n" +
+                "Hello");
+    }
+
+    @Test(timeout = 60000)
+    public void testResponseWithZeroContentLengthReturnsEmptyBody() throws Exception {
+        serverRule.startServer(new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return response.setStatus(HttpResponseStatus.BAD_REQUEST)
+                        .setHeader(HttpHeaderNames.CONTENT_LENGTH, 0);
+            }
+        });
+
+        serverRule.assertResponseEquals(
+                "HTTP/1.1 400 Bad Request\r\n" +
+                        "content-length: 0\r\n" +
+                        "\r\n");
+    }
+
+    @Test(timeout = 60000)
+    public void testResponseWithOnlyPositiveContentLengthReturnsEmptyBody() throws Exception {
+        serverRule.startServer(new RequestHandler<ByteBuf, ByteBuf>() {
+            @Override
+            public Observable<Void> handle(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                return response.setStatus(HttpResponseStatus.BAD_REQUEST)
+                        .setHeader(HttpHeaderNames.CONTENT_LENGTH, 5);
+            }
+        });
+
+        serverRule.assertResponseEquals(
+                "HTTP/1.1 400 Bad Request\r\n" +
+                "content-length: 0\r\n" +
+                "\r\n");
+    }
+}


### PR DESCRIPTION
Update `RawRequest` and `HttpServerResponseImpl` so they return `content-length: 0` and an empty body when no writes are made to `HttpClientRequest` and `HttpServerResponse` respectively.

This also adds some regression level tests against the bytes sent and received from the server.

 (#470, #520)
