### PR TITLE
Fix sometimes empty response.

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnectionProviderImpl.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnectionProviderImpl.java
@@ -421,9 +421,9 @@ public final class PooledConnectionProviderImpl<W, R> extends PooledConnectionPr
                 onNextArrived = true;
                 _terminated = terminated;
                 _error = error;
+                delegate.onNext(conn);
             }
 
-            delegate.onNext(conn);
 
             if (_terminated) {
                 if (null != error) {


### PR DESCRIPTION
Sometimes the response will be accidentally empty.
This seems to be due to the fact that onCompleted is sometimes called before onNext where the connection is send. 

Moving the onNext event into the synchronized block fixes the problem.

Also added a test that without is flaky without my fix

Might do some good for
https://github.com/ReactiveX/RxNetty/issues/611
and
https://github.com/ReactiveX/RxNetty/issues/511