### PR TITLE
`RequestN` reduces with completed subscribers.

### DIFF
--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/BytesWriteInterceptorTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/BytesWriteInterceptorTest.java
@@ -21,7 +21,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.reactivex.netty.channel.BackpressureManagingHandler.BytesWriteInterceptor;
 import io.reactivex.netty.channel.BackpressureManagingHandler.WriteStreamSubscriber;
 import io.reactivex.netty.test.util.MockProducer;
-import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -46,7 +45,7 @@ public class BytesWriteInterceptorTest {
         assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), contains(sub1));
 
         sub1.unsubscribe();
-
+        inspectorRule.channel.runPendingTasks();
         assertThat("Subscriber not removed post unsubscribe", inspectorRule.interceptor.getSubscribers(), is(empty()));
     }
 
@@ -54,15 +53,10 @@ public class BytesWriteInterceptorTest {
     public void testRequestMore() throws Exception {
 
         WriteStreamSubscriber sub1 = inspectorRule.newSubscriber();
-        MockProducer mockProducer = InspectorRule.setupSubscriber(sub1);
-
+        MockProducer mockProducer = inspectorRule.setupSubscriberAndValidate(sub1, 1);
         assertThat("Unexpected items requested from producer.", mockProducer.getRequested(), is(defaultRequestN()));
 
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), hasSize(1));
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), contains(sub1));
-
-        String msg = "Hello";
-        inspectorRule.channel.writeAndFlush(msg);
+        inspectorRule.sendMessages(1);
 
         assertThat("Channel not writable post write.", inspectorRule.channel.isWritable(), is(true));
         assertThat("Unexpected items requested.", mockProducer.getRequested(), is(defaultRequestN()));
@@ -72,12 +66,8 @@ public class BytesWriteInterceptorTest {
     public void testRequestMorePostFlush() throws Exception {
 
         WriteStreamSubscriber sub1 = inspectorRule.newSubscriber();
-        MockProducer mockProducer = InspectorRule.setupSubscriber(sub1);
-
+        MockProducer mockProducer = inspectorRule.setupSubscriberAndValidate(sub1, 1);
         assertThat("Unexpected items requested from producer.", mockProducer.getRequested(), is(defaultRequestN()));
-
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), hasSize(1));
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), contains(sub1));
 
         inspectorRule.channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(1, 2)); /*Make sure that the channel is not writable on writing.*/
 
@@ -97,25 +87,59 @@ public class BytesWriteInterceptorTest {
     @Test(timeout = 60000)
     public void testMultiSubscribers() throws Exception {
         WriteStreamSubscriber sub1 = inspectorRule.newSubscriber();
-        MockProducer producer1 = InspectorRule.setupSubscriber(sub1);
-
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), hasSize(1));
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), contains(sub1));
+        MockProducer producer1 = inspectorRule.setupSubscriberAndValidate(sub1, 1);
 
         WriteStreamSubscriber sub2 = inspectorRule.newSubscriber();
-        MockProducer producer2 = InspectorRule.setupSubscriber(sub2);
+        MockProducer producer2 = inspectorRule.setupSubscriberAndValidate(sub2, 2);
 
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), hasSize(2));
-        assertThat("Subscriber not added.", inspectorRule.interceptor.getSubscribers(), contains(sub1, sub2));
-
-        String msg = "Hello";
-        inspectorRule.channel.writeAndFlush(msg);
+        inspectorRule.sendMessages(1);
 
         assertThat("Channel not writable post write.", inspectorRule.channel.isWritable(), is(true));
         assertThat("Unexpected items requested from first subscriber.", producer1.getRequested(),
                    is(defaultRequestN()));
         assertThat("Unexpected items requested from second subscriber.", producer2.getRequested(),
                    is(defaultRequestN() / 2));
+    }
+
+    @Test(timeout = 10000)
+    public void testOneLongWriteAndManySmallWrites() throws Exception {
+        WriteStreamSubscriber sub1 = inspectorRule.newSubscriber();
+        MockProducer producer1 = inspectorRule.setupSubscriberAndValidate(sub1, 1);
+        assertThat("Unexpected items requested from producer.", producer1.getRequested(), is(defaultRequestN()));
+        inspectorRule.setupNewSubscriberAndComplete(2, true);
+        inspectorRule.setupNewSubscriberAndComplete(2, true);
+
+        inspectorRule.sendMessages(sub1, 33);
+        assertThat("Unexpected items requested.", producer1.getRequested(), is(97L));
+    }
+
+    @Test(timeout = 10000)
+    public void testBatchedSubscriberRemoves() throws Exception {
+        WriteStreamSubscriber sub1 = inspectorRule.newSubscriber();
+        MockProducer producer1 = inspectorRule.setupSubscriberAndValidate(sub1, 1);
+        assertThat("Unexpected items requested from producer.", producer1.getRequested(), is(defaultRequestN()));
+        for (int i=1; i < 5; i++) {
+            inspectorRule.setupNewSubscriberAndComplete(i+1, false);
+        }
+
+        inspectorRule.channel.runPendingTasks();
+
+        inspectorRule.sendMessages(sub1, 35);
+        assertThat("Unexpected items requested.", producer1.getRequested(), is(95L));
+    }
+
+    @Test(timeout = 10000)
+    public void testMinRequestN() throws Exception {
+        for (int i=1; i < 66; i++) {
+            inspectorRule.setupNewSubscriberAndComplete(i, false);
+        }
+        WriteStreamSubscriber sub1 = inspectorRule.newSubscriber();
+        MockProducer producer1 = inspectorRule.setupSubscriberAndValidate(sub1, 66);
+        assertThat("Unexpected items requested from producer.", producer1.getRequested(), is(1L));
+
+        inspectorRule.channel.runPendingTasks();
+        inspectorRule.sendMessages(sub1, 35);
+        assertThat("Unexpected items requested.", producer1.getRequested(), greaterThan(1L));
     }
 
     public static class InspectorRule extends ExternalResource {
@@ -136,18 +160,52 @@ public class BytesWriteInterceptorTest {
         }
 
         WriteStreamSubscriber newSubscriber() {
-            return interceptor.newSubscriber(channel.pipeline().firstContext(), channel.newPromise());
+            return interceptor.newSubscriber(channel.pipeline().lastContext(), channel.newPromise());
         }
 
-        private static MockProducer setupSubscriber(WriteStreamSubscriber sub1) {
-            sub1.onStart();
+        private MockProducer setupSubscriberAndValidate(WriteStreamSubscriber sub, int expectedSubCount) {
+            MockProducer mockProducer = setupSubscriber(sub);
+            assertThat("Subscriber not added.", interceptor.getSubscribers(), hasSize(expectedSubCount));
+            assertThat("Subscriber not added.", interceptor.getSubscribers().get(expectedSubCount - 1), equalTo(sub));
+            return mockProducer;
+        }
+
+        private static MockProducer setupSubscriber(WriteStreamSubscriber sub) {
+            sub.onStart();
             MockProducer mockProducer = new MockProducer();
-            sub1.setProducer(mockProducer);
+            sub.setProducer(mockProducer);
             return mockProducer;
         }
 
         public static Long defaultRequestN() {
             return Long.valueOf(MAX_PER_SUBSCRIBER_REQUEST);
+        }
+
+        public void sendMessages(WriteStreamSubscriber subscriber, int msgCount) {
+            for(int i=0; i < msgCount; i++) {
+                subscriber.onNext("Hello");
+                channel.write("Hello");
+            }
+            channel.flush();
+        }
+
+        public void sendMessages(int msgCount) {
+            for(int i=0; i < msgCount; i++) {
+                channel.write("Hello");
+            }
+            channel.flush();
+        }
+
+        public void setupNewSubscriberAndComplete(int expectedSubCount, boolean runPendingTasks) {
+            WriteStreamSubscriber sub2 = newSubscriber();
+            MockProducer producer2 = setupSubscriberAndValidate(sub2, expectedSubCount);
+            assertThat("Unexpected items requested from producer.", producer2.getRequested(),
+                       lessThanOrEqualTo(Math.max(1, defaultRequestN()/expectedSubCount)));
+            sub2.onCompleted();
+            sub2.unsubscribe();
+            if (runPendingTasks) {
+                channel.runPendingTasks();
+            }
         }
     }
 }


### PR DESCRIPTION
#### Problem

Re-calculation of max `requestN` per subscriber did not take into account removed subscribers correctly. This causes the `requestN` value to decrease over time when subscribers are completed.

#### Modification

- Modified `recalculateMaxPerSubscriber` to take old and new subscriber count instead of trying to determine the correct value from the current subscriber queue size.
- `subscribers.remove()` does not happen on unsubscribe but only from the task that recalculates the max `requestN` values. This also coalesces multiple removes into a single task run.

#### Result

Consistent `requestN` values with new subscribes and completions.