### PR TITLE
interval instead of timer for the idleConnectionCleanup

### DIFF
--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PoolConfig.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PoolConfig.java
@@ -37,7 +37,7 @@ public class PoolConfig<W, R> {
 
     public PoolConfig() {
         maxIdleTimeMillis = DEFAULT_MAX_IDLE_TIME_MILLIS;
-        idleConnCleanupTicker = Observable.interval(maxIdleTimeMillis, TimeUnit.MILLISECONDS);
+        idleConnCleanupTicker = Observable.interval(maxIdleTimeMillis, maxIdleTimeMillis, TimeUnit.MILLISECONDS);
         idleConnectionsHolder = new FIFOIdleConnectionsHolder<>();
         limitDeterminationStrategy = UnboundedPoolLimitDeterminationStrategy.INSTANCE;
     }

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PoolConfig.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PoolConfig.java
@@ -37,7 +37,7 @@ public class PoolConfig<W, R> {
 
     public PoolConfig() {
         maxIdleTimeMillis = DEFAULT_MAX_IDLE_TIME_MILLIS;
-        idleConnCleanupTicker = Observable.timer(maxIdleTimeMillis, TimeUnit.MILLISECONDS);
+        idleConnCleanupTicker = Observable.interval(maxIdleTimeMillis, TimeUnit.MILLISECONDS);
         idleConnectionsHolder = new FIFOIdleConnectionsHolder<>();
         limitDeterminationStrategy = UnboundedPoolLimitDeterminationStrategy.INSTANCE;
     }

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnectionProviderImpl.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnectionProviderImpl.java
@@ -74,14 +74,15 @@ public final class PooledConnectionProviderImpl<W, R> extends PooledConnectionPr
             .doOnError(LogErrorAction.INSTANCE)
             .retry() // Retry when there is an error in timer.
             .concatMap(new IdleConnectionCleanupTask())
-            .onErrorResumeNext(new Func1<Throwable, Observable<Void>>() {
+            .doOnError(new Action1<Throwable>() {
                 @Override
-                public Observable<Void> call(Throwable throwable) {
+                public void call(Throwable throwable) {
                     logger.error("Ignoring error cleaning up idle connections.",
                         throwable);
-                    return Observable.empty();
                 }
-            }).subscribe();
+            })
+            .retry()
+            .subscribe();
 
         hostConnector.getHost()
                      .getCloseNotifier()

--- a/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnectionProviderImpl.java
+++ b/rxnetty-common/src/main/java/io/reactivex/netty/client/pool/PooledConnectionProviderImpl.java
@@ -56,32 +56,23 @@ public final class PooledConnectionProviderImpl<W, R> extends PooledConnectionPr
 
     private static final Logger logger = LoggerFactory.getLogger(PooledConnectionProviderImpl.class);
 
-    private final Subscription idleConnCleanupSubscription;
+    private Subscription idleConnCleanupSubscription;
     private final IdleConnectionsHolder<W, R> idleConnectionsHolder;
 
     private final PoolLimitDeterminationStrategy limitDeterminationStrategy;
     private final long maxIdleTimeMillis;
+    private final PoolConfig<W, R>               poolConfig;
     private final HostConnector<W, R> hostConnector;
     private volatile boolean isShutdown;
 
     public PooledConnectionProviderImpl(PoolConfig<W, R> poolConfig, HostConnector<W, R> hostConnector) {
+        this.poolConfig = poolConfig;
         this.hostConnector = hostConnector;
         idleConnectionsHolder = poolConfig.getIdleConnectionsHolder();
         limitDeterminationStrategy = poolConfig.getPoolLimitDeterminationStrategy();
         maxIdleTimeMillis = poolConfig.getMaxIdleTimeMillis();
         // In case, there is no cleanup required, this observable should never give a tick.
-        idleConnCleanupSubscription = poolConfig.getIdleConnectionsCleanupTimer()
-                                                .doOnError(LogErrorAction.INSTANCE)
-                .retry() // Retry when there is an error in timer.
-                .concatMap(new IdleConnectionCleanupTask())
-                .onErrorResumeNext(new Func1<Throwable, Observable<Void>>() {
-                    @Override
-                    public Observable<Void> call(Throwable throwable) {
-                        logger.error("Ignoring error cleaning up idle connections.",
-                                     throwable);
-                        return Observable.empty();
-                    }
-                }).subscribe(Actions.empty()); // Errors are logged and ignored.
+        idleConnCleanupSubscription = getIdleConnectionCleanUpSubscription(); // Errors are logged and ignored.
 
         hostConnector.getHost()
                      .getCloseNotifier()
@@ -101,6 +92,39 @@ public final class PooledConnectionProviderImpl<W, R> extends PooledConnectionPr
                          }
                      })
                      .subscribe(Actions.empty());
+    }
+
+    /**
+     * Creates a cleanup subscription to clean up the idle connections
+     * @return
+     */
+    private Subscription getIdleConnectionCleanUpSubscription() {
+        return poolConfig.getIdleConnCleanupTicker()
+                .doOnError(LogErrorAction.INSTANCE)
+                .retry() // Retry when there is an error in timer.
+                .concatMap(new IdleConnectionCleanupTask())
+                .doOnUnsubscribe(new Action0() {
+
+                    /*
+                     * the idle connection ticker is for some reason unsubscribed and
+                     * To make the ticker work as expected by ticking every once in a while
+                     * we reinitiate the cleanUp subscription
+                     */
+                    @Override
+                    public void call() {
+                        if(!isShutdown) {
+                            idleConnCleanupSubscription = getIdleConnectionCleanUpSubscription();
+                        }
+                    }
+                })
+                .onErrorResumeNext(new Func1<Throwable, Observable<Void>>() {
+                    @Override
+                    public Observable<Void> call(Throwable throwable) {
+                        logger.error("Ignoring error cleaning up idle connections.",
+                                     throwable);
+                        return Observable.empty();
+                    }
+                }).subscribe();
     }
 
     @Override


### PR DESCRIPTION
Using interval instead of timer for the idleConnectionCleanup because the interval will tick many times every specified millisecond and timer will only tick once and then complete and I guess that is not what we want