### PR TITLE
PooledConnection.close must be subscribed to be executed

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientConnectionToChannelBridge.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientConnectionToChannelBridge.java
@@ -33,6 +33,8 @@ import io.reactivex.netty.internal.ExecuteInEventloopAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Subscriber;
+import rx.functions.Action1;
+import rx.functions.Actions;
 import rx.observers.SafeSubscriber;
 import rx.subscriptions.Subscriptions;
 

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientConnectionToChannelBridge.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/ClientConnectionToChannelBridge.java
@@ -138,7 +138,13 @@ public class ClientConnectionToChannelBridge<R, W> extends AbstractConnectionToC
             subscriber.onNext(event.getPooledConnection());
             checkEagerSubscriptionIfConfigured(channel);
         } else {
-            event.getPooledConnection().close(false); // If pooled connection not sent to the subscriber, release to the pool.
+            // If pooled connection not sent to the subscriber, release to the pool.
+            event.getPooledConnection().close(false).subscribe(Actions.empty(), new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    logger.error("Error closing connection.", throwable);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
In RxNetty 0.5.x the `PooledConnection` will just return a `releaseObservable`, as opposed to 0.4.x. The returned Observable must be subscribed in order for the connection to be released. There is a leak of connections in case the subscriber has unsubscribed when the connection is to be emitted.