### PR TITLE
Fixed client connection level events

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/HostConnector.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/HostConnector.java
@@ -42,10 +42,10 @@ public class HostConnector<W, R> implements EventSource<ClientEventListener> {
 
     public HostConnector(HostConnector<W, R> source, ConnectionProvider<W, R> connectionProvider) {
         this.connectionProvider = connectionProvider;
-        this.host = source.host;
-        this.eventSource = source.eventSource;
-        this.clientPublisher = source.clientPublisher;
-        this.publisher = source.publisher;
+        host = source.host;
+        eventSource = source.eventSource;
+        clientPublisher = source.clientPublisher;
+        publisher = source.publisher;
     }
 
     public Host getHost() {

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnection.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnection.java
@@ -101,12 +101,12 @@ public class PooledConnection<R, W> extends Connection<R, W> {
 
     private PooledConnection(PooledConnection<?, ?> toCopy, Connection<R, W> unpooledDelegate) {
         super(unpooledDelegate);
-        this.owner = toCopy.owner;
+        owner = toCopy.owner;
         this.unpooledDelegate = unpooledDelegate;
-        this.lastReturnToPoolTimeMillis = toCopy.lastReturnToPoolTimeMillis;
-        this.releasedAtLeastOnce = toCopy.releasedAtLeastOnce;
-        this.maxIdleTimeMillis = toCopy.maxIdleTimeMillis;
-        this.releaseObservable = toCopy.releaseObservable;
+        lastReturnToPoolTimeMillis = toCopy.lastReturnToPoolTimeMillis;
+        releasedAtLeastOnce = toCopy.releasedAtLeastOnce;
+        maxIdleTimeMillis = toCopy.maxIdleTimeMillis;
+        releaseObservable = toCopy.releaseObservable;
     }
 
     @Override

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/AbstractConnectionToChannelBridgeTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/AbstractConnectionToChannelBridgeTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.reactivex.netty.channel.BackpressureManagingHandler.RequestReadIfRequiredEvent;
 import io.reactivex.netty.channel.events.ConnectionEventListener;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -29,7 +30,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import rx.observers.TestSubscriber;
 
-import static io.reactivex.netty.test.util.DisabledEventPublisher.*;
+import static io.reactivex.netty.test.util.MockEventPublisher.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -200,7 +201,7 @@ public class AbstractConnectionToChannelBridgeTest {
                     ctx = channel.pipeline().firstContext();
                     handler = new AbstractConnectionToChannelBridge<String, String>("foo",
                                                                                     new ConnectionEventListener() { },
-                                                                                    DISABLED_EVENT_PUBLISHER) { };
+                                                                                    disabled()) { };
                     base.evaluate();
                 }
             };

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/DefaultChannelOperationsTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/DefaultChannelOperationsTest.java
@@ -25,6 +25,7 @@ import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.reactivex.netty.test.util.FlushSelector;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -39,7 +40,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.reactivex.netty.test.util.DisabledEventPublisher.*;
+import static io.reactivex.netty.test.util.MockEventPublisher.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -275,7 +276,7 @@ public class DefaultChannelOperationsTest {
                     writeObservableSubscribers = new ArrayList<>();
                     /*Since, the appropriate handler is not added to the pipeline that handles O<> writes.*/
                     channel = new EmbeddedChannel(new HandleObservableWrite(writeObservableSubscribers));
-                    channelOperations = new DefaultChannelOperations<>(channel, null, DISABLED_EVENT_PUBLISHER);
+                    channelOperations = new DefaultChannelOperations<>(channel, null, disabled());
                     base.evaluate();
                 }
             };

--- a/rxnetty-common/src/test/java/io/reactivex/netty/client/loadbalancer/AbstractP2CStrategyTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/client/loadbalancer/AbstractP2CStrategyTest.java
@@ -24,7 +24,7 @@ import io.reactivex.netty.client.Host;
 import io.reactivex.netty.client.HostConnector;
 import io.reactivex.netty.client.events.ClientEventListener;
 import io.reactivex.netty.events.EventPublisher;
-import io.reactivex.netty.test.util.DisabledEventPublisher;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -126,7 +126,7 @@ public class AbstractP2CStrategyTest {
                     }
                 };
                 Host h = new Host(new InetSocketAddress(0));
-                EventPublisher publisher = DisabledEventPublisher.DISABLED_EVENT_PUBLISHER;
+                EventPublisher publisher = MockEventPublisher.disabled();
                 HostConnector<ByteBuf, ByteBuf> connector = new HostConnector<>(h, dummy, null, publisher, null);
                 toReturn.add(new HostHolder<>(connector, new ClientListenerImpl(weight)));
             }
@@ -174,7 +174,7 @@ public class AbstractP2CStrategyTest {
 
             @Override
             protected void newHostsList(int size) {
-                hostsInPool = hostsInPool + size;
+                hostsInPool += size;
             }
         }
     }

--- a/rxnetty-common/src/test/java/io/reactivex/netty/client/pool/PreferCurrentEventLoopHolderTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/client/pool/PreferCurrentEventLoopHolderTest.java
@@ -25,7 +25,7 @@ import io.reactivex.netty.client.pool.PooledConnection.Owner;
 import io.reactivex.netty.client.pool.PreferCurrentEventLoopHolder.IdleConnectionsHolderFactory;
 import io.reactivex.netty.events.EventAttributeKeys;
 import io.reactivex.netty.events.EventPublisher;
-import io.reactivex.netty.test.util.DisabledEventPublisher;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import io.reactivex.netty.threads.PreferCurrentEventLoopGroup;
 import org.junit.Rule;
 import org.junit.Test;
@@ -160,7 +160,7 @@ public class PreferCurrentEventLoopHolderTest {
                     eventLoopThread = Executors.newFixedThreadPool(1);
                     channel = new EmbeddedChannel(new LoggingHandler());
                     PreferCurrentEventLoopGroup eventLoopGroup = new PreferCurrentEventLoopGroup(channel.eventLoop());
-                    eventPublisher = DisabledEventPublisher.DISABLED_EVENT_PUBLISHER;
+                    eventPublisher = MockEventPublisher.disabled();
                     channel.attr(EventAttributeKeys.EVENT_PUBLISHER).set(eventPublisher);
                     holder = new PreferCurrentEventLoopHolder<>(eventLoopGroup,
                                                                 new IdleConnectionsHolderFactoryImpl());

--- a/rxnetty-common/src/test/java/io/reactivex/netty/test/util/MockClientEventListener.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/test/util/MockClientEventListener.java
@@ -184,8 +184,18 @@ public class MockClientEventListener extends ClientEventListener {
         delegate.onCompleted();
     }
 
+    public void assertMethodCalled(Event event) {
+        delegate.assertMethodCalled(event);
+    }
+
     public void assertMethodsCalled(Event... events) {
         delegate.assertMethodsCalled(events);
+    }
+
+    public void assertMethodCalled(ClientEvent event) {
+        if (!methodsCalled.contains(event)) {
+            throw new AssertionError("Method " + event + " not called. Methods called: " + methodsCalled);
+        }
     }
 
     public void assertMethodsCalled(ClientEvent... events) {
@@ -210,5 +220,16 @@ public class MockClientEventListener extends ClientEventListener {
 
     public Throwable getRecievedError() {
         return recievedError;
+    }
+
+    @Override
+    public String toString() {
+        return "MockClientEventListener{" +
+               "methodsCalled=" + methodsCalled +
+               ", duration=" + duration +
+               ", timeUnit=" + timeUnit +
+               ", recievedError=" + recievedError +
+               ", delegate=" + delegate +
+               '}';
     }
 }

--- a/rxnetty-common/src/test/java/io/reactivex/netty/test/util/MockConnectionEventListener.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/test/util/MockConnectionEventListener.java
@@ -139,6 +139,12 @@ public class MockConnectionEventListener extends ConnectionEventListener {
         methodsCalled.add(Event.Complete);
     }
 
+    public void assertMethodCalled(Event event) {
+        if (!methodsCalled.contains(event)) {
+            throw new AssertionError("Method " + event + " not called. Methods called: " + methodsCalled);
+        }
+    }
+
     public void assertMethodsCalled(Event... events) {
         if (methodsCalled.size() < events.length) {
             throw new AssertionError("Unexpected methods called count. Methods called: " + methodsCalled
@@ -177,5 +183,18 @@ public class MockConnectionEventListener extends ConnectionEventListener {
 
     public Object getCustomEvent() {
         return customeEvent;
+    }
+
+    @Override
+    public String toString() {
+        return "MockConnectionEventListener{" +
+               "methodsCalled=" + methodsCalled +
+               ", bytesRead=" + bytesRead +
+               ", duration=" + duration +
+               ", timeUnit=" + timeUnit +
+               ", bytesWritten=" + bytesWritten +
+               ", recievedError=" + recievedError +
+               ", customeEvent=" + customeEvent +
+               '}';
     }
 }

--- a/rxnetty-common/src/test/java/io/reactivex/netty/test/util/MockEventPublisher.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/test/util/MockEventPublisher.java
@@ -23,13 +23,32 @@ import io.reactivex.netty.events.EventSource;
 import rx.Subscription;
 import rx.subscriptions.Subscriptions;
 
-public class DisabledEventPublisher<T extends EventListener> implements EventPublisher, EventSource<T> {
+public class MockEventPublisher<T extends EventListener> implements EventPublisher, EventSource<T> {
 
-    public static final DisabledEventPublisher DISABLED_EVENT_PUBLISHER = new DisabledEventPublisher();
+    private static final MockEventPublisher<?> DISABLED_EVENT_PUBLISHER = new MockEventPublisher(true);
+    private static final MockEventPublisher<?> ENABLED_EVENT_PUBLISHER = new MockEventPublisher(false);
+
+    private final boolean disable;
+
+    private MockEventPublisher(boolean disable) {
+        this.disable = disable;
+    }
+
+    public static <T extends EventListener> MockEventPublisher<T> disabled() {
+        @SuppressWarnings("unchecked")
+        MockEventPublisher<T> t = (MockEventPublisher<T>) DISABLED_EVENT_PUBLISHER;
+        return t;
+    }
+
+    public static <T extends EventListener> MockEventPublisher<T> enabled() {
+        @SuppressWarnings("unchecked")
+        MockEventPublisher<T> t = (MockEventPublisher<T>) ENABLED_EVENT_PUBLISHER;
+        return t;
+    }
 
     @Override
     public boolean publishingEnabled() {
-        return false;
+        return !disable;
     }
 
     @Override

--- a/rxnetty-common/src/test/java/io/reactivex/netty/test/util/embedded/EmbeddedChannelWithFeeder.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/test/util/embedded/EmbeddedChannelWithFeeder.java
@@ -19,7 +19,7 @@ package io.reactivex.netty.test.util.embedded;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.reactivex.netty.client.events.ClientEventListener;
 import io.reactivex.netty.events.EventSource;
-import io.reactivex.netty.test.util.DisabledEventPublisher;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import io.reactivex.netty.test.util.InboundRequestFeeder;
 
 public class EmbeddedChannelWithFeeder {
@@ -29,7 +29,7 @@ public class EmbeddedChannelWithFeeder {
     private final EventSource<? extends ClientEventListener> tcpEventSource;
 
     public EmbeddedChannelWithFeeder(EmbeddedChannel channel, InboundRequestFeeder feeder) {
-        this(channel, feeder, new DisabledEventPublisher<ClientEventListener>());
+        this(channel, feeder, MockEventPublisher.<ClientEventListener>disabled());
     }
 
     public EmbeddedChannelWithFeeder(EmbeddedChannel channel, InboundRequestFeeder feeder,

--- a/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/HttpChannelProvider.java
+++ b/rxnetty-http/src/main/java/io/reactivex/netty/protocol/http/client/internal/HttpChannelProvider.java
@@ -30,8 +30,8 @@ public class HttpChannelProvider implements ChannelProvider {
     public static final AttributeKey<HttpClientEventsListener> HTTP_CLIENT_EVENT_LISTENER =
             AttributeKey.valueOf("rxnetty_http_client_event_listener");
 
-    private HttpClientEventPublisher hostEventPublisher;
-    private ChannelProvider delegate;
+    private final HttpClientEventPublisher hostEventPublisher;
+    private final ChannelProvider delegate;
 
     public HttpChannelProvider(HttpClientEventPublisher hostEventPublisher, ChannelProvider delegate) {
         this.hostEventPublisher = hostEventPublisher;

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientPoolTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/HttpClientPoolTest.java
@@ -117,7 +117,7 @@ public class HttpClientPoolTest {
         clientRule.assertIdleConnections(0); // Since, the channel is closed
     }
 
-    @Test(/*timeout = 60000*/)
+    @Test(timeout = 60000)
     public void testReuse() throws Exception {
         clientRule.assertIdleConnections(0);
 

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListenerImpl.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsListenerImpl.java
@@ -259,4 +259,16 @@ public class HttpClientEventsListenerImpl extends HttpClientEventsListener {
     public MockClientEventListener getTcpDelegate() {
         return tcpDelegate;
     }
+
+    @Override
+    public String toString() {
+        return "HttpClientEventsListenerImpl{" +
+               "tcpDelegate=" + tcpDelegate +
+               ", responseCode=" + responseCode +
+               ", duration=" + duration +
+               ", timeUnit=" + timeUnit +
+               ", recievedError=" + recievedError +
+               ", methodsCalled=" + methodsCalled +
+               '}';
+    }
 }

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/events/HttpClientEventsTest.java
@@ -1,0 +1,66 @@
+package io.reactivex.netty.protocol.http.client.events;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.client.Host;
+import io.reactivex.netty.client.pool.SingleHostPoolingProviderFactory;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import io.reactivex.netty.protocol.http.server.HttpServerRule;
+import io.reactivex.netty.test.util.MockClientEventListener.ClientEvent;
+import io.reactivex.netty.test.util.MockConnectionEventListener.Event;
+import org.junit.Rule;
+import org.junit.Test;
+import rx.Observable;
+
+public class HttpClientEventsTest {
+
+    @Rule
+    public final HttpServerRule serverRule = new HttpServerRule();
+
+    @Test(timeout = 60000)
+    public void testEventsPublished() throws Exception {
+        HttpClientEventsListenerImpl listener = sendRequests(false);
+
+        listener.getTcpDelegate().assertMethodCalled(ClientEvent.ConnectStart);
+        listener.getTcpDelegate().assertMethodCalled(ClientEvent.ConnectSuccess);
+        listener.getTcpDelegate().assertMethodCalled(Event.WriteStart);
+        listener.getTcpDelegate().assertMethodCalled(Event.WriteSuccess);
+        listener.getTcpDelegate().assertMethodCalled(Event.FlushStart);
+        listener.getTcpDelegate().assertMethodCalled(Event.FlushSuccess);
+        listener.getTcpDelegate().assertMethodCalled(Event.BytesRead);
+    }
+
+    @Test(timeout = 60000)
+    public void testPooledEventsPublished() throws Exception {
+        HttpClientEventsListenerImpl listener = sendRequests(true);
+
+        listener.getTcpDelegate().assertMethodCalled(ClientEvent.AcquireStart);
+        listener.getTcpDelegate().assertMethodCalled(ClientEvent.AcquireSuccess);
+        listener.getTcpDelegate().assertMethodCalled(ClientEvent.ConnectStart);
+        listener.getTcpDelegate().assertMethodCalled(ClientEvent.ConnectSuccess);
+        listener.getTcpDelegate().assertMethodCalled(Event.WriteStart);
+        listener.getTcpDelegate().assertMethodCalled(Event.WriteSuccess);
+        listener.getTcpDelegate().assertMethodCalled(Event.FlushStart);
+        listener.getTcpDelegate().assertMethodCalled(Event.FlushSuccess);
+        listener.getTcpDelegate().assertMethodCalled(Event.BytesRead);
+    }
+
+    protected HttpClientEventsListenerImpl sendRequests(boolean pool) {
+        serverRule.startServer();
+        HttpClientEventsListenerImpl listener = new HttpClientEventsListenerImpl();
+        if (pool) {
+            SingleHostPoolingProviderFactory<ByteBuf, ByteBuf> provider =
+                    SingleHostPoolingProviderFactory.createBounded(10);
+            Host host = new Host(serverRule.getServerAddress());
+            serverRule.setupClient(HttpClient.newClient(provider, Observable.just(host)));
+
+        }
+        serverRule.getClient().subscribe(listener);
+        HttpClientRequest<ByteBuf, ByteBuf> request = serverRule.getClient().createGet("/");
+
+        HttpClientResponse<ByteBuf> resp = serverRule.sendRequest(request);
+        serverRule.assertResponseContent(resp);
+        return listener;
+    }
+}

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/internal/HttpClientRequestImplTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/client/internal/HttpClientRequestImplTest.java
@@ -41,7 +41,7 @@ import io.reactivex.netty.protocol.http.TrailingHeaders;
 import io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import io.reactivex.netty.protocol.tcp.client.TcpClient;
 import io.reactivex.netty.protocol.tcp.client.events.TcpClientEventPublisher;
-import io.reactivex.netty.test.util.DisabledEventPublisher;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import io.reactivex.netty.test.util.FlushSelector;
 import io.reactivex.netty.test.util.TcpConnectionRequestMock;
 import org.junit.Rule;
@@ -820,7 +820,7 @@ public class HttpClientRequestImplTest {
                 }
             };
 
-            channel.attr(EventAttributeKeys.EVENT_PUBLISHER).set(DisabledEventPublisher.DISABLED_EVENT_PUBLISHER);
+            channel.attr(EventAttributeKeys.EVENT_PUBLISHER).set(MockEventPublisher.disabled());
             ConnectionImpl<Object, Object> conn = ConnectionImpl.fromChannel(channel);
 
             Observable<?> reqAsO = rawReq.asObservable(conn);

--- a/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
+++ b/rxnetty-http/src/test/java/io/reactivex/netty/protocol/http/server/CookieTest.java
@@ -32,7 +32,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.reactivex.netty.channel.Connection;
 import io.reactivex.netty.channel.ConnectionImpl;
 import io.reactivex.netty.events.EventAttributeKeys;
-import io.reactivex.netty.test.util.DisabledEventPublisher;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -66,7 +66,7 @@ public class CookieTest {
     public void testSetCookie() throws Exception {
         DefaultHttpResponse nettyResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
-        channel.attr(EventAttributeKeys.EVENT_PUBLISHER).set(DisabledEventPublisher.DISABLED_EVENT_PUBLISHER);
+        channel.attr(EventAttributeKeys.EVENT_PUBLISHER).set(MockEventPublisher.disabled());
         Connection<ByteBuf, ByteBuf> connection = ConnectionImpl.fromChannel(channel);
         HttpServerResponse<ByteBuf> response = HttpServerResponseImpl.create(null, connection, nettyResponse);
         String cookieName = "name";

--- a/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/client/TcpClientImpl.java
+++ b/rxnetty-tcp/src/main/java/io/reactivex/netty/protocol/tcp/client/TcpClientImpl.java
@@ -265,7 +265,8 @@ public final class TcpClientImpl<W, R> extends TcpClient<W, R> {
             @SuppressWarnings("unchecked")
             ChannelProvider channelProvider = channelProviderFactory.newProvider(host, eventSource, hostEventPublisher,
                                                                                  hostEventPublisher);
-            return new HostConnector<>(host, new TerminalConnectionProvider<>(host, channelProvider, state),
+            return new HostConnector<>(host, new TerminalConnectionProvider<>(hostEventPublisher, host,
+                                                                              channelProvider, state),
                                        hostEventPublisher, hostEventPublisher, hostEventPublisher);
         }
     }
@@ -276,10 +277,11 @@ public final class TcpClientImpl<W, R> extends TcpClient<W, R> {
         private final Bootstrap bootstrap;
         private final ChannelProvider channelProvider;
 
-        public TerminalConnectionProvider(Host host, ChannelProvider channelProvider, ClientState<W, R> state) {
+        public TerminalConnectionProvider(TcpClientEventPublisher hostEventPublisher,
+                                          Host host, ChannelProvider channelProvider, ClientState<W, R> state) {
             this.host = host;
             this.channelProvider = channelProvider;
-            bootstrap = state.newBootstrap();
+            bootstrap = state.newBootstrap(hostEventPublisher, hostEventPublisher);
         }
 
         @Override

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/client/ClientStateTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/client/ClientStateTest.java
@@ -27,6 +27,7 @@ import io.reactivex.netty.channel.Connection;
 import io.reactivex.netty.channel.DetachedChannelPipeline;
 import io.reactivex.netty.protocol.tcp.server.ConnectionHandler;
 import io.reactivex.netty.protocol.tcp.server.TcpServer;
+import io.reactivex.netty.test.util.MockEventPublisher;
 import io.reactivex.netty.test.util.embedded.EmbeddedConnectionProvider;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,7 +108,7 @@ public class ClientStateTest {
         public Channel connect(final ClientState<String, String> state) throws InterruptedException {
             TestSubscriber<Channel> subscriber = new TestSubscriber<>();
 
-            final ChannelFuture connect = state.newBootstrap()
+            final ChannelFuture connect = state.newBootstrap(MockEventPublisher.disabled(), null)
                                                .connect(new InetSocketAddress("127.0.0.1", mockServer.getServerPort()));
 
             Observable.create(new OnSubscribe<Channel>() {

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/MockTcpClientEventListener.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/MockTcpClientEventListener.java
@@ -28,8 +28,16 @@ public class MockTcpClientEventListener extends TcpClientEventListener {
 
     private final MockClientEventListener mockDelegate = new MockClientEventListener();
 
+    public void assertMethodCalled(ClientEvent event) {
+        mockDelegate.assertMethodCalled(event);
+    }
+
     public void assertMethodsCalled(ClientEvent... events) {
         mockDelegate.assertMethodsCalled(events);
+    }
+
+    public void assertMethodCalled(Event event) {
+        mockDelegate.assertMethodCalled(event);
     }
 
     public void assertMethodsCalled(Event... events) {

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/TcpClientRule.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/TcpClientRule.java
@@ -24,6 +24,7 @@ import io.reactivex.netty.client.Host;
 import io.reactivex.netty.client.HostConnector;
 import io.reactivex.netty.client.pool.PooledConnection;
 import io.reactivex.netty.client.pool.PooledConnectionProvider;
+import io.reactivex.netty.client.pool.SingleHostPoolingProviderFactory;
 import io.reactivex.netty.protocol.tcp.server.ConnectionHandler;
 import io.reactivex.netty.protocol.tcp.server.TcpServer;
 import org.junit.rules.ExternalResource;
@@ -84,14 +85,8 @@ public class TcpClientRule extends ExternalResource {
 
     private void createClient(final int maxConnections) {
         InetSocketAddress serverAddr = new InetSocketAddress("127.0.0.1", server.getServerPort());
-        ConnectionProviderFactory<ByteBuf, ByteBuf> cpf = new ConnectionProviderFactory<ByteBuf, ByteBuf>() {
-            @Override
-            public ConnectionProvider<ByteBuf, ByteBuf> newProvider(final Observable<HostConnector<ByteBuf, ByteBuf>> hosts) {
-                final HostConnector<ByteBuf, ByteBuf> connector = hosts.take(1).toBlocking().first();
-                return PooledConnectionProvider.createBounded(maxConnections, connector);
-            }
-        };
-        client = TcpClient.newClient(cpf, Observable.just(new Host(serverAddr)));
+        client = TcpClient.newClient(SingleHostPoolingProviderFactory.<ByteBuf, ByteBuf>createBounded(maxConnections),
+                                     Observable.just(new Host(serverAddr)));
     }
 
     public TcpServer<ByteBuf, ByteBuf> getServer() {

--- a/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventsTest.java
+++ b/rxnetty-tcp/src/test/java/io/reactivex/netty/protocol/tcp/client/events/TcpClientEventsTest.java
@@ -1,0 +1,51 @@
+package io.reactivex.netty.protocol.tcp.client.events;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.client.pool.PooledConnection;
+import io.reactivex.netty.protocol.tcp.client.MockTcpClientEventListener;
+import io.reactivex.netty.protocol.tcp.client.TcpClientRule;
+import io.reactivex.netty.test.util.MockClientEventListener.ClientEvent;
+import io.reactivex.netty.test.util.MockConnectionEventListener.Event;
+import org.junit.Rule;
+import org.junit.Test;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+public class TcpClientEventsTest {
+
+    @Rule
+    public final TcpClientRule clientRule = new TcpClientRule();
+
+    @Test(timeout = 60000)
+    public void testEventsPublished() throws Exception {
+        MockTcpClientEventListener listener = sendRequests();
+
+        listener.assertMethodCalled(ClientEvent.AcquireStart);
+        listener.assertMethodCalled(ClientEvent.AcquireSuccess);
+        listener.assertMethodCalled(ClientEvent.ConnectStart);
+        listener.assertMethodCalled(ClientEvent.ConnectSuccess);
+        listener.assertMethodCalled(Event.WriteStart);
+        listener.assertMethodCalled(Event.WriteSuccess);
+        listener.assertMethodCalled(Event.FlushStart);
+        listener.assertMethodCalled(Event.FlushSuccess);
+        listener.assertMethodCalled(Event.BytesRead);
+    }
+
+    protected MockTcpClientEventListener sendRequests() {
+        clientRule.startServer(10);
+        MockTcpClientEventListener listener = new MockTcpClientEventListener();
+        clientRule.getClient().subscribe(listener);
+        PooledConnection<ByteBuf, ByteBuf> connection = clientRule.connect();
+        TestSubscriber<ByteBuf> testSubscriber = new TestSubscriber<>();
+        connection.writeStringAndFlushOnEach(Observable.just("Hello"))
+                  .toCompletable()
+                  .<ByteBuf>toObservable()
+                  .concatWith(connection.getInput())
+                  .take(1)
+                  .subscribe(testSubscriber);
+
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertNoErrors();
+        return listener;
+    }
+}


### PR DESCRIPTION
#### Problem

Since the pipelines for client are setup after the connection is established, callbacks like `connect` are not send to the handlers. This was the reason for missing the connection related events for clients.
`PooledConnection` acquire events were not published because the events were getting published before the event listeners were setup.
#### Modification

This change moves the work done for client on `ChannelHandler.connet()` to `ChannelActivityBufferingHandler` which is added on channel creation.

Now, publishing events for pool acquire are published using the event publisher configured on the channel.
