### PR TITLE
Allow to return connections even if pool was already closed

### DIFF
--- a/rxnetty/src/main/java/io/reactivex/netty/client/ConnectionPoolImpl.java
+++ b/rxnetty/src/main/java/io/reactivex/netty/client/ConnectionPoolImpl.java
@@ -61,7 +61,6 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
     private final PoolConfig poolConfig;
     private final ScheduledExecutorService cleanupScheduler;
     private final AtomicInteger aquiredConnectionsCounter = new AtomicInteger();
-    private final AtomicInteger connectionsInCreation = new AtomicInteger();
     //is needed to not accept any new connections that are aquired
     private final AtomicBoolean isShutdownRequested = new AtomicBoolean();
     //is needed to not perform the shutdown twice
@@ -148,7 +147,6 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
     }
 
     private void performAquire(Subscriber<? super ObservableConnection<I, O>> subscriber) {
-        logger.trace("Started to aquire connection");
         long startTimeMillis = Clock.newStartTimeMillis();
         try {
             metricEventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_START);
@@ -160,12 +158,10 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
                 long endTime = Clock.onEndMillis(startTimeMillis);
                 metricEventsSubject.onEvent(ClientMetricsEvent.POOLED_CONNECTION_REUSE, endTime);
                 metricEventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_SUCCESS, endTime);
-                logger.trace("Returned reused connection");
                 aquiredConnectionsCounter.incrementAndGet();
             } else if (limitDeterminationStrategy.acquireCreationPermit(startTimeMillis,
                     TimeUnit.MILLISECONDS)) { // Check if it is allowed to create another connection.
-                logger.trace("Start to create new connection");
-                connectionsInCreation.incrementAndGet();
+                aquiredConnectionsCounter.incrementAndGet();
                 /**
                  * Here we want to make sure that if the connection attempt failed, we should inform the strategy.
                  * Failure to do so, will leak the permits from the strategy. So, any code in this block MUST
@@ -199,7 +195,6 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
 
         // Its legal to release after shutdown as it is not under anyones control when the connection returns. Its
         // usually user initiated.
-        logger.trace("Start to release connection");
         if (null == connection) {
 
             return Observable.error(new IllegalArgumentException("Returned a null connection to the pool."));
@@ -210,13 +205,11 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
             connection.getChannel().pipeline().fireUserEventTriggered(new PooledConnectionReleasedEvent(connection));
             metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_START);
             if (isShutdownRequested.get() || !connection.isUsable()) {
-                logger.trace("Discarding returned connection. Shutdown requested {}", isShutdownRequested.get());
                 discardConnection(connection);
                 metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, Clock.onEndMillis(
                         startTimeMillis));
                 return Observable.empty();
             } else {
-                logger.trace("Returning idle connection");
                 idleConnections.add(connection);
                 metricEventsSubject.onEvent(ClientMetricsEvent.POOL_RELEASE_SUCCESS, Clock.onEndMillis(
                         startTimeMillis));
@@ -253,17 +246,7 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
         if (!isShutdownRequested.compareAndSet(false, true)) {
             return;
         }
-        boolean shutdownPerformed = performShutdownIfPossible();
-        if (!shutdownPerformed) {
-            ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
-                @Override
-                public Thread newThread(Runnable r) {
-
-                    return new Thread(r, "rx-netty-shutdown-");
-                }
-            });
-            executorService.scheduleWithFixedDelay(new ShutdownTask(executorService), 100, 100, TimeUnit.MILLISECONDS);
-        }
+        Observable.just(1L).subscribe(createShutdownAction());
     }
 
     private void performShutdownIfRequested() {
@@ -273,21 +256,32 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
         }
     }
 
+    private Action1<Long> createShutdownAction() {
+        return new Action1<Long>() {
+            @Override
+            public void call(Long aLong) {
+
+                boolean shutdown = performShutdownIfPossible();
+                if (!shutdown) {
+                    Observable<Long> timer = Observable.timer(200, TimeUnit.MILLISECONDS);
+                    timer.subscribe(createShutdownAction());
+                }
+            }
+        };
+    }
+
     private boolean performShutdownIfPossible() {
         if (aquiredConnectionsCounter.get() != 0) {
-            logger.trace("Try to shutdown but there are still connections aquired");
             return false;
         }
 
         Lock shutdownLock = this.shutdownLock.writeLock();
         boolean lockRetrieved = shutdownLock.tryLock();
         if (!lockRetrieved) {
-            logger.trace("Try to shutdown but lock not retrieved");
             return false;
         }
         try {
-            if (connectionsInCreation.get() == 0 && aquiredConnectionsCounter.get() == 0 && isShutdownPerformed.compareAndSet(false, true)) {
-                logger.trace("Start to perform shutdown");
+            if (aquiredConnectionsCounter.get() == 0 && isShutdownPerformed.compareAndSet(false, true)) {
                 performShutdown();
                 return true;
             }
@@ -305,7 +299,6 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
 
         PooledConnection<I, O> idleConnection = getAnIdleConnection(false);
         while (null != idleConnection) {
-            logger.trace("Discarding idle connection due to shutdown");
             discardConnection(idleConnection);
             idleConnection = getAnIdleConnection(false);
         }
@@ -339,8 +332,6 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
                                       @Override
                                       public void call(ObservableConnection<I, O> connection) {
 
-                                          aquiredConnectionsCounter.incrementAndGet();
-                                          connectionsInCreation.decrementAndGet();
                                           metricEventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_SUCCESS,
                                                   Clock.onEndMillis(startTime));
                                           PooledConnection<I, O> pooledConnection = (PooledConnection<I, O>) connection;
@@ -357,15 +348,13 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
                                           pooledConnection.updateMaxIdleTimeMillis(poolConfig.getMaxIdleTimeMillis());
                                           subscriber.onNext(connection);
                                           subscriber.onCompleted(); // This subscriber is for "A" connection, so it should be completed.
-                                          logger.trace("Returned new connection");
                                       }
                                   }, new Action1<Throwable>() {
                                       @Override
                                       public void call(Throwable throwable) {
-                                          logger.trace("Problem creating new connection", throwable);
                                           metricEventsSubject.onEvent(ClientMetricsEvent.POOL_ACQUIRE_FAILED,
                                                                       Clock.onEndMillis(startTime), throwable);
-                                          connectionsInCreation.decrementAndGet();
+                                          aquiredConnectionsCounter.decrementAndGet();
                                           subscriber.onError(throwable);
                                       }
                                   }
@@ -399,12 +388,9 @@ public class ConnectionPoolImpl<I, O> implements ConnectionPool<I, O> {
                         while (iterator.hasNext()) {
                             PooledConnection<I, O> idleConnection = iterator.next();
                             if (!idleConnection.isUsable() && idleConnection.claim()) {
-                                logger.trace("Will remove idle connection now from cleanup thread");
                                 iterator.remove();
-                                logger.trace("Discard idle connection from Cleanup thread");
                                 discardConnection(idleConnection); // Don't use pool.discard() as that won't do anything if the
                                 // connection isn't there in the idle queue, which is the case here.
-                                logger.trace("Discarded connection from cleanup thread");
                             }
                         }
                     } finally {

--- a/rxnetty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/client/ConnectionPoolTest.java
@@ -108,7 +108,7 @@ public class ConnectionPoolTest {
         poolConfig = new PoolConfig(MAX_IDLE_TIME_MILLIS);
         MetricEventsSubject<ClientMetricsEvent<?>> eventsSubject = new MetricEventsSubject<ClientMetricsEvent<?>>();
         factory = new ClientChannelFactoryImpl<String, String>(clientBootstrap, eventsSubject);
-        pool = new ConnectionPoolImpl<String, String>(serverInfo, poolConfig, strategy, null, factory, eventsSubject);
+        pool = new ConnectionPoolImpl<String, String>(serverInfo, poolConfig, strategy, Executors.newSingleThreadScheduledExecutor(), factory, eventsSubject);
         pool.subscribe(metricEventsListener);
         stats = new PoolStats();
         pool.subscribe(stats);


### PR DESCRIPTION
Fix for #523. I think I have also fixed the problem the you mentioned if the subscriber is being called when the pool is shutDown.
