### PR TITLE
update to netty 4.1.4.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-netty_version=4.1.3.Final
+netty_version=4.1.4.Final
 slf4j_version=1.7.6

--- a/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/UriInfoHolderTest.java
+++ b/rxnetty/src/test/java/io/reactivex/netty/protocol/http/server/UriInfoHolderTest.java
@@ -25,7 +25,7 @@ public class UriInfoHolderTest {
     public void relativeUri() throws Exception {
         UriInfoHolder holder = new UriInfoHolder("/foo/%20bar");
         Assert.assertEquals("/foo/%20bar", holder.getRawUriString());
-        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("/foo/ bar", holder.getPath());
         Assert.assertEquals("", holder.getQueryString());
     }
 
@@ -33,7 +33,7 @@ public class UriInfoHolderTest {
     public void relativeUriWithQuery() throws Exception {
         UriInfoHolder holder = new UriInfoHolder("/foo/%20bar?foo=bar%3D");
         Assert.assertEquals("/foo/%20bar?foo=bar%3D", holder.getRawUriString());
-        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("/foo/ bar", holder.getPath());
         Assert.assertEquals("foo=bar%3D", holder.getQueryString());
     }
 
@@ -42,7 +42,7 @@ public class UriInfoHolderTest {
     public void relativeUriWithQueryUnescaped() throws Exception {
         UriInfoHolder holder = new UriInfoHolder("/foo/%20bar?foo=bar|||");
         Assert.assertEquals("/foo/%20bar?foo=bar|||", holder.getRawUriString());
-        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("/foo/ bar", holder.getPath());
         Assert.assertEquals("foo=bar|||", holder.getQueryString());
     }
 
@@ -58,7 +58,7 @@ public class UriInfoHolderTest {
     public void absoluteUri() throws Exception {
         UriInfoHolder holder = new UriInfoHolder("http://www.foo.com/foo/%20bar");
         Assert.assertEquals("http://www.foo.com/foo/%20bar", holder.getRawUriString());
-        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("/foo/ bar", holder.getPath());
         Assert.assertEquals("", holder.getQueryString());
     }
 
@@ -66,7 +66,7 @@ public class UriInfoHolderTest {
     public void absoluteUriWithQuery() throws Exception {
         UriInfoHolder holder = new UriInfoHolder("http://www.foo.com/foo/%20bar?foo=bar%3D");
         Assert.assertEquals("http://www.foo.com/foo/%20bar?foo=bar%3D", holder.getRawUriString());
-        Assert.assertEquals("/foo/%20bar", holder.getPath());
+        Assert.assertEquals("/foo/ bar", holder.getPath());
         Assert.assertEquals("foo=bar%3D", holder.getQueryString());
     }
 


### PR DESCRIPTION
There is a regression in netty 4.1.3.Final, see:

http://netty.io/news/2016/07/27/4-0-40-Final-4-1-4-Final.html

The 4.1.4.Final version also includes a change to
QueryStringDecoder that broke some of the UriInfoHolder
tests. In particular the path is now decoded. I opted
to change the tests to match the netty behavior. For
context the netty ticket is: https://github.com/netty/netty/issues/5590

Tests were successful locally after those changes.
