### PR TITLE
Upgrade to Netty 4.1.51-Final to address CVE-2020-11612

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: java
 jdk:
-- oraclejdk8
+  - openjdk8
+# - oraclejdk8
+# addons:
+#   apt:
+#     packages:
+#       - oracle-java8-installer
 sudo: false
 script: gradle/buildViaTravis.sh
 env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-netty_version=4.1.5.Final
+netty_version=4.1.51.Final
 slf4j_version=1.7.6

--- a/rxnetty-common/src/test/java/io/reactivex/netty/channel/BytesWriteInterceptorTest.java
+++ b/rxnetty-common/src/test/java/io/reactivex/netty/channel/BytesWriteInterceptorTest.java
@@ -134,8 +134,8 @@ public class BytesWriteInterceptorTest {
         // Set the current thread to be the thread of the event loop
         inspectorRule.setEventLoopThread();
 
-        // Send 1000 messages from two different threads
-        int msgCount = 1000;
+        // Send 100 messages from two different threads
+        int msgCount = 100;
         Scheduler.Worker worker = Schedulers.computation().createWorker();
         for (int i = 1; i < msgCount; i+=2) {
             sub1.onNext(String.valueOf(i));


### PR DESCRIPTION
Versions [4.1.0-Final, 4.1.46.Final) are vulnerable to Uncontrolled Memory Allocation while decoding
a ZlibEncoded byte stream. An attacker could send a large ZlibEncoded byte stream to the Netty server,
forcing the server to allocate all of its free memory to a single decoder.

Ref.
https://snyk.io/vuln/SNYK-JAVA-IONETTY-564897
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11612