### PR TITLE
Update spectator version

### DIFF
--- a/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/helloworld/HelloWorldClient.java
+++ b/rxnetty-examples/src/main/java/io/reactivex/netty/examples/http/helloworld/HelloWorldClient.java
@@ -74,7 +74,7 @@ public final class HelloWorldClient {
         SocketAddress serverAddress = env.getServerAddress(HelloWorldServer.class, args);
 
         HttpClient.newClient(serverAddress)
-                  .enableWireLogging("hello-client", LogLevel.DEBUG)
+                  .enableWireLogging("hello-client", LogLevel.ERROR)
                   .createGet("/hello")
                   .doOnNext(resp -> logger.info(resp.toString()))
                   .flatMap(resp -> resp.getContent()

--- a/rxnetty-examples/src/test/java/io/reactivex/netty/spectator/http/ResponseCodesHolderTest.java
+++ b/rxnetty-examples/src/test/java/io/reactivex/netty/spectator/http/ResponseCodesHolderTest.java
@@ -17,6 +17,9 @@
 
 package io.reactivex.netty.spectator.http;
 
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import io.reactivex.netty.spectator.http.internal.ResponseCodesHolder;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
@@ -27,7 +30,8 @@ public class ResponseCodesHolderTest {
     @Test(timeout = 60000)
     public void testGetResponse1xx() throws Exception {
         String monitorId = newMonitorId();
-        ResponseCodesHolder holder = new ResponseCodesHolder(monitorId);
+        Registry registry = new DefaultRegistry();
+        ResponseCodesHolder holder = new ResponseCodesHolder(registry, monitorId);
         holder.update(100);
 
         checkCodes(holder, 1, 0, 0, 0, 0);
@@ -40,7 +44,8 @@ public class ResponseCodesHolderTest {
     @Test(timeout = 60000)
     public void testGetResponse2xx() throws Exception {
         String monitorId = newMonitorId();
-        ResponseCodesHolder holder = new ResponseCodesHolder(monitorId);
+        Registry registry = new DefaultRegistry();
+        ResponseCodesHolder holder = new ResponseCodesHolder(registry, monitorId);
         holder.update(200);
 
         checkCodes(holder, 0, 1, 0, 0, 0);
@@ -53,7 +58,8 @@ public class ResponseCodesHolderTest {
     @Test(timeout = 60000)
     public void testGetResponse3xx() throws Exception {
         String monitorId = newMonitorId();
-        ResponseCodesHolder holder = new ResponseCodesHolder(monitorId);
+        Registry registry = new DefaultRegistry();
+        ResponseCodesHolder holder = new ResponseCodesHolder(registry, monitorId);
         holder.update(300);
 
         checkCodes(holder, 0, 0, 1, 0, 0);
@@ -66,7 +72,8 @@ public class ResponseCodesHolderTest {
     @Test(timeout = 60000)
     public void testGetResponse4xx() throws Exception {
         String monitorId = newMonitorId();
-        ResponseCodesHolder holder = new ResponseCodesHolder(monitorId);
+        Registry registry = new DefaultRegistry();
+        ResponseCodesHolder holder = new ResponseCodesHolder(registry, monitorId);
         holder.update(400);
 
         checkCodes(holder, 0, 0, 0, 1, 0);
@@ -79,7 +86,8 @@ public class ResponseCodesHolderTest {
     @Test(timeout = 60000)
     public void testGetResponse5xx() throws Exception {
         String monitorId = newMonitorId();
-        ResponseCodesHolder holder = new ResponseCodesHolder(monitorId);
+        Registry registry = new DefaultRegistry();
+        ResponseCodesHolder holder = new ResponseCodesHolder(registry, monitorId);
         holder.update(500);
 
         checkCodes(holder, 0, 0, 0, 0, 1);
@@ -89,7 +97,7 @@ public class ResponseCodesHolderTest {
         checkCodes(holder, 0, 0, 0, 0, 2);
     }
 
-    private void checkCodes(ResponseCodesHolder holder, long xx1, long xx2, long xx3, long xx4, long xx5) {
+    private static void checkCodes(ResponseCodesHolder holder, long xx1, long xx2, long xx3, long xx4, long xx5) {
         assertThat("Invalid 1xx count.", holder.getResponse1xx(), is(xx1));
         assertThat("Invalid 2xx count.", holder.getResponse2xx(), is(xx2));
         assertThat("Invalid 3xx count.", holder.getResponse3xx(), is(xx3));
@@ -97,7 +105,7 @@ public class ResponseCodesHolderTest {
         assertThat("Invalid 5xx count.", holder.getResponse5xx(), is(xx5));
     }
 
-    private String newMonitorId() {
+    private static String newMonitorId() {
         return "monitorId - " + Math.random();
     }
 }

--- a/rxnetty-examples/src/test/java/io/reactivex/netty/spectator/internal/LatencyMetricTest.java
+++ b/rxnetty-examples/src/test/java/io/reactivex/netty/spectator/internal/LatencyMetricTest.java
@@ -1,0 +1,73 @@
+package io.reactivex.netty.spectator.internal;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Meter;
+import io.reactivex.netty.spectator.internal.LatencyMetrics.Percentile;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.Iterator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class LatencyMetricTest {
+
+    @Rule
+    public final LatencyMetricRule metricRule = new LatencyMetricRule();
+
+    @Test(timeout = 60000)
+    public void testPercentiles() throws Exception {
+        metricRule.populateMetrics();
+        for (Percentile percentile : Percentile.values()) {
+            Meter spectatorMetric = metricRule.getSpectatorMetric(percentile);
+            double p = metricRule.metrics.getPercentileHolder().getPercentile(percentile.getValue());
+            Iterator<Measurement> measure = spectatorMetric.measure().iterator();
+            assertThat("Spectator metric measure is empty.", measure.hasNext());
+            assertThat("Unexpected value of percentile: " + percentile.getTag(), measure.next().value(),
+                       is(p));
+        }
+    }
+
+    public static class LatencyMetricRule extends ExternalResource {
+
+        private static final Random random = new Random();
+
+        private LatencyMetrics metrics;
+        private String monitorId;
+        private String metricName;
+        private DefaultRegistry registry;
+
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    metricName = "latency-test";
+                    monitorId = "latency-test-" + random.nextInt(100);
+                    registry = new DefaultRegistry();
+                    metrics = new LatencyMetrics(metricName, monitorId, registry);
+                    base.evaluate();
+                }
+            };
+        }
+
+        public Meter getSpectatorMetric(Percentile percentile) {
+            Id id = registry.createId(metricName, "id", monitorId, "percentile", percentile.getTag());
+            return registry.get(id);
+        }
+
+        public void populateMetrics() {
+            for (int i = 0; i < 100; i++) {
+                metrics.record(1, TimeUnit.SECONDS);
+            }
+        }
+    }
+}

--- a/rxnetty-spectator-http/build.gradle
+++ b/rxnetty-spectator-http/build.gradle
@@ -15,9 +15,13 @@
  *
  */
 
+// spectator requires java 8
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile project(':rxnetty-http')
     compile project(':rxnetty-spectator-tcp')
     compile project(':rxnetty-common')
-    compile 'com.netflix.spectator:spectator-api:0.14.2'
+    compile 'com.netflix.spectator:spectator-api:0.40.0'
 }

--- a/rxnetty-spectator-http/src/main/java/io/reactivex/netty/spectator/http/HttpServerListener.java
+++ b/rxnetty-spectator-http/src/main/java/io/reactivex/netty/spectator/http/HttpServerListener.java
@@ -18,14 +18,17 @@
 package io.reactivex.netty.spectator.http;
 
 import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
 import io.reactivex.netty.protocol.http.server.events.HttpServerEventsListener;
-import io.reactivex.netty.spectator.LatencyMetrics;
+import io.reactivex.netty.spectator.http.internal.ResponseCodesHolder;
+import io.reactivex.netty.spectator.internal.LatencyMetrics;
 import io.reactivex.netty.spectator.tcp.TcpServerListener;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.reactivex.netty.spectator.SpectatorUtils.*;
+import static io.reactivex.netty.spectator.internal.SpectatorUtils.*;
 
 /**
  * HttpServerListener.
@@ -45,16 +48,20 @@ public class HttpServerListener extends HttpServerEventsListener {
     private final TcpServerListener tcpDelegate;
 
     public HttpServerListener(String monitorId) {
-        requestBacklog = newGauge("requestBacklog", monitorId, new AtomicInteger());
-        inflightRequests = newGauge("inflightRequests", monitorId, new AtomicInteger());
-        responseWriteTimes = new LatencyMetrics("responseWriteTimes", monitorId);
-        requestReadTimes = new LatencyMetrics("requestReadTimes", monitorId);
-        requestProcessingTimes = new LatencyMetrics("requestProcessingTimes", monitorId);
-        processedRequests = newCounter("processedRequests", monitorId);
-        failedRequests = newCounter("failedRequests", monitorId);
-        responseWriteFailed = newCounter("responseWriteFailed", monitorId);
-        responseCodesHolder = new ResponseCodesHolder(monitorId);
-        tcpDelegate = new TcpServerListener(monitorId);
+        this(Spectator.globalRegistry(), monitorId);
+    }
+
+    public HttpServerListener(Registry registry, String monitorId) {
+        requestBacklog = newGauge(registry, "requestBacklog", monitorId, new AtomicInteger());
+        inflightRequests = newGauge(registry, "inflightRequests", monitorId, new AtomicInteger());
+        responseWriteTimes = new LatencyMetrics("responseWriteTimes", monitorId, registry);
+        requestReadTimes = new LatencyMetrics("requestReadTimes", monitorId, registry);
+        requestProcessingTimes = new LatencyMetrics("requestProcessingTimes", monitorId, registry);
+        processedRequests = newCounter(registry, "processedRequests", monitorId);
+        failedRequests = newCounter(registry, "failedRequests", monitorId);
+        responseWriteFailed = newCounter(registry, "responseWriteFailed", monitorId);
+        responseCodesHolder = new ResponseCodesHolder(registry, monitorId);
+        tcpDelegate = new TcpServerListener(registry, monitorId);
     }
 
     public long getRequestBacklog() {

--- a/rxnetty-spectator-http/src/main/java/io/reactivex/netty/spectator/http/internal/ResponseCodesHolder.java
+++ b/rxnetty-spectator-http/src/main/java/io/reactivex/netty/spectator/http/internal/ResponseCodesHolder.java
@@ -15,11 +15,12 @@
  *
  */
 
-package io.reactivex.netty.spectator.http;
+package io.reactivex.netty.spectator.http.internal;
 
 import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
 
-import static io.reactivex.netty.spectator.SpectatorUtils.*;
+import static io.reactivex.netty.spectator.internal.SpectatorUtils.newCounter;
 
 public class ResponseCodesHolder {
 
@@ -29,12 +30,12 @@ public class ResponseCodesHolder {
     private final Counter response2xx;
     private final Counter response1xx;
 
-    public ResponseCodesHolder(String monitorId) {
-        response1xx = newCounter("responseCodes", monitorId, "code", "1xx");
-        response2xx = newCounter("responseCodes", monitorId, "code", "2xx");
-        response3xx = newCounter("responseCodes", monitorId, "code", "3xx");
-        response4xx = newCounter("responseCodes", monitorId, "code", "4xx");
-        response5xx = newCounter("responseCodes", monitorId, "code", "5xx");
+    public ResponseCodesHolder(Registry registry, String monitorId) {
+        response1xx = newCounter(registry, "responseCodes", monitorId, "code", "1xx");
+        response2xx = newCounter(registry, "responseCodes", monitorId, "code", "2xx");
+        response3xx = newCounter(registry, "responseCodes", monitorId, "code", "3xx");
+        response4xx = newCounter(registry, "responseCodes", monitorId, "code", "4xx");
+        response5xx = newCounter(registry, "responseCodes", monitorId, "code", "5xx");
     }
 
     public void update(int responseCode) {

--- a/rxnetty-spectator-tcp/build.gradle
+++ b/rxnetty-spectator-tcp/build.gradle
@@ -15,9 +15,13 @@
  *
  */
 
+// spectator requires java 8
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile project(':rxnetty-tcp')
     compile project(':rxnetty-common')
-    compile 'com.netflix.spectator:spectator-api:0.14.2'
+    compile 'com.netflix.spectator:spectator-api:0.40.0'
     compile 'com.netflix.numerus:numerus:1.1'
 }

--- a/rxnetty-spectator-tcp/src/main/java/io/reactivex/netty/spectator/internal/SpectatorUtils.java
+++ b/rxnetty-spectator-tcp/src/main/java/io/reactivex/netty/spectator/internal/SpectatorUtils.java
@@ -14,43 +14,40 @@
  * limitations under the License.
  *
  */
-package io.reactivex.netty.spectator;
+package io.reactivex.netty.spectator.internal;
 
 import com.netflix.spectator.api.Counter;
-import com.netflix.spectator.api.ExtendedRegistry;
 import com.netflix.spectator.api.Id;
-import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
 
 public final class SpectatorUtils {
     private SpectatorUtils() {
     }
 
-    public static Counter newCounter(String name, String id) {
-        return Spectator.registry().counter(name, "id", id);
+    public static Counter newCounter(Registry registry, String name, String id) {
+        return registry.counter(name, "id", id);
     }
 
-    public static Counter newCounter(String name, String id, String... tags) {
+    public static Counter newCounter(Registry registry, String name, String id, String... tags) {
         String[] allTags = getTagsWithId(id, tags);
-        return Spectator.registry().counter(name, allTags);
+        return registry.counter(name, allTags);
     }
 
-    public static Timer newTimer(String name, String id) {
-        return Spectator.registry().timer(name, "id", id);
+    public static Timer newTimer(Registry registry, String name, String id) {
+        return registry.timer(name, "id", id);
     }
 
-    public static Timer newTimer(String name, String id, String... tags) {
-        return Spectator.registry().timer(name, getTagsWithId(id, tags));
+    public static Timer newTimer(Registry registry, String name, String id, String... tags) {
+        return registry.timer(name, getTagsWithId(id, tags));
     }
 
-    public static <T extends Number> T newGauge(String name, String id, T number) {
-        final ExtendedRegistry registry = Spectator.registry();
+    public static <T extends Number> T newGauge(Registry registry, String name, String id, T number) {
         Id gaugeId = registry.createId(name, "id", id);
         return registry.gauge(gaugeId, number);
     }
 
-    public static <T extends Number> T newGauge(String name, String id, T number, String... tags) {
-        final ExtendedRegistry registry = Spectator.registry();
+    public static <T extends Number> T newGauge(Registry registry, String name, String id, T number, String... tags) {
         Id gaugeId = registry.createId(name, getTagsWithId(id, tags));
         return registry.gauge(gaugeId, number);
     }

--- a/rxnetty-spectator-tcp/src/main/java/io/reactivex/netty/spectator/tcp/TcpClientListener.java
+++ b/rxnetty-spectator-tcp/src/main/java/io/reactivex/netty/spectator/tcp/TcpClientListener.java
@@ -18,13 +18,15 @@
 package io.reactivex.netty.spectator.tcp;
 
 import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Spectator;
 import io.reactivex.netty.protocol.tcp.client.events.TcpClientEventListener;
-import io.reactivex.netty.spectator.LatencyMetrics;
+import io.reactivex.netty.spectator.internal.LatencyMetrics;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.reactivex.netty.spectator.SpectatorUtils.*;
+import static io.reactivex.netty.spectator.internal.SpectatorUtils.*;
 
 /**
  * TcpClientListener
@@ -63,34 +65,38 @@ public class TcpClientListener extends TcpClientEventListener {
     private final Counter failedFlushes;
     private final LatencyMetrics flushTimes;
 
+    public TcpClientListener(Registry registry, String monitorId) {
+        liveConnections = newGauge(registry, "liveConnections", monitorId, new AtomicInteger());
+        connectionCount = newCounter(registry, "connectionCount", monitorId);
+        pendingConnects = newGauge(registry, "pendingConnects", monitorId, new AtomicInteger());
+        failedConnects = newCounter(registry, "failedConnects", monitorId);
+        connectionTimes = new LatencyMetrics("connectionTimes", monitorId, registry);
+        pendingConnectionClose = newGauge(registry, "pendingConnectionClose", monitorId, new AtomicInteger());
+        failedConnectionClose = newCounter(registry, "failedConnectionClose", monitorId);
+        pendingPoolAcquires = newGauge(registry, "pendingPoolAcquires", monitorId, new AtomicInteger());
+        poolAcquireTimes = new LatencyMetrics("poolAcquireTimes", monitorId, registry);
+        failedPoolAcquires = newCounter(registry, "failedPoolAcquires", monitorId);
+        pendingPoolReleases = newGauge(registry, "pendingPoolReleases", monitorId, new AtomicInteger());
+        poolReleaseTimes = new LatencyMetrics("poolReleaseTimes", monitorId, registry);
+        failedPoolReleases = newCounter(registry, "failedPoolReleases", monitorId);
+        poolAcquires = newCounter(registry, "poolAcquires", monitorId);
+        poolEvictions = newCounter(registry, "poolEvictions", monitorId);
+        poolReuse = newCounter(registry, "poolReuse", monitorId);
+        poolReleases = newCounter(registry, "poolReleases", monitorId);
+
+        pendingWrites = newGauge(registry, "pendingWrites", monitorId, new AtomicInteger());
+        pendingFlushes = newGauge(registry, "pendingFlushes", monitorId, new AtomicInteger());
+
+        bytesWritten = newCounter(registry, "bytesWritten", monitorId);
+        writeTimes = new LatencyMetrics("writeTimes", monitorId, registry);
+        bytesRead = newCounter(registry, "bytesRead", monitorId);
+        failedWrites = newCounter(registry, "failedWrites", monitorId);
+        failedFlushes = newCounter(registry, "failedFlushes", monitorId);
+        flushTimes = new LatencyMetrics("flushTimes", monitorId, registry);
+    }
+
     public TcpClientListener(String monitorId) {
-        liveConnections = newGauge("liveConnections", monitorId, new AtomicInteger());
-        connectionCount = newCounter("connectionCount", monitorId);
-        pendingConnects = newGauge("pendingConnects", monitorId, new AtomicInteger());
-        failedConnects = newCounter("failedConnects", monitorId);
-        connectionTimes = new LatencyMetrics("connectionTimes", monitorId);
-        pendingConnectionClose = newGauge("pendingConnectionClose", monitorId, new AtomicInteger());
-        failedConnectionClose = newCounter("failedConnectionClose", monitorId);
-        pendingPoolAcquires = newGauge("pendingPoolAcquires", monitorId, new AtomicInteger());
-        poolAcquireTimes = new LatencyMetrics("poolAcquireTimes", monitorId);
-        failedPoolAcquires = newCounter("failedPoolAcquires", monitorId);
-        pendingPoolReleases = newGauge("pendingPoolReleases", monitorId, new AtomicInteger());
-        poolReleaseTimes = new LatencyMetrics("poolReleaseTimes", monitorId);
-        failedPoolReleases = newCounter("failedPoolReleases", monitorId);
-        poolAcquires = newCounter("poolAcquires", monitorId);
-        poolEvictions = newCounter("poolEvictions", monitorId);
-        poolReuse = newCounter("poolReuse", monitorId);
-        poolReleases = newCounter("poolReleases", monitorId);
-
-        pendingWrites = newGauge("pendingWrites", monitorId, new AtomicInteger());
-        pendingFlushes = newGauge("pendingFlushes", monitorId, new AtomicInteger());
-
-        bytesWritten = newCounter("bytesWritten", monitorId);
-        writeTimes = new LatencyMetrics("writeTimes", monitorId);
-        bytesRead = newCounter("bytesRead", monitorId);
-        failedWrites = newCounter("failedWrites", monitorId);
-        failedFlushes = newCounter("failedFlushes", monitorId);
-        flushTimes = new LatencyMetrics("flushTimes", monitorId);
+        this(Spectator.globalRegistry(), monitorId);
     }
 
     @Override


### PR DESCRIPTION
#### Problem

Spectator version used in spectator modules is pretty old.
#### Modification

Updated spectator to the latest version `0.4.0`.

**This makes spectator modules require Java 8 as we are using Java 8 APIs**
